### PR TITLE
chore: fixing text variants, adding style prop and changing as to asChild

### DIFF
--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -46,6 +46,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
     "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/design-system-react/src/components/text/README.mdx
+++ b/packages/design-system-react/src/components/text/README.mdx
@@ -220,23 +220,21 @@ Examples:
 
 Note: When using `asChild` with form elements like inputs, the Text component's styles will be applied while maintaining the element's native functionality. You can also add additional className props to further customize the styling of the rendered element.
 
-### Ref Forwarding
+### Class Name
 
-The Text component supports ref forwarding, allowing you to access the underlying DOM element:
+Adds an additional class to the `Text` component.
 
-```jsx
-const ref = useRef(null);
-<Text ref={ref}>This text's DOM element can be accessed via ref</Text>;
-```
+### Style
 
-When used with `asChild`, the ref will be forwarded to the child component:
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with className alone. For static styles, prefer using className with Tailwind classes.
 
-```jsx
-const ref = useRef(null);
-<Text asChild ref={ref}>
-  <button>The ref will point to this button element</button>
-</Text>;
-```
+### Children
+
+The text content of the `Text` component.
+
+### Component API
+
+<Controls of={TextStories.Default} />
 
 ### References
 

--- a/packages/design-system-react/src/components/text/README.mdx
+++ b/packages/design-system-react/src/components/text/README.mdx
@@ -185,37 +185,58 @@ Use the boolean `ellipsis` prop to make the `Text` component have an ellipsis.
 
 <Canvas of={TextStories.Ellipsis} />
 
-### As
+### AsChild
 
-Use the `as` prop to change the root HTML element of the `Text` component.
+Use the `asChild` prop to compose the Text component with other components while maintaining the Text's styles. This allows you to merge the Text component's styles onto its child component instead of rendering an additional DOM element.
 
-You can also utilize the `ValidTag` enum from `@metamask/design-system-react` to ensure that you are using a valid HTML element.
+When using `asChild`, you must provide exactly one child element that can accept a className prop. This works with both interactive elements like buttons and inputs, as well as standard HTML elements.
 
-<Canvas of={TextStories.As} />
+<Canvas of={TextStories.AsChild} />
 
-Renders the HTML:
+Examples:
 
