### PR TITLE
chore: removing unused typedoc

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -15,7 +15,6 @@ ignores:
   - 'rimraf'
   - 'simple-git-hooks'
   - 'ts-node'
-  - 'typedoc'
   # Ignore plugins implicitly imported by tools
   - 'jest-silent-reporter'
   - 'prettier-plugin-packagejson'

--- a/docs/package-migration-process-guide.md
+++ b/docs/package-migration-process-guide.md
@@ -104,12 +104,12 @@ This document outlines the process for migrating a MetaMask library into the met
 ### **[PR#8]** 4. Remove files and directories that will be replaced by files in the monorepo root directory
 
 - **Remove**: `.github/`, `.git*`, `scripts/`, `.depcheckrc.json`, `.yarn/`, `.yarnrc.yml`, `yarn.lock`, `.editorconfig`, `.eslint*`, `.prettier*`, `.nvm*`.
-- **Keep**: `src/`, `tests/`, `CHANGELOG.md`, `LICENSE`, `package.json`, `README.md`, `jest.config.js`, `tsconfig*.json`, `typedoc.json`
+- **Keep**: `src/`, `tests/`, `CHANGELOG.md`, `LICENSE`, `package.json`, `README.md`, `jest.config.js`, `tsconfig*.json`
 - [Example PR](https://github.com/MetaMask/core/pull/1764)
 
 ### **[PR#9]** 5. Replace config files
 
-- Update `tsconfig*.json`, `typedoc.json`, `jest.config.js` to extend from the corresponding files in the root directory by copying the contents of these files from other non-root packages.
+- Update `tsconfig*.json`, `jest.config.js` to extend from the corresponding files in the root directory by copying the contents of these files from other non-root packages.
 - Preserve TypeScript compiler flags and its compilation target.
 - Add tsconfig reference paths for non-root packages that are upstream dependencies of the migration target.
 - Preserve Jest coverage threshold values.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "scripts": {
     "build": "yarn ts-bridge --project tsconfig.build.json --verbose && yarn workspace @metamask/design-system-twrnc-preset build && yarn workspace @metamask/design-system-react-native build",
     "build:clean": "rimraf dist '**/*.tsbuildinfo' && yarn build",
-    "build:docs": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run build:docs",
     "build:types": "tsc --build tsconfig.build.json --verbose",
     "changelog:update": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run changelog:update",
     "changelog:validate": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run changelog:validate",

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -32,7 +32,6 @@
   ],
   "scripts": {
     "build": "rm -rf tsconfig.build.tsbuildinfo dist && tsc --project tsconfig.build.json",
-    "build:docs": "typedoc",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/design-system-react-native",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/design-system-react-native",
     "publish:preview": "yarn npm publish --tag preview",
@@ -65,8 +64,6 @@
     "metro-react-native-babel-preset": "^0.77.0",
     "react-test-renderer": "^18.3.1",
     "ts-jest": "^29.2.5",
-    "typedoc": "^0.24.8",
-    "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~5.2.2"
   },
   "engines": {

--- a/packages/design-system-react-native/typedoc.json
+++ b/packages/design-system-react-native/typedoc.json
@@ -1,7 +1,0 @@
-{
-  "entryPoints": ["./src/index.ts"],
-  "excludePrivate": true,
-  "hideGenerator": true,
-  "out": "docs",
-  "tsconfig": "./tsconfig.build.json"
-}

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -36,7 +36,6 @@
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
-    "build:docs": "typedoc",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/design-system-react",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/design-system-react",
     "publish:preview": "yarn npm publish --tag preview",
@@ -63,8 +62,6 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "typedoc": "^0.24.8",
-    "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~5.2.2"
   },
   "peerDependencies": {

--- a/packages/design-system-react/typedoc.json
+++ b/packages/design-system-react/typedoc.json
@@ -1,7 +1,0 @@
-{
-  "entryPoints": ["./src/index.ts"],
-  "excludePrivate": true,
-  "hideGenerator": true,
-  "out": "docs",
-  "tsconfig": "./tsconfig.build.json"
-}

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -36,7 +36,6 @@
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
-    "build:docs": "typedoc",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/design-system-tailwind-preset",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/design-system-tailwind-preset",
     "publish:preview": "yarn npm publish --tag preview",
@@ -54,8 +53,6 @@
     "jest": "^29.7.0",
     "postcss": "^8.4.47",
     "ts-jest": "^29.2.5",
-    "typedoc": "^0.24.8",
-    "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~5.2.2"
   },
   "peerDependencies": {

--- a/packages/design-system-tailwind-preset/typedoc.json
+++ b/packages/design-system-tailwind-preset/typedoc.json
@@ -1,7 +1,0 @@
-{
-  "entryPoints": ["./src/index.ts"],
-  "excludePrivate": true,
-  "hideGenerator": true,
-  "out": "docs",
-  "tsconfig": "./tsconfig.build.json"
-}

--- a/packages/design-system-twrnc-preset/package.json
+++ b/packages/design-system-twrnc-preset/package.json
@@ -36,7 +36,6 @@
   ],
   "scripts": {
     "build": "rm -rf tsconfig.build.tsbuildinfo dist && tsc --project tsconfig.build.json",
-    "build:docs": "typedoc",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/design-system-twrnc-preset",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/design-system-twrnc-preset",
     "publish:preview": "yarn npm publish --tag preview",
@@ -62,8 +61,6 @@
     "metro-react-native-babel-preset": "^0.77.0",
     "react-test-renderer": "^18.3.1",
     "ts-jest": "^29.2.5",
-    "typedoc": "^0.24.8",
-    "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~5.2.2"
   },
   "peerDependencies": {

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -39,7 +39,6 @@
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references && yarn build:css",
     "build:css": "cleancss -o dist/styles.css src/css/index.css",
-    "build:docs": "typedoc",
     "build:types": "tsc --project tsconfig.build.json",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/design-tokens",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/design-tokens",

--- a/scripts/create-package/package-template/package.json
+++ b/scripts/create-package/package-template/package.json
@@ -31,7 +31,6 @@
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
-    "build:docs": "typedoc",
     "changelog:update": "../../scripts/update-changelog.sh PACKAGE_NAME",
     "changelog:validate": "../../scripts/validate-changelog.sh PACKAGE_NAME",
     "publish:preview": "yarn npm publish --tag preview",
@@ -46,8 +45,6 @@
     "deepmerge": "^4.2.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "typedoc": "^0.24.8",
-    "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~5.2.2"
   },
   "engines": {

--- a/scripts/create-package/package-template/typedoc.json
+++ b/scripts/create-package/package-template/typedoc.json
@@ -1,7 +1,0 @@
-{
-  "entryPoints": ["./src/index.ts"],
-  "excludePrivate": true,
-  "hideGenerator": true,
-  "out": "docs",
-  "tsconfig": "./tsconfig.build.json"
-}

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -111,9 +111,6 @@ module.exports = defineConfig({
           }
         }
 
-        // All non-root packages must have the same "build:docs" script.
-        expectWorkspaceField(workspace, 'scripts.build:docs', 'typedoc');
-
         if (isPrivate) {
           // All private, non-root packages must not have a "publish:preview"
           // script.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3193,8 +3193,6 @@ __metadata:
     react-native: "npm:^0.72.15"
     react-test-renderer: "npm:^18.3.1"
     ts-jest: "npm:^29.2.5"
-    typedoc: "npm:^0.24.8"
-    typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
   languageName: unknown
   linkType: soft
@@ -3217,8 +3215,6 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     tailwind-merge: "npm:^2.0.0"
     ts-jest: "npm:^29.2.5"
-    typedoc: "npm:^0.24.8"
-    typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
   peerDependencies:
     "@metamask/design-tokens": ^4.1.0
@@ -3239,8 +3235,6 @@ __metadata:
     jest: "npm:^29.7.0"
     postcss: "npm:^8.4.47"
     ts-jest: "npm:^29.2.5"
-    typedoc: "npm:^0.24.8"
-    typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
   peerDependencies:
     "@metamask/design-tokens": ^4.1.0
@@ -3267,8 +3261,6 @@ __metadata:
     metro-react-native-babel-preset: "npm:^0.77.0"
     react-test-renderer: "npm:^18.3.1"
     ts-jest: "npm:^29.2.5"
-    typedoc: "npm:^0.24.8"
-    typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
   peerDependencies:
     "@metamask/design-tokens": ^4.1.0
@@ -13644,13 +13636,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:^3.2.0":
-  version: 3.3.1
-  resolution: "jsonc-parser@npm:3.3.1"
-  checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
-  languageName: node
-  linkType: hard
-
 "jsonfile@npm:^4.0.0":
   version: 4.0.0
   resolution: "jsonfile@npm:4.0.0"
@@ -20061,20 +20046,6 @@ __metadata:
   version: 1.1.2
   resolution: "vm-browserify@npm:1.1.2"
   checksum: 10/ad5b17c9f7a9d9f1ed0e24c897782ab7a587c1fd40f370152482e1af154c7cf0b0bacc45c5ae76a44289881e083ae4ae127808fdff864aa9b562192aae8b5c3b
-  languageName: node
-  linkType: hard
-
-"vscode-oniguruma@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "vscode-oniguruma@npm:1.7.0"
-  checksum: 10/7da9d21459f9788544b258a5fd1b9752df6edd8b406a19eea0209c6bf76507d5717277016799301c4da0d536095f9ca8c06afd1ab8f4001189090c804ca4814e
-  languageName: node
-  linkType: hard
-
-"vscode-textmate@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "vscode-textmate@npm:8.0.0"
-  checksum: 10/9fa7d66d6042cb090d116c2d8820d34c8870cfcbaed6e404da89f66b899970ed0ac47b59a2e30fc40a25af5414822bb3ea27974f714e9b91910d69c894be95f7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6399,13 +6399,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-sequence-parser@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "ansi-sequence-parser@npm:1.1.1"
-  checksum: 10/9ce30f257badc2ef62cac8028a7e26c368d22bf26650427192e8ffd102da42e377e3affe90fae58062eecc963b0b055f510dde3b677c7e0c433c67069b5a8ee5
-  languageName: node
-  linkType: hard
-
 "ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -14058,13 +14051,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lunr@npm:^2.3.9":
-  version: 2.3.9
-  resolution: "lunr@npm:2.3.9"
-  checksum: 10/f2f6db34c046f5a767782fe2454e6dd69c75ba3c5cf5c1cb9cacca2313a99c2ba78ff8fa67dac866fb7c4ffd5f22e06684793f5f15ba14bddb598b94513d54bf
-  languageName: node
-  linkType: hard
-
 "lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
@@ -14176,15 +14162,6 @@ __metadata:
   dependencies:
     object-visit: "npm:^1.0.0"
   checksum: 10/c27045a5021c344fc19b9132eb30313e441863b2951029f8f8b66f79d3d8c1e7e5091578075a996f74e417479506fe9ede28c44ca7bc351a61c9d8073daec36a
-  languageName: node
-  linkType: hard
-
-"marked@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "marked@npm:4.3.0"
-  bin:
-    marked: bin/marked.js
-  checksum: 10/c830bb4cb3705b754ca342b656e8a582d7428706b2678c898b856f6030c134ce2d1e19136efa3e6a1841f7330efbd24963d6bdeddc57d2938e906250f99895d0
   languageName: node
   linkType: hard
 
@@ -14925,7 +14902,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.4":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -17995,18 +17972,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shiki@npm:^0.14.1":
-  version: 0.14.7
-  resolution: "shiki@npm:0.14.7"
-  dependencies:
-    ansi-sequence-parser: "npm:^1.1.0"
-    jsonc-parser: "npm:^3.2.0"
-    vscode-oniguruma: "npm:^1.7.0"
-    vscode-textmate: "npm:^8.0.0"
-  checksum: 10/be3f2444c65bd0c57802026f171cb42ad571d361ee885be0c292b60785f68c70f19b69310f5ffe7f7a93db4c5ef50211e0a0248794bc6bb48d242bc43fe72a62
-  languageName: node
-  linkType: hard
-
 "side-channel@npm:^1.0.4, side-channel@npm:^1.0.6":
   version: 1.0.6
   resolution: "side-channel@npm:1.0.6"
@@ -19585,31 +19550,6 @@ __metadata:
   version: 0.0.6
   resolution: "typedarray@npm:0.0.6"
   checksum: 10/2cc1bcf7d8c1237f6a16c04efc06637b2c5f2d74e58e84665445cf87668b85a21ab18dd751fa49eee6ae024b70326635d7b79ad37b1c370ed2fec6aeeeb52714
-  languageName: node
-  linkType: hard
-
-"typedoc-plugin-missing-exports@npm:^2.0.0":
-  version: 2.3.0
-  resolution: "typedoc-plugin-missing-exports@npm:2.3.0"
-  peerDependencies:
-    typedoc: 0.24.x || 0.25.x
-  checksum: 10/83ff8affd82fa39a81931e825ef31b51b7470613c71601fde6ff413a5c7571e30734698092a38a437f12c5d3264010696ce9ca806d43485aa11e8208cb4cb323
-  languageName: node
-  linkType: hard
-
-"typedoc@npm:^0.24.8":
-  version: 0.24.8
-  resolution: "typedoc@npm:0.24.8"
-  dependencies:
-    lunr: "npm:^2.3.9"
-    marked: "npm:^4.3.0"
-    minimatch: "npm:^9.0.0"
-    shiki: "npm:^0.14.1"
-  peerDependencies:
-    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x
-  bin:
-    typedoc: bin/typedoc
-  checksum: 10/4f2f92ddde3f70a1a9666507f6bdf6620023599bd2c2a3ed3f8f909f9c28d92594c30ee6ee68f5a248ff70e09623acf1323bad633cb713b9f2e36bbd4fccf683
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Because we will be using storybook and this repos READMEs for documentation we not longer need typedoc which is left over from core. This pull request removes `typedoc` and its associated configuration files from the `design-system` monorepo. This change simplifies the repository by eliminating unused tooling and dependencies, reducing potential maintenance overhead.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/134

## **Manual testing steps**

1. Check that all `typedoc` configuration files and references (e.g., `typedoc`, `build:docs`, typedoc.json`) have been removed.

## **Screenshots/Recordings**

### **Before**

- `typedoc` dependencies and configurations present in monorepo

https://github.com/user-attachments/assets/843a7174-71dc-4a92-8d09-4d4317d986b0

### **After**

- All `typedoc` references have been removed from the monorepo.

https://github.com/user-attachments/assets/75640d54-4f82-4089-a99b-36af32310a83

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.