### PR TITLE
feat: enhance Icon component with className overrides and style support

### DIFF
--- a/packages/design-system-react/src/components/icon/Icon.test.tsx
+++ b/packages/design-system-react/src/components/icon/Icon.test.tsx
@@ -70,6 +70,71 @@ describe('Icon', () => {
     const icon = container.firstChild;
     expect(icon).toHaveStyle(customStyle);
   });
+
+  describe('className overrides', () => {
+    it('should allow className to override color prop', () => {
+      const { container } = render(
+        <Icon
+          name={IconName.AddSquare}
+          color={IconColor.IconDefault}
+          className="text-inherit text-lg"
+        />,
+      );
+      const icon = container.firstChild;
+
+      // Verify the custom class is present
+      expect(icon).toHaveClass('text-inherit');
+
+      // Verify the default color class is not present
+      expect(icon).not.toHaveClass(IconColor.IconDefault);
+    });
+
+    it('should allow className to override size prop', () => {
+      const { container } = render(
+        <Icon
+          name={IconName.AddSquare}
+          size={IconSize.Md}
+          className="w-10 h-10"
+        />,
+      );
+      const icon = container.firstChild;
+
+      // Verify the custom size classes are present
+      expect(icon).toHaveClass('w-10');
+      expect(icon).toHaveClass('h-10');
+
+      // Verify the default size classes are not present
+      const defaultSizeClasses = ICON_SIZE_CLASS_MAP[IconSize.Md].split(' ');
+      defaultSizeClasses.forEach((className) => {
+        expect(icon).not.toHaveClass(className);
+      });
+    });
+
+    it('should allow className to override both color and size props', () => {
+      const { container } = render(
+        <Icon
+          name={IconName.AddSquare}
+          color={IconColor.IconDefault}
+          size={IconSize.Md}
+          className="text-inherit w-10 h-10"
+        />,
+      );
+      const icon = container.firstChild;
+
+      // Verify custom classes are present
+      expect(icon).toHaveClass('text-inherit');
+      expect(icon).toHaveClass('w-10');
+      expect(icon).toHaveClass('h-10');
+
+      // Verify default classes are not present
+      expect(icon).not.toHaveClass(IconColor.IconDefault);
+
+      const defaultSizeClasses = ICON_SIZE_CLASS_MAP[IconSize.Md].split(' ');
+      defaultSizeClasses.forEach((className) => {
+        expect(icon).not.toHaveClass(className);
+      });
+    });
+  });
 });
 
 describe('Icon error cases', () => {

--- a/packages/design-system-react/src/components/icon/Icon.types.ts
+++ b/packages/design-system-react/src/components/icon/Icon.types.ts
@@ -19,6 +19,16 @@ export type IconProps = SVGProps<SVGElementProps> & {
    * @default IconColor.IconDefault
    */
   color?: IconColor;
+  /**
+   * Additional CSS classes to be added to the component.
+   * These classes will be merged with the component's default classes using twMerge.
+   */
+  className?: string;
+  /**
+   * Optional CSS styles to be applied to the component.
+   * Should be used sparingly and only for dynamic styles that can't be achieved with className.
+   */
+  style?: React.CSSProperties;
 };
 
 export enum IconSize {

--- a/packages/design-system-react/src/components/icon/README.mdx
+++ b/packages/design-system-react/src/components/icon/README.mdx
@@ -41,6 +41,29 @@ Use the `color` prop and the `IconColor` enum to change the color of the icon.
 
 <Canvas of={IconStories.Color} />
 
+### Class Name
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+Example:
+
+```tsx
+// Adding new styles
+<Icon className="my-4 mx-2" name={IconName.AddSquare} />
+
+// Overriding default styles
+<Icon className="text-inherit" name={IconName.AddSquare} />
+```
+
+Note: When using `className` to override default styles, the custom classes will take precedence over the component's default classes.
+
+### Style
+
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with className alone. For static styles, prefer using className with Tailwind classes.
+
 ## Component API
 
 <Controls of={IconStories.Default} />

--- a/packages/design-system-react/src/components/text/README.mdx
+++ b/packages/design-system-react/src/components/text/README.mdx
@@ -228,7 +228,22 @@ Note: When using `asChild` with form elements like inputs, the Text component's 
 
 ### Class Name
 
-Adds an additional class to the `Text` component.
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+Example:
+
+```tsx
+// Adding new styles
+<Text className="my-4 mx-2">Text content</Text>
+
+// Overriding default styles
+<Text className="text-inherit">Text content</Text>
+```
+
+Note: When using `className` to override default styles, the custom classes will take precedence over the component's default classes.
 
 ### Style
 


### PR DESCRIPTION
## Description

This PR adds `className` and `style` props to  the `Icon` component's types as well as improve docs for engineers on how to use Tailwind classnames.

## Related issues

Fixes: N/A

## Manual testing steps

1. Go to the design system storybook
2. Navigate to the `Icon` component
3. Verify that className and style docs 

## Screenshots/Recordings

### Before
<img width="1511" alt="Screenshot 2024-12-12 at 10 06 49 AM" src="https://github.com/user-attachments/assets/ea029811-0958-4678-89e5-bda950f68d7a" />
<img width="1512" alt="Screenshot 2024-12-12 at 10 07 10 AM" src="https://github.com/user-attachments/assets/5c6b508e-5217-484a-b598-b81da2e23168" />


### After
<img width="1512" alt="Screenshot 2024-12-12 at 10 05 52 AM" src="https://github.com/user-attachments/assets/1b3a7b35-5697-4e00-8608-1b27340da514" />
<img width="1508" alt="Screenshot 2024-12-12 at 10 06 20 AM" src="https://github.com/user-attachments/assets/b87437eb-5217-43e6-8419-d607c1401bb9" />


## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template
- [x] I've included tests for className override functionality
- [x] I've documented the code with proper JSDoc comments
- [x] I've applied appropriate labels