-```html
-<span>span</span> <strong>strong</strong>
+```jsx
+// Span example
+<Text asChild className="block">
+  <span>Text rendered as span</span>
+</Text>
+
+// Button example with click handler
+<Text asChild className="block">
+  <button type="button" onClick={() => console.log('button clicked')}>
+    Text rendered as button
+  </button>
+</Text>
+
+// Input example with styling
+<Text asChild className="bg-default border border-default">
+  <input
+    type="text"
+    placeholder="Rendered as input"
+    defaultValue="Text component as input"
+  />
+</Text>
 ```
 
-### Strong
+Note: When using `asChild` with form elements like inputs, the Text component's styles will be applied while maintaining the element's native functionality. You can also add additional className props to further customize the styling of the rendered element.
 
-Using the `as` prop with the value of `strong` will render the `Text` component as a `strong` element and any `strong` elements used within a `Text` component will be supported with bold styles.
+### Ref Forwarding
 
-<Canvas of={TextStories.Strong} />
+The Text component supports ref forwarding, allowing you to access the underlying DOM element:
 
-### Class Name
+```jsx
+const ref = useRef(null);
+<Text ref={ref}>This text's DOM element can be accessed via ref</Text>;
+```
 
-Adds an additional class to the `Text` component.
+When used with `asChild`, the ref will be forwarded to the child component:
 
-### Children
-
-The text content of the `Text` component.
-
-### Component API
-
-<Controls of={TextStories.Default} />
+```jsx
+const ref = useRef(null);
+<Text asChild ref={ref}>
+  <button>The ref will point to this button element</button>
+</Text>;
+```
 
 ### References
 

--- a/packages/design-system-react/src/components/text/Text.constants.ts
+++ b/packages/design-system-react/src/components/text/Text.constants.ts
@@ -16,9 +16,9 @@ export const TEXT_CLASS_MAP: Record<TextVariant, string> = {
   [TextVariant.BodyMd]:
     'text-s-body-md font-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md',
   [TextVariant.BodySm]:
-    'text-s-body-sm font-s-body-sm leading-s-body-sm tracking-s-body-sm',
+    'text-s-body-sm font-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm',
   [TextVariant.BodyXs]:
-    'text-s-body-xs font-s-body-xs leading-s-body-xs tracking-s-body-xs',
+    'text-s-body-xs font-s-body-xs leading-s-body-xs tracking-s-body-xs md:text-l-body-xs',
 };
 
 export const TEXT_DEFAULT_TAG_MAP: Record<

--- a/packages/design-system-react/src/components/text/Text.stories.tsx
+++ b/packages/design-system-react/src/components/text/Text.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import { Text } from './Text';
 import {
   TextVariant,
@@ -159,19 +160,35 @@ export const Ellipsis: Story = {
   ),
 };
 
-export const As: Story = {
+export const AsChild: Story = {
   render: () => (
     <div className="space-y-4">
-      <Text as="span">span</Text>
-      <Text as="strong">strong</Text>
+      <Text asChild className="block">
+        <span>Text rendered as span</span>
+      </Text>
+      <Text asChild className="block">
+        <button type="button" onClick={action('button-clicked')}>
+          Text rendered as button
+        </button>
+      </Text>
+      <Text asChild className="bg-default border border-default">
+        <input
+          type="text"
+          placeholder="Rendered as input"
+          defaultValue="Text component as input"
+        />
+      </Text>
     </div>
   ),
 };
+AsChild.storyName = 'AsChild';
 
 export const Strong: Story = {
   render: () => (
     <div className="space-y-4">
-      <Text>Text as strong tag</Text>
+      <Text asChild>
+        <strong>Text as strong tag</strong>
+      </Text>
       <Text>
         This is a <strong>strong tag</strong> as a child inside of Text
       </Text>

--- a/packages/design-system-react/src/components/text/Text.stories.tsx
+++ b/packages/design-system-react/src/components/text/Text.stories.tsx
@@ -181,17 +181,3 @@ export const AsChild: Story = {
     </div>
   ),
 };
-AsChild.storyName = 'AsChild';
-
-export const Strong: Story = {
-  render: () => (
-    <div className="space-y-4">
-      <Text asChild>
-        <strong>Text as strong tag</strong>
-      </Text>
-      <Text>
-        This is a <strong>strong tag</strong> as a child inside of Text
-      </Text>
-    </div>
-  ),
-};

--- a/packages/design-system-react/src/components/text/Text.test.tsx
+++ b/packages/design-system-react/src/components/text/Text.test.tsx
@@ -157,10 +157,10 @@ describe('Text Component', () => {
     expect(container.firstChild).toHaveClass('truncate');
   });
 
-  it('renders with custom HTML element when as prop is provided', () => {
+  it('renders with asChild prop correctly', () => {
     const { container } = render(
-      <Text variant={TextVariant.BodyMd} as="span">
-        Span Text
+      <Text asChild>
+        <span>Span Text</span>
       </Text>,
     );
     expect(container.firstChild?.nodeName).toBe('SPAN');
@@ -180,9 +180,9 @@ describe('Text Component', () => {
         color={TextColor.SuccessDefault}
         ellipsis
         className="custom-class"
-        as="div"
+        asChild
       >
-        Combined Props Text
+        <div>Combined Props Text</div>
       </Text>,
     );
     expect(container.firstChild).toHaveClass(

--- a/packages/design-system-react/src/components/text/Text.test.tsx
+++ b/packages/design-system-react/src/components/text/Text.test.tsx
@@ -10,7 +10,6 @@ import {
   TextTransform,
   OverflowWrap,
 } from '.';
-import { ValidTag } from './Text.types';
 import { TEXT_CLASS_MAP } from './Text.constants';
 
 describe('Text Component', () => {
@@ -84,37 +83,6 @@ describe('Text Component', () => {
     });
   });
 
-  describe('HTML Elements', () => {
-    const regularElements: ValidTag[] = [
-      'dd',
-      'div',
-      'dt',
-      'em',
-      'h1',
-      'h2',
-      'h3',
-      'h4',
-      'h5',
-      'h6',
-      'li',
-      'p',
-      'span',
-      'strong',
-      'ul',
-      'label',
-      'header',
-      'a',
-      'button',
-    ];
-
-    regularElements.forEach((tag) => {
-      it(`renders as ${tag} element when specified`, () => {
-        const { container } = render(<Text as={tag}>Test</Text>);
-        expect(container.firstChild?.nodeName.toLowerCase()).toBe(tag);
-      });
-    });
-  });
-
   describe('Combined Props', () => {
     it('combines all styling props correctly', () => {
       const { container } = render(
@@ -128,9 +96,9 @@ describe('Text Component', () => {
           overflowWrap={OverflowWrap.BreakWord}
           ellipsis
           className="custom-class"
-          as="div"
+          asChild
         >
-          Test
+          <div>Test</div>
         </Text>,
       );
 

--- a/packages/design-system-react/src/components/text/Text.tsx
+++ b/packages/design-system-react/src/components/text/Text.tsx
@@ -18,6 +18,8 @@ export const Text: React.FC<TextProps> = ({
   color = TextColor.TextDefault,
   style,
 }) => {
+  // When asChild is true, use Radix Slot to merge props onto the child component.
+  // Otherwise, render the semantic HTML element mapped to this variant (e.g. h1-h4, p).
   const Component = asChild ? Slot : TEXT_DEFAULT_TAG_MAP[variant];
 
   const mergedClassName = twMerge(

--- a/packages/design-system-react/src/components/text/Text.tsx
+++ b/packages/design-system-react/src/components/text/Text.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Slot } from '@radix-ui/react-slot';
 import { twMerge } from '../../utils/tw-merge';
 import { TextVariant, TextProps, TextColor } from './Text.types';
 import { TEXT_CLASS_MAP, TEXT_DEFAULT_TAG_MAP } from './Text.constants';
@@ -13,10 +14,11 @@ export const Text: React.FC<TextProps> = ({
   textAlign,
   overflowWrap,
   ellipsis,
-  as,
+  asChild,
   color = TextColor.TextDefault,
+  style,
 }) => {
-  const Tag = as || TEXT_DEFAULT_TAG_MAP[variant];
+  const Component = asChild ? Slot : TEXT_DEFAULT_TAG_MAP[variant];
 
   const mergedClassName = twMerge(
     color,
@@ -30,5 +32,9 @@ export const Text: React.FC<TextProps> = ({
     className,
   );
 
-  return <Tag className={mergedClassName}>{children}</Tag>;
+  return (
+    <Component className={mergedClassName} style={style}>
+      {children}
+    </Component>
+  );
 };

--- a/packages/design-system-react/src/components/text/Text.types.ts
+++ b/packages/design-system-react/src/components/text/Text.types.ts
@@ -1,5 +1,9 @@
 export type TextProps = {
   /**
+   * Optional prop for inline styles
+   */
+  style?: React.CSSProperties;
+  /**
    * Optional prop to change the font size of the component. The Text component uses responsive font sizes.
    * Different variants map to specific HTML elements by default.
    * @default TextVariant.BodyMd
@@ -46,16 +50,18 @@ export type TextProps = {
    */
   ellipsis?: boolean;
   /**
-   * Optional prop that changes the root HTML element of the Text component.
-   * Uses semantic HTML tags like h1, p, span, etc.
+   * Optional boolean that determines if the component should merge its props onto its immediate child
+   * instead of rendering a default DOM element.
+   * @default false
    */
-  as?: ValidTag;
+  asChild?: boolean;
   /**
    * Optional prop that sets the color of the text using predefined theme colors.
    * @default TextColor.TextDefault
    */
   color?: TextColor;
 };
+
 export enum TextVariant {
   // Display Sizes
   DisplayLg = 'display-lg',
@@ -116,28 +122,6 @@ export enum TextAlign {
   Right = 'text-right',
   Justify = 'text-justify',
 }
-
-export type ValidTag =
-  | 'dd'
-  | 'div'
-  | 'dt'
-  | 'em'
-  | 'h1'
-  | 'h2'
-  | 'h3'
-  | 'h4'
-  | 'h5'
-  | 'h6'
-  | 'li'
-  | 'p'
-  | 'span'
-  | 'strong'
-  | 'ul'
-  | 'label'
-  | 'input'
-  | 'header'
-  | 'a'
-  | 'button';
 
 export enum FontWeight {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3203,6 +3203,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/design-system-tailwind-preset": "workspace:^"
+    "@radix-ui/react-slot": "npm:^1.1.0"
     "@storybook/react": "npm:^8.3.5"
     "@storybook/test": "npm:^8.3.5"
     "@testing-library/jest-dom": "npm:^6.6.3"
@@ -3641,6 +3642,34 @@ __metadata:
   version: 0.1.1
   resolution: "@pkgr/core@npm:0.1.1"
   checksum: 10/6f25fd2e3008f259c77207ac9915b02f1628420403b2630c92a07ff963129238c9262afc9e84344c7a23b5cc1f3965e2cd17e3798219f5fd78a63d144d3cceba
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-compose-refs@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/047a4ed5f87cb848be475507cd62836cf5af5761484681f521ea543ea7c9d59d61d42806d6208863d5e2380bf38cdf4cff73c2bbe5f52dbbe50fb04e1a13ac72
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@radix-ui/react-slot@npm:1.1.0"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/95e190868418b1c83adf6627256f6b664b0dcbea95d7215de9c64ac2c31102fc09155565d9ca27be6abd20fc63d0b0bacfe1b67d78b2de1d198244c848e1a54e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

This PR introduces several important updates to the `Text` component in the design system react:

1. Added a new `style` prop to allow inline styles when needed for more flexible styling
2. Fixes broken text variants `BodySm` and `BodyXs` with proper responsive font sizes
3. Added the `asChild` prop to enable better component composition while maintaining styles as mentioned in [the technical spike](https://docs.google.com/document/d/1hdsxxFispA7v4-uDsbSMPVe6-Ab0tVzsSWCd4r1t-Po/edit?tab=t.0#heading=h.n13wxta3tttz)
4. Added comprehensive documentation and examples for all new features

These changes improve the component's flexibility and maintainability while maintaining its core functionality.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/149

## **Manual testing steps**

1. Go to Storybook and navigate to the Text component stories
2. Test each variant to ensure proper responsive behavior
3. Test the `asChild` prop with different elements (span, button, input)
4. Verify inline styles work correctly when applied
5. Test all existing functionality still works (colors, weights, transforms, etc.)

## **Screenshots/Recordings**

### **Before**
Text component had limited styling options and no composition capabilities


https://github.com/user-attachments/assets/c4652423-7854-43ac-b5eb-074bd6028cdb



### **After**
- Improved responsive typography
- Added component composition via `asChild`
- Added inline style support
- Added comprehensive documentation

https://github.com/user-attachments/assets/77c8a92c-a021-4bee-a1f7-cd786911b5f9

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
