### PR TITLE
feat: add ButtonLink component

### DIFF
--- a/packages/design-system-react/src/components/button-base/ButtonBase.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.tsx
@@ -54,7 +54,7 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
           <Icon
             name={startIconName}
             size={IconSize.Sm}
-            className={twMerge('mr-2', startIconProps?.className)}
+            className={twMerge('mr-2 text-inherit', startIconProps?.className)}
             {...startIconProps}
           />
         );
@@ -71,7 +71,7 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
           <Icon
             name={endIconName}
             size={IconSize.Sm}
-            className={twMerge('ml-2', endIconProps?.className)}
+            className={twMerge('ml-2 text-inherit', endIconProps?.className)}
             {...endIconProps}
           />
         );

--- a/packages/design-system-react/src/components/button-link/ButtonLink.stories.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.stories.tsx
@@ -111,45 +111,17 @@ export const IsDanger: Story = {
 
 export const Size: Story = {
   render: (args) => (
-    <>
-      <div className="flex gap-2">
-        <ButtonLink {...args} size={ButtonLinkSize.Sm}>
-          Small
-        </ButtonLink>
-        <ButtonLink {...args} size={ButtonLinkSize.Md}>
-          Medium
-        </ButtonLink>
-        <ButtonLink {...args} size={ButtonLinkSize.Lg}>
-          Large
-        </ButtonLink>
-      </div>
-      <div className="mt-4 flex flex-col gap-2">
-        <Text variant={TextVariant.BodyLg} fontWeight={FontWeight.Medium}>
-          Inherits the font-size of the parent element.{' '}
-          <ButtonLink {...args} size={ButtonLinkSize.Auto}>
-            Learn more
-          </ButtonLink>
-        </Text>
-        <Text variant={TextVariant.BodyMd}>
-          Inherits the font-size of the parent element.{' '}
-          <ButtonLink {...args} size={ButtonLinkSize.Auto}>
-            Learn more
-          </ButtonLink>
-        </Text>
-        <Text variant={TextVariant.BodySm}>
-          Inherits the font-size of the parent element.{' '}
-          <ButtonLink {...args} size={ButtonLinkSize.Auto}>
-            Learn more
-          </ButtonLink>
-        </Text>
-        <Text variant={TextVariant.BodyXs}>
-          Inherits the font-size of the parent element.{' '}
-          <ButtonLink {...args} size={ButtonLinkSize.Auto}>
-            Learn more
-          </ButtonLink>
-        </Text>
-      </div>
-    </>
+    <div className="flex gap-2">
+      <ButtonLink {...args} size={ButtonLinkSize.Sm}>
+        Small
+      </ButtonLink>
+      <ButtonLink {...args} size={ButtonLinkSize.Md}>
+        Medium
+      </ButtonLink>
+      <ButtonLink {...args} size={ButtonLinkSize.Lg}>
+        Large
+      </ButtonLink>
+    </div>
   ),
 };
 

--- a/packages/design-system-react/src/components/button-link/ButtonLink.stories.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.stories.tsx
@@ -1,0 +1,190 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { ButtonLinkSize } from '.';
+import { IconName, Text, TextVariant, FontWeight } from '..';
+import { ButtonLink } from './ButtonLink';
+import README from './README.mdx';
+
+const meta: Meta<typeof ButtonLink> = {
+  title: 'React Components/ButtonLink',
+  component: ButtonLink,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    children: {
+      control: 'text',
+      description:
+        'Required prop for the content to be rendered within the ButtonLink',
+    },
+    className: {
+      control: 'text',
+      description:
+        'Optional prop for additional CSS classes to be applied to the ButtonLink component',
+    },
+    isDanger: {
+      control: 'boolean',
+      description:
+        'Optional prop that when true, applies error/danger styling to the button',
+    },
+    size: {
+      control: 'select',
+      options: Object.values(ButtonLinkSize),
+      description: 'Optional prop to control the size of the ButtonLink',
+    },
+    isFullWidth: {
+      control: 'boolean',
+      description:
+        'Optional prop that when true, makes the button take up the full width of its container',
+    },
+    isLoading: {
+      control: 'boolean',
+      description: 'Optional prop that when true, shows a loading spinner',
+    },
+    loadingText: {
+      control: 'text',
+      description:
+        'Optional prop for text to display when button is in loading state',
+    },
+    startIconName: {
+      control: 'select',
+      options: Object.values(IconName),
+      description:
+        'Optional prop to specify an icon to show at the start of the button',
+    },
+    startIconProps: {
+      control: 'object',
+      description:
+        'Optional prop to pass additional properties to the start icon',
+    },
+    startAccessory: {
+      control: 'text',
+      description:
+        'Optional prop for a custom element to show at the start of the button',
+    },
+    endIconName: {
+      control: 'select',
+      options: Object.values(IconName),
+      description:
+        'Optional prop to specify an icon to show at the end of the button',
+    },
+    endIconProps: {
+      control: 'object',
+      description:
+        'Optional prop to pass additional properties to the end icon',
+    },
+    endAccessory: {
+      control: 'text',
+      description:
+        'Optional prop for a custom element to show at the end of the button',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Optional prop that when true, disables the button',
+    },
+    loadingIconProps: {
+      control: 'object',
+      description:
+        'Optional prop to pass additional properties to the loading icon',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonLink>;
+
+export const Default: Story = {
+  args: {
+    children: 'Link Button',
+  },
+};
+
+export const IsDanger: Story = {
+  args: {
+    children: 'Danger Link',
+    isDanger: true,
+  },
+};
+
+export const Size: Story = {
+  render: (args) => (
+    <>
+      <div className="flex gap-2">
+        <ButtonLink {...args} size={ButtonLinkSize.Sm}>
+          Small
+        </ButtonLink>
+        <ButtonLink {...args} size={ButtonLinkSize.Md}>
+          Medium
+        </ButtonLink>
+        <ButtonLink {...args} size={ButtonLinkSize.Lg}>
+          Large
+        </ButtonLink>
+      </div>
+      <div className="mt-4 flex flex-col gap-2">
+        <Text variant={TextVariant.BodyLg} fontWeight={FontWeight.Medium}>
+          Inherits the font-size of the parent element.{' '}
+          <ButtonLink {...args} size={ButtonLinkSize.Inherit}>
+            Learn more
+          </ButtonLink>
+        </Text>
+        <Text variant={TextVariant.BodyMd}>
+          Inherits the font-size of the parent element.{' '}
+          <ButtonLink {...args} size={ButtonLinkSize.Inherit}>
+            Learn more
+          </ButtonLink>
+        </Text>
+        <Text variant={TextVariant.BodySm}>
+          Inherits the font-size of the parent element.{' '}
+          <ButtonLink {...args} size={ButtonLinkSize.Inherit}>
+            Learn more
+          </ButtonLink>
+        </Text>
+        <Text variant={TextVariant.BodyXs}>
+          Inherits the font-size of the parent element.{' '}
+          <ButtonLink {...args} size={ButtonLinkSize.Inherit}>
+            Learn more
+          </ButtonLink>
+        </Text>
+      </div>
+    </>
+  ),
+};
+
+export const IsFullWidth: Story = {
+  args: {
+    children: 'Full Width Link',
+    isFullWidth: true,
+  },
+};
+
+export const StartIconName: Story = {
+  args: {
+    children: 'With Start Icon',
+    startIconName: IconName.AddSquare,
+  },
+};
+
+export const EndIconName: Story = {
+  args: {
+    children: 'With End Icon',
+    endIconName: IconName.AddSquare,
+  },
+};
+
+export const IsLoading: Story = {
+  args: {
+    children: 'Loading Link',
+    isLoading: true,
+    loadingText: 'Loading...',
+  },
+};
+
+export const IsDisabled: Story = {
+  args: {
+    children: 'Disabled Link',
+    isDisabled: true,
+  },
+};

--- a/packages/design-system-react/src/components/button-link/ButtonLink.stories.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 import { ButtonLinkSize } from '.';
-import { IconName, Text, TextVariant, FontWeight } from '..';
+import { IconName } from '..';
 import { ButtonLink } from './ButtonLink';
 import README from './README.mdx';
 

--- a/packages/design-system-react/src/components/button-link/ButtonLink.stories.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.stories.tsx
@@ -126,25 +126,25 @@ export const Size: Story = {
       <div className="mt-4 flex flex-col gap-2">
         <Text variant={TextVariant.BodyLg} fontWeight={FontWeight.Medium}>
           Inherits the font-size of the parent element.{' '}
-          <ButtonLink {...args} size={ButtonLinkSize.Inherit}>
+          <ButtonLink {...args} size={ButtonLinkSize.Auto}>
             Learn more
           </ButtonLink>
         </Text>
         <Text variant={TextVariant.BodyMd}>
           Inherits the font-size of the parent element.{' '}
-          <ButtonLink {...args} size={ButtonLinkSize.Inherit}>
+          <ButtonLink {...args} size={ButtonLinkSize.Auto}>
             Learn more
           </ButtonLink>
         </Text>
         <Text variant={TextVariant.BodySm}>
           Inherits the font-size of the parent element.{' '}
-          <ButtonLink {...args} size={ButtonLinkSize.Inherit}>
+          <ButtonLink {...args} size={ButtonLinkSize.Auto}>
             Learn more
           </ButtonLink>
         </Text>
         <Text variant={TextVariant.BodyXs}>
           Inherits the font-size of the parent element.{' '}
-          <ButtonLink {...args} size={ButtonLinkSize.Inherit}>
+          <ButtonLink {...args} size={ButtonLinkSize.Auto}>
             Learn more
           </ButtonLink>
         </Text>

--- a/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
@@ -64,11 +64,11 @@ describe('ButtonLink', () => {
     );
     expect(screen.getByRole('button')).toHaveClass('h-8');
 
+    rerender(<ButtonLink size={ButtonLinkSize.Md}>Medium</ButtonLink>);
+    expect(screen.getByRole('button')).toHaveClass('h-10');
+
     rerender(<ButtonLink size={ButtonLinkSize.Lg}>Large</ButtonLink>);
     expect(screen.getByRole('button')).toHaveClass('h-12');
-
-    rerender(<ButtonLink size={ButtonLinkSize.Auto}>Auto</ButtonLink>);
-    expect(screen.getByRole('button')).toHaveClass('inline', 'p-0');
   });
 
   it('renders with icons correctly', () => {

--- a/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { ButtonLinkSize, IconName } from '..';
+import { ButtonLink } from './ButtonLink';
+
+describe('ButtonLink', () => {
+  it('renders with link button styles by default', () => {
+    render(<ButtonLink>Link Button</ButtonLink>);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('bg-transparent', 'text-primary-default');
+  });
+
+  it('renders with danger styles when isDanger is true', () => {
+    render(<ButtonLink isDanger>Danger Link</ButtonLink>);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('bg-transparent', 'text-error-default');
+  });
+
+  it('merges custom className with default styles', () => {
+    render(<ButtonLink className="custom-class">Link Button</ButtonLink>);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('custom-class');
+    expect(button).toHaveClass('bg-transparent');
+  });
+
+  it('applies disabled styles while preserving variant-specific classes', () => {
+    render(<ButtonLink isDisabled>Disabled Link</ButtonLink>);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass(
+      'bg-transparent',
+      'text-primary-default',
+      'opacity-50',
+      'cursor-not-allowed',
+    );
+  });
+
+  it('applies loading styles while preserving variant-specific classes', () => {
+    render(
+      <ButtonLink isLoading loadingText="Loading...">
+        Loading Link
+      </ButtonLink>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass(
+      'bg-transparent',
+      'text-primary-default',
+      'opacity-50',
+      'cursor-not-allowed',
+    );
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('renders with correct size classes', () => {
+    const { rerender } = render(
+      <ButtonLink size={ButtonLinkSize.Sm}>Small</ButtonLink>,
+    );
+    expect(screen.getByRole('button')).toHaveClass('h-8');
+
+    rerender(<ButtonLink size={ButtonLinkSize.Lg}>Large</ButtonLink>);
+    expect(screen.getByRole('button')).toHaveClass('h-12');
+
+    rerender(<ButtonLink size={ButtonLinkSize.Inherit}>Inherit</ButtonLink>);
+    expect(screen.getByRole('button')).toHaveClass('inline', 'p-0');
+  });
+
+  it('renders with icons correctly', () => {
+    render(
+      <ButtonLink
+        startIconName={IconName.AddSquare}
+        endIconName={IconName.AddSquare}
+      >
+        With Icons
+      </ButtonLink>,
+    );
+
+    const icons = screen.getAllByRole('img');
+    expect(icons).toHaveLength(2);
+    expect(icons[0]).toHaveClass('mr-2'); // start icon
+    expect(icons[1]).toHaveClass('ml-2'); // end icon
+  });
+
+  it('applies full width class correctly', () => {
+    render(<ButtonLink isFullWidth>Full Width</ButtonLink>);
+    expect(screen.getByRole('button')).toHaveClass('w-full');
+  });
+
+  describe('interactive states', () => {
+    it('applies interactive styles when neither disabled nor loading', () => {
+      render(<ButtonLink>Interactive Button</ButtonLink>);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass(
+        'transition-[transform,colors,opacity]',
+        'duration-100',
+        'ease-linear',
+        'hover:bg-hover',
+        'active:bg-pressed',
+        'active:scale-95',
+      );
+    });
+
+    it('does not apply interactive styles when disabled', () => {
+      render(<ButtonLink isDisabled>Disabled Button</ButtonLink>);
+
+      const button = screen.getByRole('button');
+      expect(button).not.toHaveClass('hover:bg-hover');
+      expect(button).not.toHaveClass('active:bg-pressed');
+    });
+
+    it('does not apply interactive styles when loading', () => {
+      render(<ButtonLink isLoading>Loading Button</ButtonLink>);
+
+      const button = screen.getByRole('button');
+      expect(button).not.toHaveClass('hover:bg-hover');
+      expect(button).not.toHaveClass('active:bg-pressed');
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('forwards ref to the button element', () => {
+      const ref = React.createRef<HTMLButtonElement>();
+      render(<ButtonLink ref={ref}>Button with Ref</ButtonLink>);
+
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+      expect(ref.current).toBe(screen.getByRole('button'));
+    });
+  });
+
+  describe('style prop handling', () => {
+    it('applies custom styles when style prop is provided', () => {
+      render(
+        <ButtonLink style={{ marginTop: '10px' }}>Styled Button</ButtonLink>,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveStyle({ marginTop: '10px' });
+    });
+  });
+
+  describe('accessibility', () => {
+    it('maintains button role and disabled state when loading', () => {
+      render(
+        <ButtonLink isLoading loadingText="Loading...">
+          Click Me
+        </ButtonLink>,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('properly handles aria-label when provided', () => {
+      render(
+        <ButtonLink aria-label="Custom Label">
+          <span>♥</span>
+        </ButtonLink>,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('aria-label', 'Custom Label');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty children', () => {
+      render(<ButtonLink />);
+
+      const button = screen.getByRole('button');
+      expect(button).toBeInTheDocument();
+    });
+
+    it('handles both isDanger and isDisabled states', () => {
+      render(
+        <ButtonLink isDanger isDisabled>
+          Danger Disabled
+        </ButtonLink>,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('text-error-default', 'opacity-50');
+      expect(button).toBeDisabled();
+    });
+  });
+});

--- a/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
@@ -155,7 +155,6 @@ describe('ButtonLink', () => {
 
       const button = screen.getByRole('button');
       expect(button).toBeDisabled();
-      expect(button).toHaveAttribute('aria-busy', 'true');
     });
 
     it('properly handles aria-label when provided', () => {
@@ -171,13 +170,6 @@ describe('ButtonLink', () => {
   });
 
   describe('edge cases', () => {
-    it('handles empty children', () => {
-      render(<ButtonLink />);
-
-      const button = screen.getByRole('button');
-      expect(button).toBeInTheDocument();
-    });
-
     it('handles both isDanger and isDisabled states', () => {
       render(
         <ButtonLink isDanger isDisabled>

--- a/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
@@ -67,7 +67,7 @@ describe('ButtonLink', () => {
     rerender(<ButtonLink size={ButtonLinkSize.Lg}>Large</ButtonLink>);
     expect(screen.getByRole('button')).toHaveClass('h-12');
 
-    rerender(<ButtonLink size={ButtonLinkSize.Inherit}>Inherit</ButtonLink>);
+    rerender(<ButtonLink size={ButtonLinkSize.Auto}>Auto</ButtonLink>);
     expect(screen.getByRole('button')).toHaveClass('inline', 'p-0');
   });
 

--- a/packages/design-system-react/src/components/button-link/ButtonLink.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.tsx
@@ -1,29 +1,11 @@
 import React from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
-import { ButtonBase, ButtonBaseSize } from '../button-base';
-import { ButtonLinkSize } from './ButtonLink.types';
+import { ButtonBase } from '../button-base';
 import type { ButtonLinkProps } from './ButtonLink.types';
 
-const mapToButtonBaseSize = (size: ButtonLinkSize): ButtonBaseSize => {
-  if (size === ButtonLinkSize.Auto) {
-    return ButtonBaseSize.Md;
-  }
-  return size as unknown as ButtonBaseSize;
-};
-
 export const ButtonLink = React.forwardRef<HTMLButtonElement, ButtonLinkProps>(
-  (
-    {
-      className,
-      isDanger,
-      isDisabled,
-      isLoading,
-      size = ButtonLinkSize.Md,
-      ...props
-    },
-    ref,
-  ) => {
+  ({ className, isDanger, isDisabled, isLoading, ...props }, ref) => {
     const isInteractive = !(isDisabled ?? isLoading);
 
     const mergedClassName = twMerge(
@@ -43,7 +25,6 @@ export const ButtonLink = React.forwardRef<HTMLButtonElement, ButtonLinkProps>(
       ],
       // Disabled/Loading styles
       !isInteractive && ['opacity-50', 'cursor-not-allowed'],
-      size === ButtonLinkSize.Auto && 'inline p-0 h-auto',
       className,
     );
 
@@ -53,7 +34,6 @@ export const ButtonLink = React.forwardRef<HTMLButtonElement, ButtonLinkProps>(
         className={mergedClassName}
         isDisabled={isDisabled}
         isLoading={isLoading}
-        size={mapToButtonBaseSize(size)}
         {...props}
       />
     );

--- a/packages/design-system-react/src/components/button-link/ButtonLink.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { twMerge } from '../../utils/tw-merge';
+import { ButtonBase, ButtonBaseSize } from '../button-base';
+import { ButtonLinkSize } from './ButtonLink.types';
+import type { ButtonLinkProps } from './ButtonLink.types';
+
+export const ButtonLink = React.forwardRef<HTMLButtonElement, ButtonLinkProps>(
+  (
+    {
+      className,
+      isDanger,
+      isDisabled,
+      isLoading,
+      size = ButtonLinkSize.Md,
+      ...props
+    },
+    ref,
+  ) => {
+    const isInteractive = !(isDisabled ?? isLoading);
+
+    const mergedClassName = twMerge(
+      // Base styles (always applied)
+      'bg-transparent',
+      // Text color based on variant
+      isDanger ? 'text-error-default' : 'text-primary-default',
+      // Interactive styles
+      isInteractive && [
+        'transition-[transform,colors,opacity]',
+        'duration-100',
+        'ease-linear',
+        'hover:bg-hover',
+        'active:bg-pressed',
+        'active:scale-95',
+        'active:ease-[cubic-bezier(0.3,0.8,0.3,1)]',
+      ],
+      // Disabled/Loading styles
+      !isInteractive && ['opacity-50', 'cursor-not-allowed'],
+      size === ButtonLinkSize.Inherit && 'inline p-0 h-auto',
+      className,
+    );
+
+    return (
+      <ButtonBase
+        ref={ref}
+        className={mergedClassName}
+        isDisabled={isDisabled}
+        isLoading={isLoading}
+        size={size === ButtonLinkSize.Inherit ? ButtonBaseSize.Md : size}
+        {...props}
+      />
+    );
+  },
+);
+
+ButtonLink.displayName = 'ButtonLink';

--- a/packages/design-system-react/src/components/button-link/ButtonLink.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.tsx
@@ -5,6 +5,13 @@ import { ButtonBase, ButtonBaseSize } from '../button-base';
 import { ButtonLinkSize } from './ButtonLink.types';
 import type { ButtonLinkProps } from './ButtonLink.types';
 
+const mapToButtonBaseSize = (size: ButtonLinkSize): ButtonBaseSize => {
+  if (size === ButtonLinkSize.Inherit) {
+    return ButtonBaseSize.Md;
+  }
+  return size as unknown as ButtonBaseSize;
+};
+
 export const ButtonLink = React.forwardRef<HTMLButtonElement, ButtonLinkProps>(
   (
     {
@@ -46,7 +53,7 @@ export const ButtonLink = React.forwardRef<HTMLButtonElement, ButtonLinkProps>(
         className={mergedClassName}
         isDisabled={isDisabled}
         isLoading={isLoading}
-        size={size === ButtonLinkSize.Inherit ? ButtonBaseSize.Md : size}
+        size={mapToButtonBaseSize(size)}
         {...props}
       />
     );

--- a/packages/design-system-react/src/components/button-link/ButtonLink.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.tsx
@@ -6,7 +6,7 @@ import { ButtonLinkSize } from './ButtonLink.types';
 import type { ButtonLinkProps } from './ButtonLink.types';
 
 const mapToButtonBaseSize = (size: ButtonLinkSize): ButtonBaseSize => {
-  if (size === ButtonLinkSize.Inherit) {
+  if (size === ButtonLinkSize.Auto) {
     return ButtonBaseSize.Md;
   }
   return size as unknown as ButtonBaseSize;
@@ -43,7 +43,7 @@ export const ButtonLink = React.forwardRef<HTMLButtonElement, ButtonLinkProps>(
       ],
       // Disabled/Loading styles
       !isInteractive && ['opacity-50', 'cursor-not-allowed'],
-      size === ButtonLinkSize.Inherit && 'inline p-0 h-auto',
+      size === ButtonLinkSize.Auto && 'inline p-0 h-auto',
       className,
     );
 

--- a/packages/design-system-react/src/components/button-link/ButtonLink.types.ts
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.types.ts
@@ -1,0 +1,47 @@
+import type { ButtonBaseProps } from '../button-base';
+import { ButtonBaseSize } from '../button-base';
+
+export enum ButtonLinkSize {
+  Sm = ButtonBaseSize.Sm,
+  Md = ButtonBaseSize.Md,
+  Lg = ButtonBaseSize.Lg,
+  /**
+   * Inherits font size from parent, removes height/padding, displays inline
+   */
+  Inherit = 'inherit',
+}
+
+export type ButtonLinkProps = Omit<
+  ButtonBaseProps,
+  'className' | 'isDisabled' | 'isLoading' | 'style' | 'size'
+> & {
+  /**
+   * Optional prop for additional CSS classes to be applied to the ButtonLink component
+   */
+  className?: string;
+  /**
+   * Optional prop that when true, applies error/danger styling to the button
+   * @default false
+   */
+  isDanger?: boolean;
+  /**
+   * Optional prop that when true, disables the button
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Optional prop that when true, shows a loading spinner
+   * @default false
+   */
+  isLoading?: boolean;
+  /**
+   * Optional CSS styles to be applied to the component.
+   * Should be used sparingly and only for dynamic styles that can't be achieved with className.
+   */
+  style?: React.CSSProperties;
+  /**
+   * Optional prop to control the size of the ButtonLink
+   * @default ButtonLinkSize.Md
+   */
+  size?: ButtonLinkSize;
+};

--- a/packages/design-system-react/src/components/button-link/ButtonLink.types.ts
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.types.ts
@@ -8,7 +8,7 @@ export enum ButtonLinkSize {
   /**
    * Inherits font size from parent, removes height/padding, displays inline
    */
-  Inherit = 'inherit',
+  Auto = 'auto',
 }
 
 export type ButtonLinkProps = Omit<

--- a/packages/design-system-react/src/components/button-link/ButtonLink.types.ts
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.types.ts
@@ -1,19 +1,8 @@
 import type { ButtonBaseProps } from '../button-base';
-import { ButtonBaseSize } from '../button-base';
-
-export enum ButtonLinkSize {
-  Sm = ButtonBaseSize.Sm,
-  Md = ButtonBaseSize.Md,
-  Lg = ButtonBaseSize.Lg,
-  /**
-   * Inherits font size from parent, removes height/padding, displays inline
-   */
-  Auto = 'auto',
-}
 
 export type ButtonLinkProps = Omit<
   ButtonBaseProps,
-  'className' | 'isDisabled' | 'isLoading' | 'style' | 'size'
+  'className' | 'isDisabled' | 'isLoading' | 'style'
 > & {
   /**
    * Optional prop for additional CSS classes to be applied to the ButtonLink component
@@ -39,9 +28,4 @@ export type ButtonLinkProps = Omit<
    * Should be used sparingly and only for dynamic styles that can't be achieved with className.
    */
   style?: React.CSSProperties;
-  /**
-   * Optional prop to control the size of the ButtonLink
-   * @default ButtonLinkSize.Md
-   */
-  size?: ButtonLinkSize;
 };

--- a/packages/design-system-react/src/components/button-link/README.mdx
+++ b/packages/design-system-react/src/components/button-link/README.mdx
@@ -1,0 +1,91 @@
+import { Controls, Canvas } from '@storybook/blocks';
+
+import * as ButtonLinkStories from './ButtonLink.stories';
+
+# ButtonLink
+
+ButtonLink is used for link-like actions that maintain button behavior
+
+```tsx
+import { ButtonLink } from '@metamask/design-system-react';
+
+<ButtonLink onClick={() => {}}>Link Button</ButtonLink>;
+```
+
+<Canvas of={ButtonLinkStories.Default} />
+
+## Props
+
+### Size
+
+ButtonLink supports three sizes:
+
+- `ButtonLinkSize.Sm` (32px)
+- `ButtonLinkSize.Md` (40px) - default
+- `ButtonLinkSize.Lg` (48px)
+
+<Canvas of={ButtonLinkStories.Size} />
+
+### IsFullWidth
+
+ButtonLink can be set to take up the full width of its container.
+
+<Canvas of={ButtonLinkStories.IsFullWidth} />
+
+### IsDanger
+
+Use the danger variant for destructive actions.
+
+<Canvas of={ButtonLinkStories.IsDanger} />
+
+### StartIconName and EndIconName
+
+ButtonLink can display icons at the start and/or end of the content.
+
+#### StartIconName
+
+<Canvas of={ButtonLinkStories.StartIconName} />
+
+#### EndIconName
+
+<Canvas of={ButtonLinkStories.EndIconName} />
+
+### IsLoading
+
+ButtonLink can show a loading state with optional loading text.
+
+<Canvas of={ButtonLinkStories.IsLoading} />
+
+### IsDisabled
+
+ButtonLink can be disabled.
+
+<Canvas of={ButtonLinkStories.IsDisabled} />
+
+### Class Name
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+Example:
+
+```tsx
+// Adding new styles
+<ButtonLink className="my-4 mx-2">Button content</ButtonLink>
+```
+
+Note: When using `className` to override default styles, the custom classes will take precedence over the component's default classes.
+
+### Style
+
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with className alone. For static styles, prefer using className with Tailwind classes.
+
+## Component API
+
+<Controls of={ButtonLinkStories.Default} />
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/src/components/button-link/README.mdx
+++ b/packages/design-system-react/src/components/button-link/README.mdx
@@ -23,6 +23,7 @@ ButtonLink supports three sizes:
 - `ButtonLinkSize.Sm` (32px)
 - `ButtonLinkSize.Md` (40px) - default
 - `ButtonLinkSize.Lg` (48px)
+- `ButtonLinkSize.Inherit` inherits the font-size of the parent element. Used for inline links in paragraphs
 
 <Canvas of={ButtonLinkStories.Size} />
 

--- a/packages/design-system-react/src/components/button-link/README.mdx
+++ b/packages/design-system-react/src/components/button-link/README.mdx
@@ -23,7 +23,6 @@ ButtonLink supports three sizes:
 - `ButtonLinkSize.Sm` (32px)
 - `ButtonLinkSize.Md` (40px) - default
 - `ButtonLinkSize.Lg` (48px)
-- `ButtonLinkSize.Auto` inherits the font-size of the parent element. Used for inline links in paragraphs
 
 <Canvas of={ButtonLinkStories.Size} />
 

--- a/packages/design-system-react/src/components/button-link/README.mdx
+++ b/packages/design-system-react/src/components/button-link/README.mdx
@@ -23,7 +23,7 @@ ButtonLink supports three sizes:
 - `ButtonLinkSize.Sm` (32px)
 - `ButtonLinkSize.Md` (40px) - default
 - `ButtonLinkSize.Lg` (48px)
-- `ButtonLinkSize.Inherit` inherits the font-size of the parent element. Used for inline links in paragraphs
+- `ButtonLinkSize.Auto` inherits the font-size of the parent element. Used for inline links in paragraphs
 
 <Canvas of={ButtonLinkStories.Size} />
 

--- a/packages/design-system-react/src/components/button-link/index.ts
+++ b/packages/design-system-react/src/components/button-link/index.ts
@@ -1,0 +1,3 @@
+export { ButtonLink } from './ButtonLink';
+export type { ButtonLinkProps } from './ButtonLink.types';
+export { ButtonLinkSize } from './ButtonLink.types';

--- a/packages/design-system-react/src/components/button-link/index.ts
+++ b/packages/design-system-react/src/components/button-link/index.ts
@@ -1,3 +1,3 @@
 export { ButtonLink } from './ButtonLink';
 export type { ButtonLinkProps } from './ButtonLink.types';
-export { ButtonLinkSize } from './ButtonLink.types';
+export { ButtonBaseSize as ButtonLinkSize } from '../button-base';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -25,3 +25,7 @@ export { ButtonPrimarySize } from './button-primary';
 export { ButtonSecondary } from './button-secondary';
 export type { ButtonSecondaryProps } from './button-secondary';
 export { ButtonSecondarySize } from './button-secondary';
+
+export { ButtonLink } from './button-link';
+export type { ButtonLinkProps } from './button-link';
+export { ButtonLinkSize } from './button-link';


### PR DESCRIPTION
## **Description**

Adds a new ButtonLink component that provides link-like styling while maintaining button behavior. This component extends ButtonBase with specific link-like styling and introduces a new size option 'inherit' for better text integration.

Key changes:
- Introduces ButtonLink component with link-like styling
- Adds ButtonLinkSize enum extending ButtonBaseSize with new 'inherit' option
- Implements interactive states (hover, active, disabled, loading)
- Includes comprehensive test coverage
- Provides full documentation with examples

## **Related issues**

Fixes: : #143 

## **Manual testing steps**

1. Run Storybook locally
2. Navigate to React Components/ButtonLink
3. Test different variants:
   - Default and danger variants
   - All size options (Sm, Md, Lg, Inherit)
   - Full width option
   - With icons/accessories
4. Verify interactive states:
   - Hover and active states
   - Disabled state
   - Loading state
5. Test inherit size within different text contexts

## **Screenshots/Recordings**

### Before

https://github.com/user-attachments/assets/87a41eb0-a122-45c3-9660-ee144b2110f6

### After

https://github.com/user-attachments/assets/a156790f-0ee4-48c2-83b6-2816f09440e2

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template
- [x] I've included comprehensive tests
- [x] I've documented the code using JSDoc format

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm this PR addresses all acceptance criteria