### PR TITLE
feat: adding shadow to tailwind preset

### DIFF
--- a/apps/storybook-react/stories/Shadows.stories.tsx
+++ b/apps/storybook-react/stories/Shadows.stories.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+interface ShadowBoxProps {
+  /** Text to display inside the box */
+  children: string;
+  /** Shadow class to apply */
+  className: string;
+  /** Style to apply to the box */
+  style?: React.CSSProperties;
+}
+
+const ShadowBox: React.FC<ShadowBoxProps> = ({
+  children,
+  className,
+  style,
+}) => (
+  <div
+    className={`w-32 h-32 flex items-center justify-center bg-alternative text-default rounded-md m-2 ${className}`}
+    style={style}
+  >
+    {children}
+  </div>
+);
+
+const meta = {
+  title: 'Design Tokens/Shadows',
+  component: ShadowBox,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ShadowBox>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const DefaultStory: Story = {
+  render: () => (
+    <div className="flex">
+      <ShadowBox className="shadow-primary shadow-xs">xs primary</ShadowBox>
+      <ShadowBox className="shadow-error shadow-xs">xs error</ShadowBox>
+      <ShadowBox className="shadow-xs">xs</ShadowBox>
+      <ShadowBox className="shadow-sm">sm</ShadowBox>
+      <ShadowBox className="shadow-md">md</ShadowBox>
+      <ShadowBox className="shadow-lg">lg</ShadowBox>
+      <ShadowBox className="shadow-xl">xl</ShadowBox>
+    </div>
+  ),
+};

--- a/packages/design-system-tailwind-preset/src/index.test.ts
+++ b/packages/design-system-tailwind-preset/src/index.test.ts
@@ -1,5 +1,6 @@
 import tailwindConfig from '.';
 import { colors } from './colors';
+import { shadows } from './shadows';
 
 describe('Tailwind Preset', () => {
   /**
@@ -12,7 +13,8 @@ describe('Tailwind Preset', () => {
 
   it('configuration has correct structure', () => {
     expect(tailwindConfig).toHaveProperty('content');
-    expect(tailwindConfig).toHaveProperty('theme.extend');
+    expect(tailwindConfig).toHaveProperty('theme');
+    expect(tailwindConfig.theme).toHaveProperty('extend');
     expect(tailwindConfig).toHaveProperty('plugins');
   });
 
@@ -70,6 +72,20 @@ describe('Tailwind Preset', () => {
         ...colors,
         ...colors.border,
       }),
+    );
+  });
+
+  /**
+   * Shadows
+   */
+
+  it('boxShadow is correctly defined in theme.extend', () => {
+    expect(tailwindConfig.theme?.extend).toHaveProperty('boxShadow');
+  });
+
+  it('boxShadow contains all expected shadow sizes', () => {
+    expect(tailwindConfig.theme?.extend?.boxShadow).toStrictEqual(
+      expect.objectContaining(shadows),
     );
   });
 });

--- a/packages/design-system-tailwind-preset/src/index.test.ts
+++ b/packages/design-system-tailwind-preset/src/index.test.ts
@@ -13,8 +13,7 @@ describe('Tailwind Preset', () => {
 
   it('configuration has correct structure', () => {
     expect(tailwindConfig).toHaveProperty('content');
-    expect(tailwindConfig).toHaveProperty('theme');
-    expect(tailwindConfig.theme).toHaveProperty('extend');
+    expect(tailwindConfig).toHaveProperty('theme.extend');
     expect(tailwindConfig).toHaveProperty('plugins');
   });
 

--- a/packages/design-system-tailwind-preset/src/index.ts
+++ b/packages/design-system-tailwind-preset/src/index.ts
@@ -23,12 +23,13 @@ const tailwindConfig: Config = {
         ...theme('colors'), // Incorporate existing color utilities like border-primary-default
         ...colors.border, // e.g. border-default instead of border-border-default
       }),
-      boxShadow: shadows,
+      boxShadow: shadows, // Sets default shadows
     },
   },
   plugins: [
-    shadowPlugin, // Use the imported shadowPlugin
+    shadowPlugin, // Allows for combination of size and color shadow utilities
   ],
 };
 
 export default tailwindConfig;
+module.exports = tailwindConfig;

--- a/packages/design-system-tailwind-preset/src/index.ts
+++ b/packages/design-system-tailwind-preset/src/index.ts
@@ -1,8 +1,7 @@
 import type { Config } from 'tailwindcss';
-import plugin from 'tailwindcss/plugin';
 
 import { colors } from './colors';
