### PR TITLE
chore: ignoring test tsx files and duplicate configurations

### DIFF
--- a/packages/design-system-react/tsconfig.build.json
+++ b/packages/design-system-react/tsconfig.build.json
@@ -5,15 +5,9 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "jsx": "react",
-    "types": [
-      "react",
-      "jest",
-      "@testing-library/react",
-      "@testing-library/jest-dom"
-    ],
+    "types": ["react"],
     "lib": ["ES2020", "DOM"]
   },
   "references": [],
-  "include": ["./src"],
-  "exclude": ["**/*.stories.tsx", "**/*.stories.ts"]
+  "include": ["./src"]
 }

--- a/tsconfig.packages.build.json
+++ b/tsconfig.packages.build.json
@@ -15,6 +15,7 @@
   "exclude": [
     "./jest.config.packages.ts",
     "**/*.test.ts",
+    "**/*.test.tsx",
     "**/jest.config.ts",
     "**/*.stories.ts",
     "**/*.stories.tsx"


### PR DESCRIPTION
## **Description**

This PR updates the `tsconfig.json` configuration to exclude `test.tsx` files from the build process. 

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Pull this branch
2. Run `yarn build`
3. Verify that the `test.tsx`, `stories.tsx` and `stories.ts`  files are not included in the build output of `design-system-react`

## **Screenshots/Recordings**

### Before

<img width="355" alt="Screenshot 2024-11-21 at 2 46 16 PM" src="https://github.com/user-attachments/assets/0741ffbd-d919-4a27-9b68-407f4b240b0d">

### After

<img width="355" alt="Screenshot 2024-11-21 at 2 48 02 PM" src="https://github.com/user-attachments/assets/3adfd13b-9114-4b37-93f1-323ef92a29c4">


## **Pre-merge author checklist**

- [x] I’ve followed [[MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)](https://github.com/MetaMask/contributor-docs).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [[JSDoc](https://jsdoc.app/)](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [[labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I’ve manually tested the PR (e.g., pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described and includes the necessary testing evidence such as recordings and/or screenshots.