### PR TITLE
chore: exporting types from index in design tokens

### DIFF
--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,4 +1,14 @@
-export { colors, typography, lightTheme, darkTheme, brandColor } from './js';
-export type { Theme, ThemeColors, ThemeShadows } from './js';
-export type { ThemeTypography } from './js/typography';
-export type { BrandColor } from './js/brandColor/brandColor.types';
+export {
+  colors, // DEPRECATED in favor of importing lightTheme and darkTheme
+  brandColor,
+  lightTheme,
+  darkTheme,
+  typography,
+} from './js';
+export type {
+  BrandColor,
+  Theme,
+  ThemeColors,
+  ThemeShadows,
+  ThemeTypography,
+} from './js';

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,2 +1,4 @@
-export type { Theme } from './js';
 export { colors, typography, lightTheme, darkTheme, brandColor } from './js';
+export type { Theme, ThemeColors, ThemeShadows } from './js';
+export type { ThemeTypography } from './js/typography';
+export type { BrandColor } from './js/brandColor/brandColor.types';

--- a/packages/design-tokens/src/js/index.ts
+++ b/packages/design-tokens/src/js/index.ts
@@ -1,4 +1,3 @@
-export type { Theme } from './themes';
 export { lightTheme } from './themes';
 export { darkTheme } from './themes';
 export { brandColor } from './brandColor';
@@ -6,3 +5,7 @@ export { brandColor } from './brandColor';
 // DEPRECATED in favor of importing theme objects above
 export { colors } from './colors';
 export { typography } from './typography';
+
+export type { Theme, ThemeColors, ThemeShadows } from './themes/types';
+export type { ThemeTypography } from './typography';
+export type { BrandColor } from './brandColor/brandColor.types';

--- a/packages/design-tokens/src/js/index.ts
+++ b/packages/design-tokens/src/js/index.ts
@@ -1,11 +1,14 @@
-export { lightTheme } from './themes';
-export { darkTheme } from './themes';
-export { brandColor } from './brandColor';
-
-// DEPRECATED in favor of importing theme objects above
+// DEPRECATED in favor of importing lightTheme and darkTheme
 export { colors } from './colors';
-export { typography } from './typography';
 
-export type { Theme, ThemeColors, ThemeShadows } from './themes/types';
-export type { ThemeTypography } from './typography';
+// Brand Color
+export { brandColor } from './brandColor';
 export type { BrandColor } from './brandColor/brandColor.types';
+
+// Themes
+export { lightTheme, darkTheme } from './themes';
+export type { Theme, ThemeColors, ThemeShadows } from './themes/types';
+
+// Typography
+export { typography } from './typography';
+export type { ThemeTypography } from './typography';


### PR DESCRIPTION
## **Description**

This PR reorganizes type exports in the design-tokens package to improve type organization and maintainability. It also fixes a bug in `v4.2.0` where type imports are broken likely due to the migration of the package into the monorepo and updated build package.json configuration.

Currently, type imports require long, complex paths that no longer work e.g.

```typescript
import type { ThemeColors } from '@metamask/design-tokens/dist/types/js/themes/types'
```

This PR simplifies type imports to use the package root e.g.

```typescript
import type { ThemeColors } from '@metamask/design-tokens'
```

Key changes:
- Added explicit type exports for `ThemeColors`, `ThemeShadows`, `ThemeTypography`, and `BrandColor`
- Reorganized type exports to be more centralized and intuitive
- Simplified import paths for better developer experience

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/341

## **Manual testing steps**

1. Use the preview build in metamask-mobile
Change
```
"@metamask/design-tokens": "^4.0.0",
```
to
```
"@metamask/design-tokens": "npm:@metamask-previews/design-tokens@4.2.0-preview.ad2f94b",
```
2. Run `yarn setup`
3. Import types from '@metamask/design-tokens' 
4. Verify that all types can be imported directly from the package root:
   ```typescript
   import type { 
     Theme,
     ThemeColors,
     ThemeShadows,
     ThemeTypography,
     BrandColor 
   } from '@metamask/design-tokens';
   ```
5. Confirm the types work as expected in the consuming project

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/9d2d3f71-8dc5-4fab-a1eb-20a7eb4f1ba5

### **After**

https://github.com/user-attachments/assets/df78df1c-4eb4-4c5f-9332-d8e728d99499

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.