### PR TITLE
feat: Add Text component wrapping to ButtonBase

### DIFF
--- a/packages/design-system-react/src/components/button-base/ButtonBase.stories.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { IconName } from '..';
+import { IconName, TextVariant } from '..';
 import { ButtonBase } from './ButtonBase';
 import { ButtonBaseSize } from './ButtonBase.types';
 import README from './README.mdx';
@@ -90,6 +90,14 @@ const meta: Meta<typeof ButtonBase> = {
       description:
         'Optional prop to pass additional properties to the loading icon',
     },
+    textProps: {
+      control: 'object',
+      description:
+        'Optional props to be passed to the Text component when children is a string',
+      table: {
+        type: { summary: 'Partial<TextProps>' },
+      },
+    },
   },
 };
 
@@ -116,6 +124,15 @@ export const Size: Story = {
       </ButtonBase>
     </div>
   ),
+};
+
+export const TextProps: Story = {
+  args: {
+    children: 'Button with custom text variant',
+    textProps: {
+      variant: TextVariant.BodySm,
+    },
+  },
 };
 
 export const IsFullWidth: Story = {

--- a/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
@@ -208,6 +208,13 @@ describe('ButtonBase', () => {
       </ButtonBase>,
     );
     const customChild = screen.getByTestId('custom-child');
-    expect(customChild.parentElement).not.toHaveClass('text-base');
+    expect(customChild.parentElement).not.toHaveClass(
+      'text-default',
+      'text-s-body-md',
+      'font-s-body-md',
+      'leading-s-body-md',
+      'tracking-s-body-md',
+      'md:text-l-body-md',
+    );
   });
 });

--- a/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
@@ -178,24 +178,31 @@ describe('ButtonBase', () => {
     expect(button).toHaveClass('opacity-50', 'cursor-not-allowed');
   });
 
