### PR TITLE
fix: accessibility bug in icon

### DIFF
--- a/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
+++ b/packages/design-system-react/src/components/button-base/ButtonBase.test.tsx
@@ -46,18 +46,29 @@ describe('ButtonBase', () => {
 
   it('shows loading state with loading text', () => {
     render(
-      <ButtonBase isLoading loadingText="Please wait...">
+      <ButtonBase
+        isLoading
+        loadingText="Please wait..."
+        loadingIconProps={{ 'data-testid': 'loading-spinner' }}
+      >
         Submit
       </ButtonBase>,
     );
-    expect(screen.getByRole('img')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
     expect(screen.getByText('Please wait...')).toBeInTheDocument();
     expect(screen.queryByText('Submit')).not.toBeInTheDocument();
   });
 
   it('shows loading state with children when no loading text provided', () => {
-    render(<ButtonBase isLoading>Submit</ButtonBase>);
-    expect(screen.getByRole('img')).toBeInTheDocument();
+    render(
+      <ButtonBase
+        isLoading
+        loadingIconProps={{ 'data-testid': 'loading-spinner' }}
+      >
+        Submit
+      </ButtonBase>,
+    );
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
     expect(screen.getByText('Submit')).toBeInTheDocument();
   });
 

--- a/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
+++ b/packages/design-system-react/src/components/button-link/ButtonLink.test.tsx
@@ -71,20 +71,32 @@ describe('ButtonLink', () => {
     expect(screen.getByRole('button')).toHaveClass('h-12');
   });
 
-  it('renders with icons correctly', () => {
+  it('renders start icon when startIconName is provided', () => {
     render(
       <ButtonLink
         startIconName={IconName.AddSquare}
-        endIconName={IconName.AddSquare}
+        startIconProps={{ 'data-testid': 'icon-add-square' }}
       >
-        With Icons
+        With Icon
       </ButtonLink>,
     );
+    const icon = screen.getByTestId('icon-add-square');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('mr-2');
+  });
 
-    const icons = screen.getAllByRole('img');
-    expect(icons).toHaveLength(2);
-    expect(icons[0]).toHaveClass('mr-2'); // start icon
-    expect(icons[1]).toHaveClass('ml-2'); // end icon
+  it('renders end icon when endIconName is provided', () => {
+    render(
+      <ButtonLink
+        endIconName={IconName.AddSquare}
+        endIconProps={{ 'data-testid': 'icon-add-square' }}
+      >
+        With Icon
+      </ButtonLink>,
+    );
+    const icon = screen.getByTestId('icon-add-square');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('ml-2');
   });
 
   it('applies full width class correctly', () => {

--- a/packages/design-system-react/src/components/button-primary/ButtonPrimary.test.tsx
+++ b/packages/design-system-react/src/components/button-primary/ButtonPrimary.test.tsx
@@ -131,16 +131,18 @@ describe('ButtonPrimary', () => {
     render(
       <ButtonPrimary
         startIconName={IconName.AddSquare}
+        startIconProps={{ 'data-testid': 'start-icon' }}
         endIconName={IconName.AddSquare}
+        endIconProps={{ 'data-testid': 'end-icon' }}
       >
         With Icons
       </ButtonPrimary>,
     );
 
-    const icons = screen.getAllByRole('img');
-    expect(icons).toHaveLength(2);
-    expect(icons[0]).toHaveClass('mr-2'); // start icon
-    expect(icons[1]).toHaveClass('ml-2'); // end icon
+    const startIcon = screen.getByTestId('start-icon');
+    const endIcon = screen.getByTestId('end-icon');
+    expect(startIcon).toHaveClass('mr-2');
+    expect(endIcon).toHaveClass('ml-2');
   });
 
   it('renders loading text when provided', () => {

--- a/packages/design-system-react/src/components/button-secondary/ButtonSecondary.test.tsx
+++ b/packages/design-system-react/src/components/button-secondary/ButtonSecondary.test.tsx
@@ -141,16 +141,18 @@ describe('ButtonSecondary', () => {
     render(
       <ButtonSecondary
         startIconName={IconName.AddSquare}
+        startIconProps={{ 'data-testid': 'start-icon' }}
         endIconName={IconName.AddSquare}
+        endIconProps={{ 'data-testid': 'end-icon' }}
       >
         With Icons
       </ButtonSecondary>,
     );
 
-    const icons = screen.getAllByRole('img');
-    expect(icons).toHaveLength(2);
-    expect(icons[0]).toHaveClass('mr-2'); // start icon
-    expect(icons[1]).toHaveClass('ml-2'); // end icon
+    const startIcon = screen.getByTestId('start-icon');
+    const endIcon = screen.getByTestId('end-icon');
+    expect(startIcon).toHaveClass('mr-2');
+    expect(endIcon).toHaveClass('ml-2');
   });
 
   it('renders loading text when provided', () => {

--- a/packages/design-system-react/src/components/icon/.svgrrc.js
+++ b/packages/design-system-react/src/components/icon/.svgrrc.js
@@ -3,7 +3,6 @@ module.exports = {
   dimensions: false,
   ref: true,
   svgProps: {
-    role: 'img',
     fill: 'currentColor',
   },
   template: require('./template').default,

--- a/packages/design-system-react/src/components/icon/icons/Add.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Add.tsx
@@ -6,7 +6,6 @@ const SvgAdd = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/AddSquare.tsx
+++ b/packages/design-system-react/src/components/icon/icons/AddSquare.tsx
@@ -9,7 +9,6 @@ const SvgAddSquare = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Arrow2Down.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Arrow2Down.tsx
@@ -9,7 +9,6 @@ const SvgArrow2Down = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Arrow2Left.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Arrow2Left.tsx
@@ -9,7 +9,6 @@ const SvgArrow2Left = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Arrow2Right.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Arrow2Right.tsx
@@ -9,7 +9,6 @@ const SvgArrow2Right = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Arrow2Up.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Arrow2Up.tsx
@@ -9,7 +9,6 @@ const SvgArrow2Up = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Arrow2UpRight.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Arrow2UpRight.tsx
@@ -9,7 +9,6 @@ const SvgArrow2UpRight = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/ArrowDoubleLeft.tsx
+++ b/packages/design-system-react/src/components/icon/icons/ArrowDoubleLeft.tsx
@@ -9,7 +9,6 @@ const SvgArrowDoubleLeft = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/ArrowDoubleRight.tsx
+++ b/packages/design-system-react/src/components/icon/icons/ArrowDoubleRight.tsx
@@ -9,7 +9,6 @@ const SvgArrowDoubleRight = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/ArrowDown.tsx
+++ b/packages/design-system-react/src/components/icon/icons/ArrowDown.tsx
@@ -9,7 +9,6 @@ const SvgArrowDown = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/ArrowLeft.tsx
+++ b/packages/design-system-react/src/components/icon/icons/ArrowLeft.tsx
@@ -9,7 +9,6 @@ const SvgArrowLeft = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/ArrowRight.tsx
+++ b/packages/design-system-react/src/components/icon/icons/ArrowRight.tsx
@@ -9,7 +9,6 @@ const SvgArrowRight = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/ArrowUp.tsx
+++ b/packages/design-system-react/src/components/icon/icons/ArrowUp.tsx
@@ -9,7 +9,6 @@ const SvgArrowUp = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Ban.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Ban.tsx
@@ -6,7 +6,6 @@ const SvgBan = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Bank.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Bank.tsx
@@ -6,7 +6,6 @@ const SvgBank = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/BankToken.tsx
+++ b/packages/design-system-react/src/components/icon/icons/BankToken.tsx
@@ -9,7 +9,6 @@ const SvgBankToken = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Bold.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Bold.tsx
@@ -6,7 +6,6 @@ const SvgBold = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Book.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Book.tsx
@@ -6,7 +6,6 @@ const SvgBook = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Bookmark.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Bookmark.tsx
@@ -9,7 +9,6 @@ const SvgBookmark = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Bridge.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Bridge.tsx
@@ -6,7 +6,6 @@ const SvgBridge = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Calculator.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Calculator.tsx
@@ -9,7 +9,6 @@ const SvgCalculator = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Card.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Card.tsx
@@ -6,7 +6,6 @@ const SvgCard = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/CardPos.tsx
+++ b/packages/design-system-react/src/components/icon/icons/CardPos.tsx
@@ -9,7 +9,6 @@ const SvgCardPos = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/CardToken.tsx
+++ b/packages/design-system-react/src/components/icon/icons/CardToken.tsx
@@ -9,7 +9,6 @@ const SvgCardToken = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Category.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Category.tsx
@@ -9,7 +9,6 @@ const SvgCategory = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Chart.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Chart.tsx
@@ -6,7 +6,6 @@ const SvgChart = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Check.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Check.tsx
@@ -6,7 +6,6 @@ const SvgCheck = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/CheckBold.tsx
+++ b/packages/design-system-react/src/components/icon/icons/CheckBold.tsx
@@ -9,7 +9,6 @@ const SvgCheckBold = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/CircleX.tsx
+++ b/packages/design-system-react/src/components/icon/icons/CircleX.tsx
@@ -9,7 +9,6 @@ const SvgCircleX = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Clock.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Clock.tsx
@@ -6,7 +6,6 @@ const SvgClock = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Close.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Close.tsx
@@ -6,7 +6,6 @@ const SvgClose = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/CodeCircle.tsx
+++ b/packages/design-system-react/src/components/icon/icons/CodeCircle.tsx
@@ -9,7 +9,6 @@ const SvgCodeCircle = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Coin.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Coin.tsx
@@ -6,7 +6,6 @@ const SvgCoin = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Collapse.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Collapse.tsx
@@ -9,7 +9,6 @@ const SvgCollapse = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Confirmation.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Confirmation.tsx
@@ -9,7 +9,6 @@ const SvgConfirmation = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Connect.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Connect.tsx
@@ -9,7 +9,6 @@ const SvgConnect = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Copy.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Copy.tsx
@@ -6,7 +6,6 @@ const SvgCopy = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/CopySuccess.tsx
+++ b/packages/design-system-react/src/components/icon/icons/CopySuccess.tsx
@@ -9,7 +9,6 @@ const SvgCopySuccess = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Customize.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Customize.tsx
@@ -9,7 +9,6 @@ const SvgCustomize = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Danger.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Danger.tsx
@@ -6,7 +6,6 @@ const SvgDanger = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Dark.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Dark.tsx
@@ -6,7 +6,6 @@ const SvgDark = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Data.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Data.tsx
@@ -6,7 +6,6 @@ const SvgData = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Diagram.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Diagram.tsx
@@ -9,7 +9,6 @@ const SvgDiagram = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/DocumentCode.tsx
+++ b/packages/design-system-react/src/components/icon/icons/DocumentCode.tsx
@@ -9,7 +9,6 @@ const SvgDocumentCode = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Download.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Download.tsx
@@ -9,7 +9,6 @@ const SvgDownload = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Edit.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Edit.tsx
@@ -6,7 +6,6 @@ const SvgEdit = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Eraser.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Eraser.tsx
@@ -6,7 +6,6 @@ const SvgEraser = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Ethereum.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Ethereum.tsx
@@ -9,7 +9,6 @@ const SvgEthereum = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 417 417"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Expand.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Expand.tsx
@@ -6,7 +6,6 @@ const SvgExpand = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Explore.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Explore.tsx
@@ -9,7 +9,6 @@ const SvgExplore = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Export.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Export.tsx
@@ -6,7 +6,6 @@ const SvgExport = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Eye.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Eye.tsx
@@ -6,7 +6,6 @@ const SvgEye = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/EyeSlash.tsx
+++ b/packages/design-system-react/src/components/icon/icons/EyeSlash.tsx
@@ -9,7 +9,6 @@ const SvgEyeSlash = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/File.tsx
+++ b/packages/design-system-react/src/components/icon/icons/File.tsx
@@ -6,7 +6,6 @@ const SvgFile = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Filter.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Filter.tsx
@@ -6,7 +6,6 @@ const SvgFilter = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Flag.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Flag.tsx
@@ -6,7 +6,6 @@ const SvgFlag = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Flash.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Flash.tsx
@@ -6,7 +6,6 @@ const SvgFlash = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/FlashSlash.tsx
+++ b/packages/design-system-react/src/components/icon/icons/FlashSlash.tsx
@@ -9,7 +9,6 @@ const SvgFlashSlash = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Flask.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Flask.tsx
@@ -6,7 +6,6 @@ const SvgFlask = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/FullCircle.tsx
+++ b/packages/design-system-react/src/components/icon/icons/FullCircle.tsx
@@ -9,7 +9,6 @@ const SvgFullCircle = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Gas.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Gas.tsx
@@ -6,7 +6,6 @@ const SvgGas = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Global.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Global.tsx
@@ -6,7 +6,6 @@ const SvgGlobal = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/GlobalSearch.tsx
+++ b/packages/design-system-react/src/components/icon/icons/GlobalSearch.tsx
@@ -9,7 +9,6 @@ const SvgGlobalSearch = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Graph.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Graph.tsx
@@ -6,7 +6,6 @@ const SvgGraph = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Hardware.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Hardware.tsx
@@ -9,7 +9,6 @@ const SvgHardware = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Heart.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Heart.tsx
@@ -6,7 +6,6 @@ const SvgHeart = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Hierarchy.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Hierarchy.tsx
@@ -9,7 +9,6 @@ const SvgHierarchy = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Home.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Home.tsx
@@ -6,7 +6,6 @@ const SvgHome = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Import.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Import.tsx
@@ -6,7 +6,6 @@ const SvgImport = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Info.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Info.tsx
@@ -6,7 +6,6 @@ const SvgInfo = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Key.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Key.tsx
@@ -6,7 +6,6 @@ const SvgKey = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Light.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Light.tsx
@@ -6,7 +6,6 @@ const SvgLight = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Link.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Link.tsx
@@ -6,7 +6,6 @@ const SvgLink = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Loading.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Loading.tsx
@@ -9,7 +9,6 @@ const SvgLoading = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Lock.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Lock.tsx
@@ -6,7 +6,6 @@ const SvgLock = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/LockCircle.tsx
+++ b/packages/design-system-react/src/components/icon/icons/LockCircle.tsx
@@ -9,7 +9,6 @@ const SvgLockCircle = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/LockSlash.tsx
+++ b/packages/design-system-react/src/components/icon/icons/LockSlash.tsx
@@ -9,7 +9,6 @@ const SvgLockSlash = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Login.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Login.tsx
@@ -6,7 +6,6 @@ const SvgLogin = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Logout.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Logout.tsx
@@ -6,7 +6,6 @@ const SvgLogout = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Menu.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Menu.tsx
@@ -6,7 +6,6 @@ const SvgMenu = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/MessageQuestion.tsx
+++ b/packages/design-system-react/src/components/icon/icons/MessageQuestion.tsx
@@ -9,7 +9,6 @@ const SvgMessageQuestion = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Messages.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Messages.tsx
@@ -9,7 +9,6 @@ const SvgMessages = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Minus.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Minus.tsx
@@ -6,7 +6,6 @@ const SvgMinus = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/MinusBold.tsx
+++ b/packages/design-system-react/src/components/icon/icons/MinusBold.tsx
@@ -9,7 +9,6 @@ const SvgMinusBold = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/MinusSquare.tsx
+++ b/packages/design-system-react/src/components/icon/icons/MinusSquare.tsx
@@ -9,7 +9,6 @@ const SvgMinusSquare = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Mobile.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Mobile.tsx
@@ -6,7 +6,6 @@ const SvgMobile = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Money.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Money.tsx
@@ -6,7 +6,6 @@ const SvgMoney = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Monitor.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Monitor.tsx
@@ -9,7 +9,6 @@ const SvgMonitor = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/MoreHorizontal.tsx
+++ b/packages/design-system-react/src/components/icon/icons/MoreHorizontal.tsx
@@ -9,7 +9,6 @@ const SvgMoreHorizontal = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/MoreVertical.tsx
+++ b/packages/design-system-react/src/components/icon/icons/MoreVertical.tsx
@@ -9,7 +9,6 @@ const SvgMoreVertical = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Notification.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Notification.tsx
@@ -9,7 +9,6 @@ const SvgNotification = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/NotificationCircle.tsx
+++ b/packages/design-system-react/src/components/icon/icons/NotificationCircle.tsx
@@ -9,7 +9,6 @@ const SvgNotificationCircle = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/PasswordCheck.tsx
+++ b/packages/design-system-react/src/components/icon/icons/PasswordCheck.tsx
@@ -9,7 +9,6 @@ const SvgPasswordCheck = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/People.tsx
+++ b/packages/design-system-react/src/components/icon/icons/People.tsx
@@ -6,7 +6,6 @@ const SvgPeople = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Pin.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Pin.tsx
@@ -6,7 +6,6 @@ const SvgPin = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Plug.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Plug.tsx
@@ -6,7 +6,6 @@ const SvgPlug = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/PlusMinus.tsx
+++ b/packages/design-system-react/src/components/icon/icons/PlusMinus.tsx
@@ -9,7 +9,6 @@ const SvgPlusMinus = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 22 22"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/ProgrammingArrows.tsx
+++ b/packages/design-system-react/src/components/icon/icons/ProgrammingArrows.tsx
@@ -9,7 +9,6 @@ const SvgProgrammingArrows = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/QrCode.tsx
+++ b/packages/design-system-react/src/components/icon/icons/QrCode.tsx
@@ -6,7 +6,6 @@ const SvgQrCode = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Question.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Question.tsx
@@ -9,7 +9,6 @@ const SvgQuestion = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Received.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Received.tsx
@@ -9,7 +9,6 @@ const SvgReceived = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Refresh.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Refresh.tsx
@@ -9,7 +9,6 @@ const SvgRefresh = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Save.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Save.tsx
@@ -6,7 +6,6 @@ const SvgSave = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Scan.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Scan.tsx
@@ -6,7 +6,6 @@ const SvgScan = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/ScanBarcode.tsx
+++ b/packages/design-system-react/src/components/icon/icons/ScanBarcode.tsx
@@ -9,7 +9,6 @@ const SvgScanBarcode = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/ScanFocus.tsx
+++ b/packages/design-system-react/src/components/icon/icons/ScanFocus.tsx
@@ -9,7 +9,6 @@ const SvgScanFocus = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Scroll.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Scroll.tsx
@@ -6,7 +6,6 @@ const SvgScroll = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Search.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Search.tsx
@@ -6,7 +6,6 @@ const SvgSearch = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Security.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Security.tsx
@@ -9,7 +9,6 @@ const SvgSecurity = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SecurityCard.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SecurityCard.tsx
@@ -9,7 +9,6 @@ const SvgSecurityCard = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SecurityCross.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SecurityCross.tsx
@@ -9,7 +9,6 @@ const SvgSecurityCross = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SecurityKey.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SecurityKey.tsx
@@ -9,7 +9,6 @@ const SvgSecurityKey = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SecuritySearch.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SecuritySearch.tsx
@@ -9,7 +9,6 @@ const SvgSecuritySearch = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SecuritySlash.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SecuritySlash.tsx
@@ -9,7 +9,6 @@ const SvgSecuritySlash = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SecurityTick.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SecurityTick.tsx
@@ -9,7 +9,6 @@ const SvgSecurityTick = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SecurityTime.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SecurityTime.tsx
@@ -9,7 +9,6 @@ const SvgSecurityTime = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SecurityUser.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SecurityUser.tsx
@@ -9,7 +9,6 @@ const SvgSecurityUser = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Send1.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Send1.tsx
@@ -6,7 +6,6 @@ const SvgSend1 = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Send2.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Send2.tsx
@@ -6,7 +6,6 @@ const SvgSend2 = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Setting.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Setting.tsx
@@ -9,7 +9,6 @@ const SvgSetting = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Share.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Share.tsx
@@ -6,7 +6,6 @@ const SvgShare = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Slash.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Slash.tsx
@@ -6,7 +6,6 @@ const SvgSlash = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Snaps.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Snaps.tsx
@@ -6,7 +6,6 @@ const SvgSnaps = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SnapsMobile.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SnapsMobile.tsx
@@ -9,7 +9,6 @@ const SvgSnapsMobile = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SnapsPlus.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SnapsPlus.tsx
@@ -9,7 +9,6 @@ const SvgSnapsPlus = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Speedometer.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Speedometer.tsx
@@ -9,7 +9,6 @@ const SvgSpeedometer = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Square.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Square.tsx
@@ -6,7 +6,6 @@ const SvgSquare = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Stake.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Stake.tsx
@@ -6,7 +6,6 @@ const SvgStake = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Star.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Star.tsx
@@ -6,7 +6,6 @@ const SvgStar = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Student.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Student.tsx
@@ -9,7 +9,6 @@ const SvgStudent = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SwapHorizontal.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SwapHorizontal.tsx
@@ -9,7 +9,6 @@ const SvgSwapHorizontal = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/SwapVertical.tsx
+++ b/packages/design-system-react/src/components/icon/icons/SwapVertical.tsx
@@ -9,7 +9,6 @@ const SvgSwapVertical = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Tag.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Tag.tsx
@@ -6,7 +6,6 @@ const SvgTag = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Tilde.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Tilde.tsx
@@ -6,7 +6,6 @@ const SvgTilde = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Timer.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Timer.tsx
@@ -6,7 +6,6 @@ const SvgTimer = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Tint.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Tint.tsx
@@ -6,7 +6,6 @@ const SvgTint = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Trash.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Trash.tsx
@@ -6,7 +6,6 @@ const SvgTrash = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/TrendDown.tsx
+++ b/packages/design-system-react/src/components/icon/icons/TrendDown.tsx
@@ -9,7 +9,6 @@ const SvgTrendDown = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/TrendUp.tsx
+++ b/packages/design-system-react/src/components/icon/icons/TrendUp.tsx
@@ -9,7 +9,6 @@ const SvgTrendUp = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Twitter.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Twitter.tsx
@@ -9,7 +9,6 @@ const SvgTwitter = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Unpin.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Unpin.tsx
@@ -6,7 +6,6 @@ const SvgUnpin = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Upload.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Upload.tsx
@@ -6,7 +6,6 @@ const SvgUpload = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Usb.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Usb.tsx
@@ -6,7 +6,6 @@ const SvgUsb = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/User.tsx
+++ b/packages/design-system-react/src/components/icon/icons/User.tsx
@@ -6,7 +6,6 @@ const SvgUser = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/UserCheck.tsx
+++ b/packages/design-system-react/src/components/icon/icons/UserCheck.tsx
@@ -9,7 +9,6 @@ const SvgUserCheck = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/UserCircle.tsx
+++ b/packages/design-system-react/src/components/icon/icons/UserCircle.tsx
@@ -9,7 +9,6 @@ const SvgUserCircle = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/UserCircleAdd.tsx
+++ b/packages/design-system-react/src/components/icon/icons/UserCircleAdd.tsx
@@ -9,7 +9,6 @@ const SvgUserCircleAdd = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/UserCircleRemove.tsx
+++ b/packages/design-system-react/src/components/icon/icons/UserCircleRemove.tsx
@@ -9,7 +9,6 @@ const SvgUserCircleRemove = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Wallet.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Wallet.tsx
@@ -6,7 +6,6 @@ const SvgWallet = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/WalletCard.tsx
+++ b/packages/design-system-react/src/components/icon/icons/WalletCard.tsx
@@ -9,7 +9,6 @@ const SvgWalletCard = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/WalletMoney.tsx
+++ b/packages/design-system-react/src/components/icon/icons/WalletMoney.tsx
@@ -9,7 +9,6 @@ const SvgWalletMoney = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Warning.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Warning.tsx
@@ -9,7 +9,6 @@ const SvgWarning = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/icons/Wifi.tsx
+++ b/packages/design-system-react/src/components/icon/icons/Wifi.tsx
@@ -6,7 +6,6 @@ const SvgWifi = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >

--- a/packages/design-system-react/src/components/icon/template.js
+++ b/packages/design-system-react/src/components/icon/template.js
@@ -37,7 +37,6 @@ const ${variables.componentName} = (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
     fill="currentColor"
-    role="img"
     ref={ref}
     {...props}
   >


### PR DESCRIPTION
## **Description**

This PR removes the `role="img"` attribute from icon components to improve accessibility. The icons are primarily decorative and don't require the img role. When icons need to be accessible (e.g., in ButtonIcon components), we use aria-label directly on the parent component instead.

Key changes:
- Removed `role="img"` from `.svgrrc.js` configuration
- Removed `role="img"` attribute from all icon components
- Icons remain accessible through aria-label when used in semantic contexts

This change aligns with accessibility best practices by not announcing decorative icons to screen readers while maintaining the ability to provide meaningful labels where needed.

## **Related issues**

Fixes: #309

## **Manual testing steps**

1. Run accessibility tests on icon components
2. Verify icons render correctly without the role attribute
3. Test ButtonIcon components to ensure aria-labels still function properly
4. Verify screen readers ignore decorative icons but properly announce labeled icons

## **Screenshots/Recordings**

### **Before**
Icons had `role="img"` which caused accessibility warnings due to missing alt/title attributes:

<img width="757" alt="Screenshot 2025-01-08 at 1 31 06 PM" src="https://github.com/user-attachments/assets/4cf08b63-bf32-4b21-bdd4-d59522f58c24" />


### **After**
Icons are properly marked as decorative by removing the unnecessary role attribute:

<img width="1509" alt="Screenshot 2025-01-08 at 1 36 30 PM" src="https://github.com/user-attachments/assets/e400c4a4-aa09-4860-90b7-63a09eb1bd0a" />


## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template
- [x] I've included tests (accessibility tests pass)
- [x] I've documented my code
- [x] I've applied appropriate labels

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria