### PR TITLE
chore: updating migration docs to remove dependabot step

### DIFF
--- a/docs/package-migration-process-guide.md
+++ b/docs/package-migration-process-guide.md
@@ -12,15 +12,9 @@ This document outlines the process for migrating a MetaMask library into the met
 
 - [Example PR](https://github.com/MetaMask/eth-json-rpc-provider/pull/38)
 
-### 2. Disable `dependabot` dependency version updates and security alerts
+### 2. Add the source repo to the ZenHub workspace repo filter so that its issues/PRs show up on the board
 
-- [Disable dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/configuring-dependabot-alerts#enabling-or-disabling-dependabot-alerts-for-a-repository) for the repo.
-- [Disable dependabot dependency version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#disabling-dependabot-version-updates) from settings, or delete the source repo's `.github/dependabot.yml` file.
-- Contact a [**maintainer**](https://github.com/orgs/MetaMask/teams/engineering?query=role%3Amaintainer) to perform this step.
-
-### 3. Add the source repo to the ZenHub workspace repo filter so that its issues/PRs show up on the board
-
-### **[PR#2]** 4. Align dependency versions and TypeScript, ESLint, Prettier configurations with the metamask module template
+### **[PR#2]** 3. Align dependency versions and TypeScript, ESLint, Prettier configurations with the core monorepo
 
 - If the dependency versions of the migration target are ahead of metamask design system, consider updating the metamask design system dependencies first.
 - Apply the configurations of the metamask module template to the source repo files.
@@ -28,19 +22,19 @@ This document outlines the process for migrating a MetaMask library into the met
 - Resolve any errors or issues resulting from these changes.
 - [Example PR](https://github.com/MetaMask/eth-json-rpc-provider/pull/28)
 
-### **[PR#3]** 5. Review the `metamask-module-template`, and add any missing files or elements (e.g. LICENSE)
+### **[PR#3]** 4. Review the `metamask-module-template`, and add any missing files or elements (e.g. LICENSE)
 
 - [Example PR](https://github.com/MetaMask/eth-json-rpc-provider/pull/24)
 
-### **[PR#4]** 6. Rename the migration target package so that it is prepended by the `@metamask/` namespace (skip if not applicable)
+### **[PR#4]** 5. Rename the migration target package so that it is prepended by the `@metamask/` namespace (skip if not applicable)
 
 - Modify the "name" field in `package.json`.
 - Update the title of the README.md.
 - Add a CHANGELOG entry for the rename.
 
-### **[PR#5]** 7. Create a new release of the migration target from the source repo
+### **[PR#5]** 6. Create a new release of the migration target from the source repo
 
-- All subsequent releases of the migration target will be made from the metamask module template.
+- All subsequent releases of the migration target will be made from the metamask design system monorepo.
 - [Example PR](https://github.com/MetaMask/eth-json-rpc-provider/pull/29)
 
 ## Phase B: **Staging** from the metamask module template's `merged-packages/` directory


### PR DESCRIPTION
## **Explanation**

This PR removes the section regarding disabling `dependabot` alerts and updates from the migration guide documentation, based on organizational requirements discussed in this [Slack thread](https://consensys.slack.com/archives/C01V1L10W2E/p1731097509734129). It was determined that this step is no longer necessary because:

- Dependabot alerts cannot be disabled at the repository level due to new organizational rules.
- Disabling Dependabot alerts would ultimately be redundant, as the repository will be archived after the migration, which will disable Dependabot by default.
- This step was originally intended to prevent confusion due to updates after migration began, but archiving the repository will achieve the same effect once complete.

## **References**

- Related conversation in Slack: [Discussion on Dependabot configuration](https://consensys.slack.com/archives/C01V1L10W2E/p1731097509734129).
