### PR TITLE
chore: improving Text unit and utils tests

### DIFF
--- a/packages/design-system-react/src/components/text/Text.test.tsx
+++ b/packages/design-system-react/src/components/text/Text.test.tsx
@@ -1,6 +1,17 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Text, TextVariant, TextColor } from '.';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+  TextAlign,
+  FontWeight,
+  FontStyle,
+  TextTransform,
+  OverflowWrap,
+} from '.';
+import { ValidTag } from './Text.types';
+import { TEXT_CLASS_MAP } from './Text.constants';
 
 describe('Text Component', () => {
   it('renders children correctly', () => {
@@ -8,43 +19,133 @@ describe('Text Component', () => {
     expect(screen.getByText('Hello, World!')).toBeInTheDocument();
   });
 
-  it('applies the correct variant classes', () => {
-    const { container } = render(
-      <Text variant={TextVariant.HeadingLg}>Heading</Text>,
-    );
-    expect(container.firstChild).toHaveClass(
-      'text-default',
-      'text-s-heading-lg',
-      'font-s-heading-lg',
-      'leading-s-heading-lg',
-      'tracking-s-heading-lg',
-      'md:text-l-heading-lg',
-    );
+  describe('Variants', () => {
+    Object.values(TextVariant).forEach((variant) => {
+      it(`renders ${variant} variant correctly`, () => {
+        const { container } = render(<Text variant={variant}>Test</Text>);
+        expect(container.firstChild).toHaveClass(TEXT_CLASS_MAP[variant]);
+      });
+    });
   });
 
-  it('merges additional class names', () => {
-    const { container } = render(
-      <Text variant={TextVariant.BodySm} className="custom-class">
-        Custom Class
-      </Text>,
-    );
-    expect(container.firstChild).toHaveClass(
-      'text-default',
-      'text-s-body-sm',
-      'font-s-body-sm',
-      'leading-s-body-sm',
-      'tracking-s-body-sm',
-      'custom-class',
-    );
+  describe('Colors', () => {
+    Object.values(TextColor).forEach((color) => {
+      it(`applies ${color} color correctly`, () => {
+        const { container } = render(<Text color={color}>Test</Text>);
+        expect(container.firstChild).toHaveClass(color);
+      });
+    });
   });
 
-  it('applies correct color class when color prop is provided', () => {
-    const { container } = render(
-      <Text variant={TextVariant.BodyMd} color={TextColor.ErrorDefault}>
-        Error Text
-      </Text>,
-    );
-    expect(container.firstChild).toHaveClass('text-error-default');
+  describe('Text Alignment', () => {
+    Object.values(TextAlign).forEach((alignment) => {
+      it(`applies ${alignment} alignment correctly`, () => {
+        const { container } = render(<Text textAlign={alignment}>Test</Text>);
+        expect(container.firstChild).toHaveClass(alignment);
+      });
+    });
+  });
+
+  describe('Font Weight', () => {
+    Object.values(FontWeight).forEach((weight) => {
+      it(`applies ${weight} font weight correctly`, () => {
+        const { container } = render(<Text fontWeight={weight}>Test</Text>);
+        expect(container.firstChild).toHaveClass(weight);
+      });
+    });
+  });
+
+  describe('Font Style', () => {
+    Object.values(FontStyle).forEach((style) => {
+      it(`applies ${style} font style correctly`, () => {
+        const { container } = render(<Text fontStyle={style}>Test</Text>);
+        expect(container.firstChild).toHaveClass(style);
+      });
+    });
+  });
+
+  describe('Text Transform', () => {
+    Object.values(TextTransform).forEach((transform) => {
+      it(`applies ${transform} text transform correctly`, () => {
+        const { container } = render(
+          <Text textTransform={transform}>Test</Text>,
+        );
+        expect(container.firstChild).toHaveClass(transform);
+      });
+    });
+  });
+
+  describe('Overflow Wrap', () => {
+    Object.values(OverflowWrap).forEach((wrap) => {
+      it(`applies ${wrap} overflow wrap correctly`, () => {
+        const { container } = render(<Text overflowWrap={wrap}>Test</Text>);
+        expect(container.firstChild).toHaveClass(wrap);
+      });
+    });
+  });
+
+  describe('HTML Elements', () => {
+    const regularElements: ValidTag[] = [
+      'dd',
+      'div',
+      'dt',
+      'em',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'li',
+      'p',
+      'span',
+      'strong',
+      'ul',
+      'label',
+      'header',
+      'a',
+      'button',
+    ];
+
+    regularElements.forEach((tag) => {
+      it(`renders as ${tag} element when specified`, () => {
+        const { container } = render(<Text as={tag}>Test</Text>);
+        expect(container.firstChild?.nodeName.toLowerCase()).toBe(tag);
+      });
+    });
+  });
+
+  describe('Combined Props', () => {
+    it('combines all styling props correctly', () => {
+      const { container } = render(
+        <Text
+          variant={TextVariant.HeadingLg}
+          color={TextColor.PrimaryDefault}
+          fontWeight={FontWeight.Bold}
+          fontStyle={FontStyle.Italic}
+          textTransform={TextTransform.Uppercase}
+          textAlign={TextAlign.Center}
+          overflowWrap={OverflowWrap.BreakWord}
+          ellipsis
+          className="custom-class"
+          as="div"
+        >
+          Test
+        </Text>,
+      );
+
+      expect(container.firstChild).toHaveClass(
+        TextColor.PrimaryDefault,
+        FontWeight.Bold,
+        FontStyle.Italic,
+        TextTransform.Uppercase,
+        TextAlign.Center,
+        OverflowWrap.BreakWord,
+        'truncate',
+        'custom-class',
+      );
+      expect(container.firstChild?.nodeName).toBe('DIV');
+    });
   });
 
   it('applies ellipsis class when ellipsis prop is true', () => {

--- a/packages/design-system-react/src/utils/tw-merge.test.ts
+++ b/packages/design-system-react/src/utils/tw-merge.test.ts
@@ -1,0 +1,106 @@
+import { twMerge } from './tw-merge';
+
+describe('twMerge utility', () => {
+  describe('text color conflicts', () => {
+    it('should override default text color with alternative', () => {
+      const result = twMerge('text-default text-alternative');
+      expect(result).toBe('text-alternative');
+    });
+
+    it('should override alternative text color with muted', () => {
+      const result = twMerge('text-alternative text-muted');
+      expect(result).toBe('text-muted');
+    });
+
+    it('should maintain the last text color in a sequence', () => {
+      const result = twMerge('text-default text-muted text-alternative');
+      expect(result).toBe('text-alternative');
+    });
+  });
+
+  describe('typography variant conflicts', () => {
+    it('should handle small variant overrides', () => {
+      const result = twMerge('text-s-body-md text-s-heading-lg');
+      expect(result).toBe('text-s-heading-lg');
+    });
+
+    it('should handle large variant overrides', () => {
+      const result = twMerge('text-l-body-md text-l-heading-lg');
+      expect(result).toBe('text-l-heading-lg');
+    });
+
+    it('should handle mixed size variant overrides', () => {
+      const result = twMerge('text-s-body-md text-l-heading-lg');
+      expect(result).toBe('text-l-heading-lg');
+    });
+  });
+
+  describe('font weight conflicts', () => {
+    it('should handle standard Tailwind font weight overrides', () => {
+      const result = twMerge('font-normal font-bold');
+      expect(result).toBe('font-bold');
+    });
+
+    it('should handle custom typography font weight overrides', () => {
+      const result = twMerge('font-s-body-md font-l-heading-lg');
+      expect(result).toBe('font-l-heading-lg');
+    });
+
+    it('should handle mixed standard and custom font weight overrides', () => {
+      const result = twMerge('font-bold font-s-body-md');
+      expect(result).toBe('font-s-body-md');
+    });
+  });
+
+  describe('complex class combinations', () => {
+    it('should handle multiple property conflicts simultaneously', () => {
+      const result = twMerge(
+        'text-default font-normal text-s-body-md',
+        'text-alternative font-bold text-l-heading-lg',
+      );
+      expect(result).toBe('text-alternative font-bold text-l-heading-lg');
+    });
+
+    it('should preserve non-conflicting classes', () => {
+      const result = twMerge(
+        'px-4 text-default font-normal',
+        'py-2 text-alternative font-bold',
+      );
+      expect(result).toBe('px-4 py-2 text-alternative font-bold');
+    });
+  });
+
+  describe('variant class validation', () => {
+    it('should handle all small variant classes', () => {
+      const smallVariants = [
+        'text-s-display-md',
+        'text-s-heading-lg',
+        'text-s-heading-md',
+        'text-s-heading-sm',
+        'text-s-body-lg',
+        'text-s-body-md',
+        'text-s-body-sm',
+        'text-s-body-xs',
+      ];
+
+      const result = twMerge(smallVariants.join(' '));
+      expect(result).toBe('text-s-body-xs'); // Should keep last one
+    });
+
+    it('should handle all large variant classes', () => {
+      const largeVariants = [
+        'text-l-display-md',
+        'text-l-heading-lg',
+        'text-l-heading-md',
+        'text-l-heading-sm',
+        'text-l-body-lg',
+        'text-l-body-md',
+        'text-l-body-sm',
+        'text-l-body-xs',
+      ];
+
+      const result = twMerge(largeVariants.join(' '));
+      expect(result).toBe('text-l-body-xs'); // Should keep last one
+    });
+  });
+});

--- a/packages/design-system-react/src/utils/tw-merge.ts
+++ b/packages/design-system-react/src/utils/tw-merge.ts
@@ -1,6 +1,5 @@
 import { extendTailwindMerge } from 'tailwind-merge';
 
-// TODO create a test that checks against typographyMap in Text.tsx
 const variantClassGroups = [
   's-display-md',
   's-heading-lg',


### PR DESCRIPTION
## **Description**

This PR enhances the unit tests for the `Text` component by expanding coverage to include all prop variations and types. Additionally, it adds specific tests for the `twmerge` utility to prevent conflicts with Tailwind classnames, ensuring that styles are applied correctly without unintended overrides. These improvements aim to bolster test reliability and component resilience against styling conflicts and unexpected behavior with various prop configurations.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/119

## **Manual testing steps**

1. Run the unit tests suite to verify that all `Text` component props and variants are tested.
2. Confirm that the `twmerge` utility tests pass and correctly prevent Tailwind classname conflicts.
3. Review test output to ensure each prop and `twmerge` interaction behaves as expected.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs).
- [x] I’ve completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I’ve manually tested the PR (e.g., pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria and includes necessary testing evidence, such as recordings or screenshots.