-import { shadows, shadowColors } from './shadows';
+import { shadows, shadowPlugin } from './shadows';
 
 const tailwindConfig: Config = {
   content: [],
@@ -28,34 +27,8 @@ const tailwindConfig: Config = {
     },
   },
   plugins: [
-    plugin(function ({
-      addUtilities,
-    }: {
-      addUtilities: (
-        utilities: Record<string, Record<string, string>>,
-        options?: Partial<{
-          respectPrefix: boolean;
-          respectImportant: boolean;
-        }>,
-      ) => void;
-    }) {
-      const shadowColorUtilities: Record<string, Record<string, string>> = {};
-
-      Object.entries(shadowColors).forEach(([key, value]) => {
-        shadowColorUtilities[`.shadow-${key}`] = {
-          '--shadow-color': value, // This ensures that --shadow-color is set
-        };
-      });
-
-      // Add the utilities with Tailwind’s addUtilities method
-      addUtilities(shadowColorUtilities, {
-        respectPrefix: false,
-        respectImportant: true,
-      });
-    }),
+    shadowPlugin, // Use the imported shadowPlugin
   ],
 };
 
 export default tailwindConfig;
-
-module.exports = tailwindConfig;

--- a/packages/design-system-tailwind-preset/src/index.ts
+++ b/packages/design-system-tailwind-preset/src/index.ts
@@ -1,6 +1,8 @@
 import type { Config } from 'tailwindcss';
+import plugin from 'tailwindcss/plugin';
 
 import { colors } from './colors';
+import { shadows, shadowColors } from './shadows';
 
 const tailwindConfig: Config = {
   content: [],
@@ -22,9 +24,36 @@ const tailwindConfig: Config = {
         ...theme('colors'), // Incorporate existing color utilities like border-primary-default
         ...colors.border, // e.g. border-default instead of border-border-default
       }),
+      boxShadow: shadows,
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({
+      addUtilities,
+    }: {
+      addUtilities: (
+        utilities: Record<string, Record<string, string>>,
+        options?: Partial<{
+          respectPrefix: boolean;
+          respectImportant: boolean;
+        }>,
+      ) => void;
+    }) {
+      const shadowColorUtilities: Record<string, Record<string, string>> = {};
+
+      Object.entries(shadowColors).forEach(([key, value]) => {
+        shadowColorUtilities[`.shadow-${key}`] = {
+          '--shadow-color': value, // This ensures that --shadow-color is set
+        };
+      });
+
+      // Add the utilities with Tailwind’s addUtilities method
+      addUtilities(shadowColorUtilities, {
+        respectPrefix: false,
+        respectImportant: true,
+      });
+    }),
+  ],
 };
 
 export default tailwindConfig;

--- a/packages/design-system-tailwind-preset/src/shadows.test.ts
+++ b/packages/design-system-tailwind-preset/src/shadows.test.ts
@@ -1,0 +1,53 @@
+import {
+  getDesignTokenVariables,
+  collectCssVariables,
+} from '../scripts/testUtils';
+import { shadows, shadowColors } from './shadows';
+
+describe('Shadows Preset', () => {
+  // Collect all CSS variables used in the 'shadows' object
+  const usedVariables = collectCssVariables({ ...shadows, ...shadowColors });
+
+  /**
+   * Test to ensure that all CSS variables used in the 'shadows' object
+   * are defined in the @metamask/design-tokens package.
+   */
+  it('should use only shadow color and size CSS variables that exist in @metamask/design-tokens', async () => {
+    // Retrieve all design token variables that start with '--color-shadow' and '--shadow-size'
+    const designTokens = await getDesignTokenVariables([
+      '--color-shadow',
+      '--shadow-size',
+    ]);
+
+    // Identify any used variables that are missing from the design tokens
+    const missingVariables = usedVariables.filter(
+      (varName) => !designTokens.has(varName),
+    );
+
+    // Expect no missing variables
+    expect(missingVariables).toHaveLength(0);
+  });
+
+  /**
+   * Test to ensure that there are no unused CSS variables in the
+   * design-tokens package that are not used in the 'shadows' object.
+   */
+  it('should not have unused shadow color and size CSS variables in @metamask/design-tokens', async () => {
+    // Retrieve all design token variables that start with '--color-shadow' and '--shadow-size'
+    const designTokens = await getDesignTokenVariables([
+      '--color-shadow',
+      '--shadow-size',
+    ]);
+
+    // Create a set for used variables for efficient lookup
+    const usedSet = new Set(usedVariables);
+
+    // Identify design token variables that are neither used nor ignored
+    const unusedVariables = Array.from(designTokens).filter(
+      (varName) => !usedSet.has(varName),
+    );
+
+    // Expect no unused variables
+    expect(unusedVariables).toHaveLength(0);
+  });
+});

