### PR TITLE
chore: prep for Buttons - React Native

### DIFF
--- a/apps/storybook-react-native/babel.config.js
+++ b/apps/storybook-react-native/babel.config.js
@@ -2,5 +2,8 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: [
+      'react-native-reanimated/plugin', // Must be the last plugin
+    ],
   };
 };

--- a/packages/design-system-react-native/.eslintrc.js
+++ b/packages/design-system-react-native/.eslintrc.js
@@ -22,7 +22,21 @@ module.exports = {
     'svgMock.js',
     'scripts/',
   ],
-
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      rules: {
+        'import/default': [
+          'off',
+          {
+            patterns: {
+              'react-native-reanimated': false,
+            },
+          },
+        ],
+      },
+    },
+  ],
   rules: {
     'import/extensions': [
       'error',

--- a/packages/design-system-react-native/babel.config.js
+++ b/packages/design-system-react-native/babel.config.js
@@ -16,6 +16,7 @@ module.exports = {
         ['@babel/plugin-transform-class-properties', { loose: true }],
         ['@babel/plugin-transform-private-methods', { loose: true }],
         ['@babel/plugin-transform-private-property-in-object', { loose: true }],
+        'react-native-reanimated/plugin', // Must be the last plugin
       ],
     },
   },

--- a/packages/design-system-react-native/jest.config.js
+++ b/packages/design-system-react-native/jest.config.js
@@ -27,6 +27,9 @@ module.exports = merge(baseConfig, {
     '!**/*.scripts.{js,ts}', // Exclude .scripts files
     '!**/node_modules/**', // Exclude node_modules
     '!**/dist/**', // Exclude build outputs
+    '!**/*.constants.{js,ts}', // Exclude .constants files
+    '!**/*.assets.{js,ts}', // Exclude .assets files
+    '!**/*.types.{js,ts}', // Exclude .types files
   ],
   preset: 'react-native',
   transform: {
@@ -34,6 +37,7 @@ module.exports = merge(baseConfig, {
   },
   transformIgnorePatterns: [
     'node_modules/(?!(react-native|@react-native|@react-navigation)/)',
+    'node_modules/(?!(react-native|react-native-reanimated|@react-native|@react-navigation)/)',
   ],
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
   moduleNameMapper: {

--- a/packages/design-system-react-native/jest.setup.js
+++ b/packages/design-system-react-native/jest.setup.js
@@ -10,3 +10,12 @@ jest.mock('react-native-svg', () => {
     Rect: MockedSvg,
   };
 });
+
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+
+  // Overriding the `call` method to avoid issues with animations
+  Reanimated.default.call = () => {};
+
+  return Reanimated;
+});

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "@metamask/design-system-twrnc-preset": "workspace:^",
     "react": "^18.2.0",
-    "react-native": "^0.72.15"
+    "react-native": "^0.72.15",
+    "react-native-reanimated": "3.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",

--- a/packages/design-system-twrnc-preset/src/Theme/Theme.providers.tsx
+++ b/packages/design-system-twrnc-preset/src/Theme/Theme.providers.tsx
@@ -11,6 +11,7 @@ import { generateTailwindConfig } from './Theme.utilities';
 export const defaultThemeContextValue: ThemeContextProps = {
   tw: create(generateTailwindConfig(ColorSet.Brand, ColorScheme.Light)),
   colorSet: ColorSet.Brand,
+  colorSetList: colorSetList[ColorSet.Brand][Theme.Light],
   theme: Theme.Light,
   setColorSet: () => {},
   setTheme: () => {},
@@ -23,7 +24,6 @@ export const ThemeContext = createContext<ThemeContextProps>(
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   children,
   colorSet = ColorSet.Brand,
-  colorSetList: colorSetList[ColorSet.Brand][Theme.Light],
   theme = Theme.Default,
 }) => {
   const [currentColorSet, setCurrentColorSet] = useState<ColorSet>(colorSet);

--- a/packages/design-system-twrnc-preset/src/Theme/Theme.providers.tsx
+++ b/packages/design-system-twrnc-preset/src/Theme/Theme.providers.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useState, useMemo } from 'react';
 import { useColorScheme } from 'react-native';
 import { create } from 'twrnc';
 
-import { ColorSet, ColorScheme } from '../twrnc-settings';
+import { ColorSet, ColorScheme, colorSetList } from '../twrnc-settings';
 import type { ThemeContextProps, ThemeProviderProps } from './Theme.types';
 import { Theme } from './Theme.types';
 import { generateTailwindConfig } from './Theme.utilities';
@@ -23,6 +23,7 @@ export const ThemeContext = createContext<ThemeContextProps>(
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   children,
   colorSet = ColorSet.Brand,
+  colorSetList: colorSetList[ColorSet.Brand][Theme.Light],
   theme = Theme.Default,
 }) => {
   const [currentColorSet, setCurrentColorSet] = useState<ColorSet>(colorSet);
@@ -57,6 +58,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
       value={{
         tw,
         colorSet: currentColorSet,
+        colorSetList: colorSetList[colorSet][activeColorScheme],
         theme: currentTheme,
         setColorSet: setCurrentColorSet,
         setTheme: setCurrentTheme,

--- a/packages/design-system-twrnc-preset/src/Theme/Theme.types.ts
+++ b/packages/design-system-twrnc-preset/src/Theme/Theme.types.ts
@@ -12,6 +12,7 @@ export enum Theme {
 export type ThemeContextProps = {
   tw: ReturnType<typeof create>;
   colorSet: ColorSet;
+  colorSetList: Record<string, string>;
   theme: Theme;
   setColorSet: (theme: ColorSet) => void;
   setTheme: (scheme: Theme) => void;

--- a/packages/design-system-twrnc-preset/src/hocs/withThemeProvider.tsx
+++ b/packages/design-system-twrnc-preset/src/hocs/withThemeProvider.tsx
@@ -5,9 +5,9 @@
 import React, { forwardRef, useContext } from 'react';
 
 import {
+  Theme,
   ThemeProvider,
   ThemeContext,
-  Theme,
   defaultThemeContextValue,
 } from '../Theme';
 import { ColorSet } from '../twrnc-settings';
@@ -15,22 +15,29 @@ import { ColorSet } from '../twrnc-settings';
 /**
  * HOC to wrap components with ThemeProvider if none is present.
  * @param Component - The component to wrap with ThemeProvider.
+ * @param theme - The theme to use for ThemeProvider.
+ * @param colorSet - The colorSet to use for ThemeProvider.
  */
 export function withThemeProvider<Props extends object>(
   Component: React.ComponentType<Props>,
+  theme?: Theme,
+  colorSet?: ColorSet,
 ) {
   const WrappedComponent = forwardRef<any, Props>((props, ref) => {
     // Check if a ThemeProvider is already present
     const themeContext = useContext(ThemeContext);
 
-    // If ThemeProvider exists, use the component as is
-    if (themeContext !== defaultThemeContextValue) {
+    // If ThemeProvider exists or if there isn't additional settings passed, use the component as is
+    if (themeContext !== defaultThemeContextValue && !(theme || colorSet)) {
       return <Component {...(props as Props)} ref={ref} />;
     }
 
     // Otherwise, wrap with ThemeProvider
     return (
-      <ThemeProvider colorSet={ColorSet.Brand} theme={Theme.Default}>
+      <ThemeProvider
+        colorSet={colorSet ?? ColorSet.Brand}
+        theme={theme ?? Theme.Default}
+      >
         <Component {...(props as Props)} ref={ref} />
       </ThemeProvider>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,6 +3178,7 @@ __metadata:
     metro-react-native-babel-preset: "npm:^0.77.0"
     react: "npm:^18.2.0"
     react-native: "npm:^0.72.15"
+    react-native-reanimated: "npm:3.3.0"
     react-native-svg: "npm:^15.10.1"
     react-native-svg-transformer: "npm:^1.5.0"
     react-test-renderer: "npm:^18.3.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR prepares for the upcoming `Button` component. It includes:
- Added `reanimated` dependencies and settings to both `storybook-react-native` and `design-system-react-native`
- Updated twrnc-preset to provide `colorSetList`

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #319 

## **Manual testing steps**

1. Run `yarn storybook:ios`
2. Verify that everything is working as intended
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/8c3b321a-6afa-4da8-ae3f-e21d79d6fef5

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
