### PR TITLE
chore: adding to do note to preview builds script and docs

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,3 +1,5 @@
+# TODO: Publish a preview build doesn't work and needs to be fixed https://github.com/MetaMask/metamask-design-system/issues/38
+
 name: Publish a preview build
 
 on:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,6 +85,8 @@ If you're developing your project locally and want to test changes to a package,
 
 ### Testing changes to packages with preview builds
 
+> NOTE: Publish a preview builds doesn't work and needs to be fixed https://github.com/MetaMask/metamask-design-system/issues/38
+
 If you want to test changes to a package where it would be unwieldy or impossible to use a local version, such as on CI, you can publish a preview build and configure your project to use it.
 
 #### Publishing preview builds as a MetaMask contributor


### PR DESCRIPTION
## **Description**

This PR adds a `TODO` note to the publish preview builds script to inform contributors that the script is currently broken and needs to be fixed. Additionally, the relevant documentation is updated to notify contributors about the issue and links to the related GitHub issue for tracking.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/37

## **Manual testing steps**

1. Read the updated documentation and check the link to the related issue.
2. Search the codebase for other instances where similar `TODO` notes might be necessary.
3. Confirm that the `TODO` note is visible in the relevant script file.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="485" alt="Screenshot 2024-10-10 at 7 42 54 PM" src="https://github.com/user-attachments/assets/c920faf3-ece7-48a2-afb6-a4a41046b54c">

<img width="497" alt="Screenshot 2024-10-10 at 7 42 24 PM" src="https://github.com/user-attachments/assets/be731e85-91fe-490b-97fb-0867aa64a4e0">

### **After**

<img width="954" alt="Screenshot 2024-10-10 at 7 43 13 PM" src="https://github.com/user-attachments/assets/8f04986d-2d50-41c6-97da-e3d8339a1bf8">

<img width="492" alt="Screenshot 2024-10-10 at 7 42 01 PM" src="https://github.com/user-attachments/assets/790204ed-9503-4945-a008-caf5c9148f0f">


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and/or screenshots.