### PR TITLE
chore: reverting release 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.3.0]
-
-### Added
-
-- chore: exporting types from index in design tokens ([#340](https://github.com/metamask/metamask-design-system/pull/340))
-- Added 8 new colors (4 muted-hover & 4 muted-pressed) to design-tokens Figma Json. ([#325](https://github.com/metamask/metamask-design-system/pull/325))
-
 ## [4.2.0]
 
 ### Added
@@ -314,7 +307,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Adding css stylesheet containing color design tokens ([#17](https://github.com/MetaMask/design-tokens/pull/17))
+- Adding css stylesheet containg color design tokens ([#17](https://github.com/MetaMask/design-tokens/pull/17))
 - Add issue template ([#20](https://github.com/MetaMask/design-tokens/pull/20))
 
 ## [1.0.0]
@@ -323,8 +316,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.3.0...HEAD
-[4.3.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.2.0...@metamask/design-tokens@4.3.0
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.2.0...HEAD
 [4.2.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.1.0...@metamask/design-tokens@4.2.0
 [4.1.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.0.0...@metamask/design-tokens@4.1.0
 [4.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@3.0.0...@metamask/design-tokens@4.0.0

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "4.3.0",
+  "version": "4.2.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Description

This PR reverts version changes that were incorrectly merged, specifically:

1. Reverts the monorepo version from 2.0.0 back to 1.0.0
2. Reverts @metamask/design-tokens from 4.3.0 back to 4.2.0
3. Removes the 4.3.0 changelog entries from design-tokens

## Related issues

Fixes: N/A - Version reversion

## Manual testing steps

1. Check package.json versions match expected values:
   - Root package.json should show version 1.0.0
   - design-tokens package.json should show version 4.2.0
2. Verify CHANGELOG.md in design-tokens no longer contains 4.3.0 entries
3. Verify all packages can still be built and tested successfully

## Screenshots/Recordings

N/A - Version changes only

## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.