### PR TITLE
feat: add ButtonSecondary component

### DIFF
--- a/packages/design-system-react/src/components/button-secondary/ButtonSecondary.stories.tsx
+++ b/packages/design-system-react/src/components/button-secondary/ButtonSecondary.stories.tsx
@@ -1,0 +1,180 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { ButtonSecondarySize } from '.';
+import { IconName } from '..';
+import { ButtonSecondary } from './ButtonSecondary';
+import README from './README.mdx';
+
+const meta: Meta<typeof ButtonSecondary> = {
+  title: 'React Components/ButtonSecondary',
+  component: ButtonSecondary,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    children: {
+      control: 'text',
+      description:
+        'Required prop for the content to be rendered within the ButtonSecondary',
+    },
+    className: {
+      control: 'text',
+      description:
+        'Optional prop for additional CSS classes to be applied to the ButtonSecondary component',
+    },
+    isDanger: {
+      control: 'boolean',
+      description:
+        'Optional prop that when true, applies error/danger styling to the button',
+    },
+    isInverse: {
+      control: 'boolean',
+      description:
+        'Optional prop that when true, applies inverse styling to the button',
+    },
+    size: {
+      control: 'select',
+      options: Object.values(ButtonSecondarySize),
+      description: 'Optional prop to control the size of the ButtonSecondary',
+    },
+    isFullWidth: {
+      control: 'boolean',
+      description:
+        'Optional prop that when true, makes the button take up the full width of its container',
+    },
+    isLoading: {
+      control: 'boolean',
+      description: 'Optional prop that when true, shows a loading spinner',
+    },
+    loadingText: {
+      control: 'text',
+      description:
+        'Optional prop for text to display when button is in loading state',
+    },
+    startIconName: {
+      control: 'select',
+      options: Object.values(IconName),
+      description:
+        'Optional prop to specify an icon to show at the start of the button',
+    },
+    startIconProps: {
+      control: 'object',
+      description:
+        'Optional prop to pass additional properties to the start icon',
+    },
+    startAccessory: {
+      control: 'text',
+      description:
+        'Optional prop for a custom element to show at the start of the button',
+    },
+    endIconName: {
+      control: 'select',
+      options: Object.values(IconName),
+      description:
+        'Optional prop to specify an icon to show at the end of the button',
+    },
+    endIconProps: {
+      control: 'object',
+      description:
+        'Optional prop to pass additional properties to the end icon',
+    },
+    endAccessory: {
+      control: 'text',
+      description:
+        'Optional prop for a custom element to show at the end of the button',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Optional prop that when true, disables the button',
+    },
+    loadingIconProps: {
+      control: 'object',
+      description:
+        'Optional prop to pass additional properties to the loading icon',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonSecondary>;
+
+export const Default: Story = {
+  args: {
+    children: 'Secondary Button',
+  },
+};
+
+export const IsDanger: Story = {
+  args: {
+    children: 'Danger Button',
+    isDanger: true,
+  },
+};
+
+export const IsInverse: Story = {
+  render: (args) => (
+    <div className="bg-primary-default p-4 rounded flex gap-2">
+      <ButtonSecondary {...args} isInverse>
+        Inverse Button
+      </ButtonSecondary>
+      <ButtonSecondary {...args} isInverse isDanger>
+        No Inverse Danger Button
+      </ButtonSecondary>
+    </div>
+  ),
+};
+
+export const Size: Story = {
+  render: (args) => (
+    <div className="flex gap-2">
+      <ButtonSecondary {...args} size={ButtonSecondarySize.Sm}>
+        Small
+      </ButtonSecondary>
+      <ButtonSecondary {...args} size={ButtonSecondarySize.Md}>
+        Medium
+      </ButtonSecondary>
+      <ButtonSecondary {...args} size={ButtonSecondarySize.Lg}>
+        Large
+      </ButtonSecondary>
+    </div>
+  ),
+};
+
+export const IsFullWidth: Story = {
+  args: {
+    children: 'Full Width Button',
+    isFullWidth: true,
+  },
+};
+
+export const StartIconName: Story = {
+  args: {
+    children: 'With Start Icon',
+    startIconName: IconName.AddSquare,
+  },
+};
+
+export const EndIconName: Story = {
+  args: {
+    children: 'With End Icon',
+    endIconName: IconName.AddSquare,
+  },
+};
+
+export const IsLoading: Story = {
+  args: {
+    children: 'Loading Button',
+    isLoading: true,
+    loadingText: 'Loading...',
+  },
+};
+
+export const IsDisabled: Story = {
+  args: {
+    children: 'Disabled Button',
+    isDisabled: true,
+  },
+};

--- a/packages/design-system-react/src/components/button-secondary/ButtonSecondary.test.tsx
+++ b/packages/design-system-react/src/components/button-secondary/ButtonSecondary.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { ButtonSecondarySize, IconName } from '..';
+import { ButtonSecondary } from './ButtonSecondary';
+
+describe('ButtonSecondary', () => {
+  it('renders with secondary button styles by default', () => {
+    render(<ButtonSecondary>Secondary Button</ButtonSecondary>);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass(
+      'bg-default',
+      'border-2',
+      'border-muted',
+      'text-default',
+    );
+  });
+
+  it('renders with danger styles when isDanger is true', () => {
+    render(<ButtonSecondary isDanger>Danger Button</ButtonSecondary>);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass(
+      'bg-default',
+      'border-2',
+      'border-error-default',
+      'text-error-default',
+    );
+  });
+
+  it('renders with inverse styles when isInverse is true', () => {
+    render(<ButtonSecondary isInverse>Inverse Button</ButtonSecondary>);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass(
+      'bg-transparent',
+      'border-2',
+      'border-primary-inverse',
+      'text-primary-inverse',
+    );
+  });
+
+  it('merges custom className with default styles', () => {
+    render(
+      <ButtonSecondary className="custom-class">
+        Secondary Button
+      </ButtonSecondary>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('custom-class');
+    expect(button).toHaveClass('bg-default');
+  });
+
+  it('renders with inverse danger styles when both isInverse and isDanger are true', () => {
+    render(
+      <ButtonSecondary isInverse isDanger>
+        Inverse Danger Button
+      </ButtonSecondary>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass(
+      'bg-transparent',
+      'border-2',
+      'border-error-inverse',
+      'text-error-inverse',
+    );
+  });
+
+  it('applies disabled styles while preserving variant-specific classes', () => {
+    render(<ButtonSecondary isDisabled>Disabled Button</ButtonSecondary>);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass(
+      'bg-default',
+      'border-2',
+      'border-muted',
+      'text-default',
+      'opacity-50',
+      'cursor-not-allowed',
+    );
+  });
+
+  it('applies loading styles while preserving variant-specific classes', () => {
+    render(
+      <ButtonSecondary isLoading loadingText="Loading...">
+        Loading Button
+      </ButtonSecondary>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass(
+      'bg-default',
+      'border-2',
+      'border-muted',
+      'text-default',
+      'opacity-50',
+      'cursor-not-allowed',
+    );
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('does not apply hover/active classes when disabled or loading', () => {
+    const { rerender } = render(
+      <ButtonSecondary isDisabled>Disabled</ButtonSecondary>,
+    );
+
+    let button = screen.getByRole('button');
+    expect(button).not.toHaveClass(
+      'hover:bg-default-hover',
+      'hover:border-default',
+      'active:bg-default-pressed',
+    );
+
+    rerender(<ButtonSecondary isLoading>Loading</ButtonSecondary>);
+    button = screen.getByRole('button');
+    expect(button).not.toHaveClass(
+      'hover:bg-default-hover',
+      'hover:border-default',
+      'active:bg-default-pressed',
+    );
+  });
+
+  it('renders with correct size classes', () => {
+    const { rerender } = render(
+      <ButtonSecondary size={ButtonSecondarySize.Sm}>Small</ButtonSecondary>,
+    );
+    expect(screen.getByRole('button')).toHaveClass('h-8');
+
+    rerender(
+      <ButtonSecondary size={ButtonSecondarySize.Lg}>Large</ButtonSecondary>,
+    );
+    expect(screen.getByRole('button')).toHaveClass('h-12');
+  });
+
+  it('renders with icons correctly', () => {
+    render(
+      <ButtonSecondary
+        startIconName={IconName.AddSquare}
+        endIconName={IconName.AddSquare}
+      >
+        With Icons
+      </ButtonSecondary>,
+    );
+
+    const icons = screen.getAllByRole('img');
+    expect(icons).toHaveLength(2);
+    expect(icons[0]).toHaveClass('mr-2'); // start icon
+    expect(icons[1]).toHaveClass('ml-2'); // end icon
+  });
+
+  it('renders loading text when provided', () => {
+    render(
+      <ButtonSecondary isLoading loadingText="Please wait...">
+        Submit
+      </ButtonSecondary>,
+    );
+
+    expect(screen.getByText('Please wait...')).toBeInTheDocument();
+    expect(screen.queryByText('Submit')).not.toBeInTheDocument();
+  });
+
+  it('applies full width class correctly', () => {
+    render(<ButtonSecondary isFullWidth>Full Width</ButtonSecondary>);
+    expect(screen.getByRole('button')).toHaveClass('w-full');
+  });
+
+  it('renders as child component when asChild is true', () => {
+    render(
+      <ButtonSecondary asChild>
+        <a href="#">Link Button</a>
+      </ButtonSecondary>,
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '#');
+  });
+});

--- a/packages/design-system-react/src/components/button-secondary/ButtonSecondary.tsx
+++ b/packages/design-system-react/src/components/button-secondary/ButtonSecondary.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import { twMerge } from '../../utils/tw-merge';
+import { ButtonBase } from '../button-base';
+import type { ButtonSecondaryProps } from './ButtonSecondary.types';
+
+export const ButtonSecondary = React.forwardRef<
+  HTMLButtonElement,
+  ButtonSecondaryProps
+>(
+  (
+    { className, isDanger, isInverse, isDisabled, isLoading, ...props },
+    ref,
+  ) => {
+    const isInteractive = !(isDisabled ?? isLoading);
+
+    const mergedClassName = twMerge(
+      // Default secondary styles
+      !isDanger &&
+        !isInverse && [
+          'bg-default border-2 border-muted text-default',
+          // Only apply hover/active styles when interactive
+          isInteractive && [
+            'hover:bg-default-hover hover:border-default',
+            'active:bg-default-pressed',
+          ],
+        ],
+      // Danger styles
+      isDanger &&
+        !isInverse && [
+          'bg-default border-2 border-error-default text-error-default',
+          // Only apply hover/active styles when interactive
+          isInteractive && [
+            'hover:bg-default-hover',
+            'active:bg-default-pressed',
+          ],
+        ],
+      // Inverse styles
+      isInverse &&
+        !isDanger && [
+          'bg-transparent border-2 border-primary-inverse text-primary-inverse',
+          // Only apply hover/active styles when interactive
+          isInteractive && ['hover:bg-hover', 'active:bg-pressed'],
+        ],
+      // Inverse danger styles
+      isInverse &&
+        isDanger && [
+          'bg-transparent border-2 border-error-inverse text-error-inverse',
+          // Only apply hover/active styles when interactive
+          isInteractive && ['hover:bg-hover', 'active:bg-pressed'],
+        ],
+      // Animation classes - only applied when interactive
+      isInteractive && [
+        'transition-[transform,colors,opacity]',
+        'duration-100',
+        'ease-linear',
+        // Scale animation
+        'active:scale-95',
+        'active:ease-[cubic-bezier(0.3,0.8,0.3,1)]',
+      ],
+      className,
+    );
+
+    return (
+      <ButtonBase
+        ref={ref}
+        className={mergedClassName}
+        isDisabled={isDisabled}
+        isLoading={isLoading}
+        {...props}
+      />
+    );
+  },
+);
+
+ButtonSecondary.displayName = 'ButtonSecondary';

--- a/packages/design-system-react/src/components/button-secondary/ButtonSecondary.types.ts
+++ b/packages/design-system-react/src/components/button-secondary/ButtonSecondary.types.ts
@@ -1,0 +1,37 @@
+import type { ButtonBaseProps } from '../button-base';
+
+export type ButtonSecondaryProps = Omit<
+  ButtonBaseProps,
+  // We handle these props in ButtonSecondary
+  'className' | 'isDisabled' | 'isLoading' | 'style'
+> & {
+  /**
+   * Optional prop for additional CSS classes to be applied to the ButtonSecondary component
+   */
+  className?: string;
+  /**
+   * Optional prop that when true, applies error/danger styling to the button
+   * @default false
+   */
+  isDanger?: boolean;
+  /**
+   * Optional prop that when true, applies inverse styling to the button
+   * @default false
+   */
+  isInverse?: boolean;
+  /**
+   * Optional prop that when true, disables the button
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Optional prop that when true, shows a loading spinner
+   * @default false
+   */
+  isLoading?: boolean;
+  /**
+   * Optional CSS styles to be applied to the component.
+   * Should be used sparingly and only for dynamic styles that can't be achieved with className.
+   */
+  style?: React.CSSProperties;
+};

--- a/packages/design-system-react/src/components/button-secondary/README.mdx
+++ b/packages/design-system-react/src/components/button-secondary/README.mdx
@@ -1,0 +1,97 @@
+import { Controls, Canvas } from '@storybook/blocks';
+
+import * as ButtonSecondaryStories from './ButtonSecondary.stories';
+
+# ButtonSecondary
+
+ButtonSecondary is used for secondary actions
+
+```tsx
+import { ButtonSecondary } from '@metamask/design-system-react';
+
+<ButtonSecondary onClick={() => {}>Secondary Button</ButtonSecondary>;
+```
+
+<Canvas of={ButtonSecondaryStories.Default} />
+
+## Props
+
+### Size
+
+ButtonSecondary supports three sizes:
+
+- `ButtonSecondarySize.Sm` (32px)
+- `ButtonSecondarySize.Md` (40px) - default
+- `ButtonSecondarySize.Lg` (48px)
+
+<Canvas of={ButtonSecondaryStories.Size} />
+
+### IsFullWidth
+
+ButtonSecondary can be set to take up the full width of its container.
+
+<Canvas of={ButtonSecondaryStories.IsFullWidth} />
+
+### IsDanger
+
+Use the danger variant for destructive actions.
+
+<Canvas of={ButtonSecondaryStories.IsDanger} />
+
+### IsInverse
+
+Use the inverse variant when the button needs to be displayed on a dark background. When combined with `isDanger`, the button will have inverse styling with error text color.
+
+<Canvas of={ButtonSecondaryStories.IsInverse} />
+
+### StartIconName and EndIconName
+
+ButtonSecondary can display icons at the start and/or end of the content.
+
+#### StartIconName
+
+<Canvas of={ButtonSecondaryStories.StartIconName} />
+
+#### EndIconName
+
+<Canvas of={ButtonSecondaryStories.EndIconName} />
+
+### IsLoading
+
+ButtonSecondary can show a loading state with optional loading text.
+
+<Canvas of={ButtonSecondaryStories.IsLoading} />
+
+### IsDisabled
+
+ButtonSecondary can be disabled.
+
+<Canvas of={ButtonSecondaryStories.IsDisabled} />
+
+### Class Name
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+Example:
+
+```tsx
+// Adding new styles
+<ButtonSecondary className="my-4 mx-2">Button content</ButtonSecondary>
+```
+
+Note: When using `className` to override default styles, the custom classes will take precedence over the component's default classes.
+
+### Style
+
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with className alone. For static styles, prefer using className with Tailwind classes.
+
+## Component API
+
+<Controls of={ButtonSecondaryStories.Default} />
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/src/components/button-secondary/index.ts
+++ b/packages/design-system-react/src/components/button-secondary/index.ts
@@ -1,0 +1,3 @@
+export { ButtonSecondary } from './ButtonSecondary';
+export type { ButtonSecondaryProps } from './ButtonSecondary.types';
+export { ButtonBaseSize as ButtonSecondarySize } from '../button-base';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -21,3 +21,7 @@ export { ButtonBaseSize } from './button-base';
 export { ButtonPrimary } from './button-primary';
 export type { ButtonPrimaryProps } from './button-primary';
 export { ButtonPrimarySize } from './button-primary';
+
+export { ButtonSecondary } from './button-secondary';
+export type { ButtonSecondaryProps } from './button-secondary';
+export { ButtonSecondarySize } from './button-secondary';


### PR DESCRIPTION
## **Description**

This PR adds a new ButtonSecondary component that extends ButtonBase with primary styling. The ButtonSecondary component provides default, danger, and inverse variants while maintaining all the functionality of ButtonBase.

Key changes:
1. Added ButtonSecondary component with primary styling
2. Added support for isDanger and isInverse variants
3. Created ButtonSecondarySize alias for ButtonBaseSize
4. Added comprehensive tests and stories
5. Added full documentation with examples

## **Related issues**

Fixes: : #142 

## **Manual testing steps**

1. Run Storybook (`yarn storybook`)
2. Navigate to React Components/ButtonSecondary
3. Test different variants:
   - Default primary button
   - Danger variant (isDanger)
   - Inverse variant (isInverse)
4. Verify all ButtonBase functionality works:
   - Different sizes
   - Full width
   - Icons
   - Loading state
   - Disabled state
5. Verify styles and hover/active states work correctly
6. Test custom className merging
7. Ensure styles align with [Figma](https://www.figma.com/design/HKpPKij9V3TpsyMV1TpV7C/branch/uPPH2eQcSOb1HIhELHyOpx/DS-Components?m=auto&node-id=9924-39599&t=8tiJ7AwpOSZVly7f-1)

## **Screenshots/Recordings**

### **Before**
N/A - New component

### **After**


https://github.com/user-attachments/assets/79d10276-eff0-4aa6-9710-f6a9f44886a6




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests for all functionality
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria and includes the necessary testing evidence