--- a/packages/design-system-tailwind-preset/src/shadows.ts
+++ b/packages/design-system-tailwind-preset/src/shadows.ts
@@ -1,0 +1,12 @@
+export const shadows = {
+  xs: 'var(--shadow-size-xs) var(--shadow-color, var(--color-shadow-default))',
+  sm: 'var(--shadow-size-sm) var(--shadow-color, var(--color-shadow-default))',
+  md: 'var(--shadow-size-md) var(--shadow-color, var(--color-shadow-default))',
+  lg: 'var(--shadow-size-lg) var(--shadow-color, var(--color-shadow-default))',
+};
+
+export const shadowColors = {
+  default: 'var(--color-shadow-default)',
+  primary: 'var(--color-shadow-primary)',
+  error: 'var(--color-shadow-error)',
+};

--- a/packages/design-system-tailwind-preset/src/shadows.ts
+++ b/packages/design-system-tailwind-preset/src/shadows.ts
@@ -1,3 +1,5 @@
+import plugin from 'tailwindcss/plugin';
+
 export const shadows = {
   xs: 'var(--shadow-size-xs) var(--shadow-color, var(--color-shadow-default))',
   sm: 'var(--shadow-size-sm) var(--shadow-color, var(--color-shadow-default))',
@@ -10,3 +12,30 @@ export const shadowColors = {
   primary: 'var(--color-shadow-primary)',
   error: 'var(--color-shadow-error)',
 };
+
+// Define and export the shadow plugin
+export const shadowPlugin = plugin(function ({
+  addUtilities,
+}: {
+  addUtilities: (
+    utilities: Record<string, Record<string, string>>,
+    options?: Partial<{
+      respectPrefix: boolean;
+      respectImportant: boolean;
+    }>,
+  ) => void;
+}) {
+  const shadowColorUtilities: Record<string, Record<string, string>> = {};
+
+  Object.entries(shadowColors).forEach(([key, value]) => {
+    shadowColorUtilities[`.shadow-${key}`] = {
+      '--shadow-color': value, // This ensures that --shadow-color is set to the correct color value
+    };
+  });
+
+  // Add the utilities with Tailwind’s addUtilities method
+  addUtilities(shadowColorUtilities, {
+    respectPrefix: false,
+    respectImportant: true,
+  });
+});

--- a/packages/design-system-tailwind-preset/src/shadows.ts
+++ b/packages/design-system-tailwind-preset/src/shadows.ts
@@ -1,5 +1,16 @@
 import plugin from 'tailwindcss/plugin';
 
+/**
+ * We want to allow for the combination of shadow size and color utilities.
+ * Shadow size should default to --color-shadow-default.
+ * e.g. className="shadow-md" (size medium / color default)
+ * We also want to allow for the combination of shadow size and color utilities.
+ * e.g. className="shadow-md shadow-primary" (size medium / color primary)
+ *
+ * To achieve this we define the following order:
+ * size / (color placeholder / color default fallback)
+ */
+
 export const shadows = {
   xs: 'var(--shadow-size-xs) var(--shadow-color, var(--color-shadow-default))',
   sm: 'var(--shadow-size-sm) var(--shadow-color, var(--color-shadow-default))',
@@ -13,7 +24,10 @@ export const shadowColors = {
   error: 'var(--color-shadow-error)',
 };
 
-// Define and export the shadow plugin
+/**
+ * The shadowPlugin is a Tailwind CSS plugin that allows the --shadow-color CSS variable to be set based on the shadow color utility class.
+ * This enables the combination of shadow size and color utilities.
+ */
 export const shadowPlugin = plugin(function ({
   addUtilities,
 }: {


### PR DESCRIPTION
## **Description**

This pull request adds new shadow tokens to the `design-system-tailwind-preset` package. The shadow tokens are derived from the design token CSS variables, and include both color and size definitions. These tokens will generate Tailwind utility classes that ensure consistent shadow styles across components. The shadow configuration has been imported into the index preset for global use.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/57

## **Manual testing steps**

1. Run `yarn build && yarn` to build and install the local version of the tailwind preset in `storybook-react`
2. Run storybook using `yarn storybook`
3. See the shadows stories
4. Apply shadow utility classes (`shadow-default`, `shadow-primary`, `shadow-error`, etc.) to verify color.
5. Apply shadow size classes (`shadow-xs`, `shadow-sm`, `shadow-md`, `shadow-lg`) to check correct shadow sizing.
6. Verify that the shadows match the design tokens for both size and color.

## **Screenshots/Recordings**

### **Before**

N/A (no shadow utilities available)

### **After**

https://github.com/user-attachments/assets/14f0eb19-2a59-4234-89af-f0b8c97949b4

Testing in Portfolio using `yarn link`


https://github.com/user-attachments/assets/76b6e554-13b4-40b1-83f0-6f540c827fb2

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and/or screenshots.