-  it('wraps string children in Text component', () => {
-    render(<ButtonBase>Click me</ButtonBase>);
-    expect(screen.getByText('Click me')).toHaveClass(
-      'text-default text-s-body-md font-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md',
-    );
-  });
+  it('handles text children correctly', () => {
+    // Test basic text wrapping and styling
+    const { rerender } = render(<ButtonBase>Click me</ButtonBase>);
+    const textElement = screen.getByText('Click me');
 
-  it('passes textProps to Text component when children is string', () => {
-    render(
+    expect(textElement.tagName).toBe('SPAN');
+    expect(textElement).toHaveClass(
+      'text-default',
+      'text-s-body-md',
+      'font-s-body-md',
+      'leading-s-body-md',
+      'tracking-s-body-md',
+      'md:text-l-body-md',
+    );
+
+    // Test custom text props
+    rerender(
       <ButtonBase textProps={{ className: 'custom-text-class' }}>
         Click me
       </ButtonBase>,
     );
     expect(screen.getByText('Click me')).toHaveClass('custom-text-class');
-  });
 
-  it('does not wrap non-string children in Text component', () => {
-    render(
+    // Test non-string children
+    rerender(
       <ButtonBase>
         <div data-testid="custom-child">Custom Element</div>
       </ButtonBase>,

--- a/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
@@ -180,7 +180,9 @@ describe('ButtonBase', () => {
 
   it('wraps string children in Text component', () => {
     render(<ButtonBase>Click me</ButtonBase>);
-    expect(screen.getByText('Click me')).toHaveClass('text-base');
+    expect(screen.getByText('Click me')).toHaveClass(
+      'text-default text-s-body-md font-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md',
+    );
   });
 
   it('passes textProps to Text component when children is string', () => {

--- a/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
@@ -185,7 +185,7 @@ describe('ButtonBase', () => {
 
     expect(textElement.tagName).toBe('SPAN');
     expect(textElement).toHaveClass(
-      'text-default',
+      'text-inherit',
       'text-s-body-md',
       'font-s-body-md',
       'leading-s-body-md',
@@ -209,7 +209,7 @@ describe('ButtonBase', () => {
     );
     const customChild = screen.getByTestId('custom-child');
     expect(customChild.parentElement).not.toHaveClass(
-      'text-default',
+      'text-inherit',
       'text-s-body-md',
       'font-s-body-md',
       'leading-s-body-md',

--- a/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
@@ -177,4 +177,28 @@ describe('ButtonBase', () => {
     expect(button).toBeDisabled();
     expect(button).toHaveClass('opacity-50', 'cursor-not-allowed');
   });
+
+  it('wraps string children in Text component', () => {
+    render(<ButtonBase>Click me</ButtonBase>);
+    expect(screen.getByText('Click me')).toHaveClass('text-base');
+  });
+
+  it('passes textProps to Text component when children is string', () => {
+    render(
+      <ButtonBase textProps={{ className: 'custom-text-class' }}>
+        Click me
+      </ButtonBase>,
+    );
+    expect(screen.getByText('Click me')).toHaveClass('custom-text-class');
+  });
+
+  it('does not wrap non-string children in Text component', () => {
+    render(
+      <ButtonBase>
+        <div data-testid="custom-child">Custom Element</div>
+      </ButtonBase>,
+    );
+    const customChild = screen.getByTestId('custom-child');
+    expect(customChild.parentElement).not.toHaveClass('text-base');
+  });
 });

--- a/packages/design-system-react/src/components/button-base/ButtonBase.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.tsx
@@ -1,7 +1,7 @@
 import { Slot, Slottable } from '@radix-ui/react-slot';
 import React from 'react';
 
-import { Icon, IconName, Text, TextColor } from '..';
+import { Icon, IconName, IconSize, Text, TextColor } from '..';
 import { twMerge } from '../../utils/tw-merge';
 import { BUTTON_BASE_SIZE_CLASS_MAP } from './ButtonBase.constants';
 import type { ButtonBaseProps } from './ButtonBase.types';
@@ -37,6 +37,7 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
       <span className="inline-flex items-center">
         <Icon
           name={IconName.Loading}
+          size={IconSize.Sm}
           className={twMerge(
             'animate-spin mr-2 text-inherit',
             loadingIconProps?.className,
@@ -52,6 +53,7 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
         return (
           <Icon
             name={startIconName}
+            size={IconSize.Sm}
             className={twMerge('mr-2 text-inherit', startIconProps?.className)}
             {...startIconProps}
           />
@@ -68,6 +70,7 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
         return (
           <Icon
             name={endIconName}
+            size={IconSize.Sm}
             className={twMerge('ml-2 text-inherit', endIconProps?.className)}
             {...endIconProps}
           />

--- a/packages/design-system-react/src/components/button-base/ButtonBase.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { Icon, IconName } from '..';
 import { twMerge } from '../../utils/tw-merge';
+import { Text } from '../text';
 import { BUTTON_BASE_SIZE_CLASS_MAP } from './ButtonBase.constants';
 import type { ButtonBaseProps } from './ButtonBase.types';
 import { ButtonBaseSize } from './ButtonBase.types';
@@ -25,6 +26,7 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
       endIconName,
       endIconProps,
       endAccessory,
+      textProps,
       style,
       ...props
     },
@@ -78,6 +80,13 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
       return null;
     };
 
+    const renderContent = () => {
+      if (children && typeof children === 'string') {
+        return <Text {...textProps}>{children}</Text>;
+      }
+      return children;
+    };
+
     const mergedClassName = twMerge(
       // Base styles
       'inline-flex items-center justify-center',
@@ -103,7 +112,9 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
         {...props}
       >
         {renderStartContent()}
-        <Slottable>{isLoading ? renderLoadingState() : children}</Slottable>
+        <Slottable>
+          {isLoading ? renderLoadingState() : renderContent()}
+        </Slottable>
         {renderEndContent()}
       </Component>
     );

--- a/packages/design-system-react/src/components/button-base/ButtonBase.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.tsx
@@ -1,9 +1,8 @@
 import { Slot, Slottable } from '@radix-ui/react-slot';
 import React from 'react';
 
-import { Icon, IconName } from '..';
+import { Icon, IconName, Text, TextColor } from '..';
 import { twMerge } from '../../utils/tw-merge';
-import { Text } from '../text';
 import { BUTTON_BASE_SIZE_CLASS_MAP } from './ButtonBase.constants';
 import type { ButtonBaseProps } from './ButtonBase.types';
 import { ButtonBaseSize } from './ButtonBase.types';
@@ -83,7 +82,7 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
     const renderContent = () => {
       if (children && typeof children === 'string') {
         return (
-          <Text asChild {...textProps}>
+          <Text color={TextColor.Inherit} asChild {...textProps}>
             <span>{children}</span>
           </Text>
         );

--- a/packages/design-system-react/src/components/button-base/ButtonBase.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.tsx
@@ -82,7 +82,11 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
 
     const renderContent = () => {
       if (children && typeof children === 'string') {
-        return <Text {...textProps}>{children}</Text>;
+        return (
+          <Text asChild {...textProps}>
+            <span>{children}</span>
+          </Text>
+        );
       }
       return children;
     };

--- a/packages/design-system-react/src/components/button-base/ButtonBase.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.tsx
@@ -54,7 +54,7 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
           <Icon
             name={startIconName}
             size={IconSize.Sm}
-            className={twMerge('mr-2 text-inherit', startIconProps?.className)}
+            className={twMerge('mr-2', startIconProps?.className)}
             {...startIconProps}
           />
         );
@@ -71,7 +71,7 @@ export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
           <Icon
             name={endIconName}
             size={IconSize.Sm}
-            className={twMerge('ml-2 text-inherit', endIconProps?.className)}
+            className={twMerge('ml-2', endIconProps?.className)}
             {...endIconProps}
           />
         );

--- a/packages/design-system-react/src/components/button-base/ButtonBase.types.ts
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.types.ts
@@ -35,6 +35,10 @@ export type ButtonBaseProps = ComponentProps<'button'> & {
    */
   size?: ButtonBaseSize;
   /**
+   * Optional props to be passed to the Text component when children is a string
+   */
+  textProps?: Partial<TextProps>;
+  /**
    * Optional prop that when true, makes the button take up the full width of its container
    * @default false
    */
@@ -92,8 +96,4 @@ export type ButtonBaseProps = ComponentProps<'button'> & {
    * Should be used sparingly and only for dynamic styles that can't be achieved with className.
    */
   style?: React.CSSProperties;
-  /**
-   * Optional props to be passed to the Text component when children is a string
-   */
-  textProps?: Partial<TextProps>;
 };

--- a/packages/design-system-react/src/components/button-base/ButtonBase.types.ts
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.types.ts
@@ -2,6 +2,7 @@ import type { ComponentProps } from 'react';
 
 import type { MakePropsOptional } from '../../types/make-props-optional';
 import type { IconName, IconProps } from '../icon';
+import type { TextProps } from '../text';
 
 export enum ButtonBaseSize {
   /**
@@ -91,4 +92,8 @@ export type ButtonBaseProps = ComponentProps<'button'> & {
    * Should be used sparingly and only for dynamic styles that can't be achieved with className.
    */
   style?: React.CSSProperties;
+  /**
+   * Optional props to be passed to the Text component when children is a string
+   */
+  textProps?: Partial<TextProps>;
 };

--- a/packages/design-system-react/src/components/button-base/README.mdx
+++ b/packages/design-system-react/src/components/button-base/README.mdx
@@ -48,7 +48,6 @@ import { ButtonBase, TextVariant } from '@metamask/design-system-react';
 <ButtonBase
   textProps={{
     variant: TextVariant.BodySm,
-    className: 'italic',
   }}
 >
   Custom text styling

--- a/packages/design-system-react/src/components/button-base/README.mdx
+++ b/packages/design-system-react/src/components/button-base/README.mdx
@@ -34,6 +34,27 @@ import { ButtonBase, ButtonBaseSize } from '@metamask/design-system-react';
 <ButtonBase size={ButtonBaseSize.Lg}>Large</ButtonBase>
 ```
 
+### TextProps
+
+ButtonBase automatically wraps string children in a Text component for consistent typography. You can customize the Text component's appearance using the `textProps` prop.
+
+**Note:** `textProps` only applies when `children` is a string. Non-string children are rendered as-is without the Text wrapper.
+
+<Canvas of={ButtonBaseStories.TextProps} />
+
+```tsx
+import { ButtonBase, TextVariant } from '@metamask/design-system-react';
+
+<ButtonBase
+  textProps={{
+    variant: TextVariant.BodySm,
+    className: 'italic',
+  }}
+>
+  Custom text styling
+</ButtonBase>;
+```
+
 ### IsFullWidth
 
 ButtonBase can be set to take up the full width of its container.


### PR DESCRIPTION
## Description

This PR adds automatic Text component wrapping for string children in ButtonBase, improving typography consistency across all buttons and improves customization.

Key changes:
- Added `textProps` prop to customize Text component rendering
- Added automatic string children wrapping in Text component
- Updated tests to verify Text wrapping behavior
- Added documentation and stories for textProps functionality
- Changes Icon size to small

## Related issues

Fixes: https://github.com/MetaMask/metamask-design-system/issues/308

## Manual testing steps

1. Run Storybook (`yarn storybook`)
2. Navigate to ButtonBase component
3. See story demonstrating Text wrapping string children rendering with default Text wrapping

## Screenshots/Recordings

### Before

https://github.com/user-attachments/assets/63059e0f-ba75-4a85-93a0-b5a4577689be

### After

https://github.com/user-attachments/assets/ba08ac47-e370-42fb-bee3-2bfb9feb6d97

100% testing coverage

<img width="1504" alt="Screenshot 2025-01-07 at 10 53 21 AM" src="https://github.com/user-attachments/assets/71cb789a-d830-4c4f-8247-4b5eee075805" />

## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template
- [x] I've included tests (100% coverage for new Text wrapping functionality)
- [x] I've documented code using JSDoc format

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR
- [ ] I confirm this PR addresses all acceptance criteria