### PR TITLE
chore: updating design tokens package

### DIFF
--- a/apps/storybook-react/.storybook/preview.tsx
+++ b/apps/storybook-react/.storybook/preview.tsx
@@ -38,7 +38,7 @@ function withColorScheme(Story, context) {
 
   if (colorScheme === 'light') {
     return (
-      <Wrapper data-theme="light">
+      <Wrapper className="light">
         <Story {...context} />
       </Wrapper>
     );
@@ -46,7 +46,7 @@ function withColorScheme(Story, context) {
 
   if (colorScheme === 'dark') {
     return (
-      <Wrapper data-theme="dark">
+      <Wrapper className="dark">
         <Story {...context} />
       </Wrapper>
     );
@@ -54,10 +54,10 @@ function withColorScheme(Story, context) {
 
   return (
     <>
-      <Wrapper data-theme="light">
+      <Wrapper className="light">
         <Story {...context} />
       </Wrapper>
-      <Wrapper data-theme="dark">
+      <Wrapper className="dark">
         <Story {...context} />
       </Wrapper>
     </>

--- a/apps/storybook-react/package.json
+++ b/apps/storybook-react/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^1.9.0",
     "@metamask/design-system-tailwind-preset": "workspace:^",
-    "@metamask/design-tokens": "^4.0.0",
+    "@metamask/design-tokens": "^4.1.0",
     "@storybook/addon-a11y": "^8.3.5",
     "@storybook/addon-essentials": "^8.3.5",
     "@storybook/addon-interactions": "^8.3.5",

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -64,7 +64,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^4.0.0",
+    "@metamask/design-tokens": "^4.1.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "tailwindcss": "^3.0.0"

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -59,7 +59,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^4.0.0",
+    "@metamask/design-tokens": "^4.1.0",
     "tailwindcss": "^3.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3223,7 +3223,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^4.0.0
+    "@metamask/design-tokens": ^4.1.0
     react: ^16.0.0
     react-dom: ^16.0.0
     tailwindcss: ^3.0.0
@@ -3245,7 +3245,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^4.0.0
+    "@metamask/design-tokens": ^4.1.0
     tailwindcss: ^3.0.0
   languageName: unknown
   linkType: soft
@@ -3265,7 +3265,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/design-tokens@npm:^4.0.0":
+"@metamask/design-tokens@npm:^4.1.0":
   version: 4.1.0
   resolution: "@metamask/design-tokens@npm:4.1.0"
   checksum: 10/c56757521b749d8fd95f468e8d13edb2e36c98310966838fc40e44b72113c5b6eec53ff5548d2cef46d9232ec93fca3f3465fdb8e5d4018829289962a98d1367
@@ -3409,7 +3409,7 @@ __metadata:
   dependencies:
     "@chromatic-com/storybook": "npm:^1.9.0"
     "@metamask/design-system-tailwind-preset": "workspace:^"
-    "@metamask/design-tokens": "npm:^4.0.0"
+    "@metamask/design-tokens": "npm:^4.1.0"
     "@storybook/addon-a11y": "npm:^8.3.5"
     "@storybook/addon-essentials": "npm:^8.3.5"
     "@storybook/addon-interactions": "npm:^8.3.5"


### PR DESCRIPTION
## **Description**

This PR updates the design tokens minor version from 4.0.0 to 4.1.0.  Since we're locked to the major version, we were already using 4.1.0, but this PR allows us to test the light/dark class names in Storybook.

## **Related Issues**

Fixes: N/A 

## **Manual Testing Steps**

1. Check that the design tokens library version has been updated to 4.1.0.
2. Verify that light and dark mode classnames are correctly applied and responsive to theme changes.
3. Confirm that licensing information is visible and accurate where required.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/cc5b8cc4-712a-41f9-8cb6-dd0bdc348408

### **After**

https://github.com/user-attachments/assets/02f12f35-4129-42ad-bf28-894e83b97ccc

## **Pre-merge Author Checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (per [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge Reviewer Checklist**

- [ ] I've manually tested the PR (e.g., pull and build branch, run the app, test code).
- [ ] This PR addresses all acceptance criteria outlined and includes relevant testing evidence such as recordings or screenshots.