### PR TITLE
chore: updating yarn config to ignore docs workspace for package.json checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "files": [],
   "workspaces": [
+    "docs/*",
     "packages/*"
   ],
   "scripts": {

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -38,9 +38,15 @@ module.exports = defineConfig({
       const isChildWorkspace = workspace.cwd !== '.';
       const isPrivate =
         'private' in workspace.manifest && workspace.manifest.private === true;
+      const isDocs = workspace.cwd.startsWith('docs/');
       const dependenciesByIdentAndType = getDependenciesByIdentAndType(
         Yarn.dependencies({ workspace }),
       );
+
+      // Completely ignore docs workspaces
+      if (isDocs) {
+        continue;
+      }
 
       // All packages must have a name.
       expectWorkspaceField(workspace, 'name');


### PR DESCRIPTION
## **Description**

This pull request modifies the monorepo configuration to add and exclude the `docs/` workspace from monorepo-wide constraints and linting checks, such as those applied to package names. The `docs` workspace, which will contain our Storybook for React and React Native components, does not require these checks. The goal is to streamline the configuration and avoid applying unnecessary constraints to this workspace.

This PR updates the workspaces in `package.json` and relevant configuration in `yarn.config.cjs` to ensure that the `docs` workspace is ignored, while other workspaces remain unaffected by this change.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/28

## **Manual testing steps**

1. Run the linting process across the monorepo.
2. Verify that the `docs` workspace is excluded from linting checks.
3. Confirm that all other workspaces continue to be subject to the current linting rules and constraints.
4. Check that the Storybook for React and React Native still works as expected in the `docs` workspace.

Check this draft PR to see `storybook-react` passing all yarn constraint checks https://github.com/MetaMask/metamask-design-system/pull/30

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and/or screenshots.