### PR TITLE
chore: adding issue templates for general and bug issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Report a bug in the project
+title: 'Bug: '
+labels: bug
+assignees: ''
+---
+
+### **Description**
+
+A clear and concise description of what the bug is.
+
+### **Steps to Reproduce**
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### **Expected Behavior**
+
+A clear and concise description of what you expected to happen.
+
+### **Screenshots**
+
+If applicable, add screenshots to help explain your problem.
+
+### **Environment**
+
+- OS: [e.g., Windows, macOS, Linux]
+- Browser [e.g., Chrome, Safari]
+- Version [e.g., 22]
+
+### **Additional Context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/general_issue.md
+++ b/.github/ISSUE_TEMPLATE/general_issue.md
@@ -1,0 +1,31 @@
+---
+name: General issue
+about: For any issues
+title: ''
+labels: team-design-system
+assignees: ''
+---
+
+### **Description**
+
+Describe the task. What does this aim to solve?
+
+### **Technical Details**
+
+- Implementation details
+- Insight to what needs to be done
+- Etc.
+
+### **Acceptance Criteria**
+
+- Check with product on metrics
+- Cases to satisfy
+- XYZ should work
+- Etc.
+
+### **References**
+
+- References go here.
+- Issue numbers. Links.
+- Slack threads.
+- Etc.


### PR DESCRIPTION
## **Description**

This pull request adds a new issue templates for the `metamask-design-system` repository for general and bug. This template will simplify the process of creating issues related to design system tasks and ensure the `team-design-system` label is applied automatically.

### **Key Changes:**

- Created a new `ISSUE_TEMPLATE` in the `.github` directory.
- Used the general issue template from the design tokens repository as a base.
- Configured the template to apply the `team-design-system` label by default.
- Structured the template with sections for:
  - Description
  - Technical details
  - Acceptance criteria
  - References

## **Related Issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/2

## **Manual Testing Steps**

1. Navigate to the `metamask-design-system` repository.
2. Create a new issue using the template.
3. Confirm that the `team-design-system` label is automatically applied.
4. Ensure that all sections (Description, Technical Details, Acceptance Criteria, and References) are present in the issue.

## **Screenshots/Recordings**

### **After**
<img width="489" alt="Screenshot 2024-10-16 at 11 46 44 AM" src="https://github.com/user-attachments/assets/047b858f-4c55-4500-84c1-8eebb87cd2fc">

<img width="498" alt="Screenshot 2024-10-16 at 11 46 49 AM" src="https://github.com/user-attachments/assets/f228b7be-ea2f-4f84-ac63-ccddba80fa42">

## **Pre-merge Author Checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs).
- [x] I've completed the PR template to the best of my ability.
- [x] I've included tests, if applicable.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/), if applicable.
- [x] I've applied the right labels on the PR as per [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md).

## **Pre-merge Reviewer Checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses all acceptance criteria and includes the necessary testing evidence.