### PR TITLE
Release/2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -76,7 +76,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^4.1.0",
+    "@metamask/design-tokens": "^5.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "tailwindcss": "^3.0.0"

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -57,7 +57,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^4.1.0",
+    "@metamask/design-tokens": "^5.0.0",
     "tailwindcss": "^3.0.0"
   },
   "engines": {

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0]
+
 ### Uncategorized
 
-- chore: reverting release 2.0.0 ([#348](https://github.com/MetaMask/metamask-design-system/pull/348))
-- Release/2.0.0 ([#347](https://github.com/MetaMask/metamask-design-system/pull/347))
-- chore: exporting types from index in design tokens ([#340](https://github.com/MetaMask/metamask-design-system/pull/340))
+- BREAKING CHANGE: exporting types from index in design tokens ([#340](https://github.com/MetaMask/metamask-design-system/pull/340))
 - Added 8 new colors (4 muted-hover & 4 muted-pressed) to design-tokens Figma Json. ([#325](https://github.com/MetaMask/metamask-design-system/pull/325))
 
 ## [4.2.0]
@@ -323,7 +323,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@5.0.0...HEAD
+[5.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.2.0...@metamask/design-tokens@5.0.0
 [4.2.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.1.0...@metamask/design-tokens@4.2.0
 [4.1.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.0.0...@metamask/design-tokens@4.1.0
 [4.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@3.0.0...@metamask/design-tokens@4.0.0

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: reverting release 2.0.0 ([#348](https://github.com/MetaMask/metamask-design-system/pull/348))
+- Release/2.0.0 ([#347](https://github.com/MetaMask/metamask-design-system/pull/347))
+- chore: exporting types from index in design tokens ([#340](https://github.com/MetaMask/metamask-design-system/pull/340))
+- Added 8 new colors (4 muted-hover & 4 muted-pressed) to design-tokens Figma Json. ([#325](https://github.com/MetaMask/metamask-design-system/pull/325))
+
 ## [4.2.0]
 
 ### Added

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -100,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- chore: updating package.json and contraints.prop config to allow for css export ([#609](https://github.com/MetaMask/design-tokens/pull/609))
+- chore: updating package.json and constraints.pro config to allow for css export ([#609](https://github.com/MetaMask/design-tokens/pull/609))
 
 ## [2.0.0]
 
@@ -315,7 +315,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Adding css stylesheet containg color design tokens ([#17](https://github.com/MetaMask/design-tokens/pull/17))
+- Adding css stylesheet containing color design tokens ([#17](https://github.com/MetaMask/design-tokens/pull/17))
 - Add issue template ([#20](https://github.com/MetaMask/design-tokens/pull/20))
 
 ## [1.0.0]

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.0.0]
 
-### Uncategorized
+### Added
 
-- BREAKING CHANGE: exporting types from index in design tokens ([#340](https://github.com/MetaMask/metamask-design-system/pull/340))
+- **BREAKING:** Following the unintentional breaking change in `4.2.0` we are now exporting the types from root index instead of requiring deep imports ([#340](https://github.com/MetaMask/metamask-design-system/pull/340)). See the [migration guide](./MIGRATION.md#from-version-410-to-500) for details.
+
 - Added 8 new colors (4 muted-hover & 4 muted-pressed) to design-tokens Figma Json. ([#325](https://github.com/MetaMask/metamask-design-system/pull/325))
 
 ## [4.2.0]
@@ -20,13 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: color updates to the design tokens package ([#230](https://github.com/metamask/metamask-design-system/pull/230))
 
-- `@metamask/design-tokens` package migrated from standalone repository into the design system monorepo ([128](https://github.com/MetaMask/metamask-design-system/pull/128))
+- **BREAKING:** `@metamask/design-tokens` package migrated from standalone repository into the design system monorepo, which unintentionally broke type imports ([128](https://github.com/MetaMask/metamask-design-system/pull/128)). See the [migration guide](./MIGRATION.md#from-version-410-to-500) for details on the fix in 5.0.0.
 
 ## [4.1.0]
 
 ### Added
 
-- Adding (MIT OR Apache 2.0) license aligning with MetaMask’s open-source standards ([#738](https://github.com/MetaMask/design-tokens/pull/738))
+- Adding (MIT OR Apache 2.0) license aligning with MetaMask's open-source standards ([#738](https://github.com/MetaMask/design-tokens/pull/738))
 - Adding dark/light classname ([#729](https://github.com/MetaMask/design-tokens/pull/729))
 
 ## [4.0.0]

--- a/packages/design-tokens/MIGRATION.md
+++ b/packages/design-tokens/MIGRATION.md
@@ -2,8 +2,30 @@
 
 This guide provides detailed instructions for migrating your project from one version of the `@metamask/design-tokens` to another.
 
-- [From version 2.1.1 to 3.0.0](#from-version-211-to-300)
+- [From version 4.1.0 to 5.0.0](#from-version-410-to-500)
 - [From version 3.0.0 to 4.0.0](#from-version-300-to-400)
+- [From version 2.1.1 to 3.0.0](#from-version-211-to-300)
+
+## From version 4.1.0 to 5.0.0
+
+### Changes to Type Imports (Breaking Changes)
+
+In version 5.0.0, we've simplified the type import system. Instead of deep importing types from specific paths, all types are now exported from the package root. You'll need to update your type imports as follows:
+
+#### Before (No Longer Works)
+
+```typescript
+import { ThemeColors } from '@metamask/design-tokens/dist/js/themes/types';
+import { BrandColor } from '@metamask/design-tokens/dist/types/js/brandColor/brandColor.types';
+```
+
+#### After
+
+```typescript
+import type { ThemeColors, BrandColor } from '@metamask/design-tokens';
+```
+
+This change simplifies imports and provides a more maintainable API for TypeScript users.
 
 ## From version 3.0.0 to 4.0.0
 

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3215,7 +3215,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^4.1.0
+    "@metamask/design-tokens": ^5.0.0
     react: ^16.0.0
     react-dom: ^16.0.0
     tailwindcss: ^3.0.0
@@ -3236,7 +3236,7 @@ __metadata:
     ts-jest: "npm:^29.2.5"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^4.1.0
+    "@metamask/design-tokens": ^5.0.0
     tailwindcss: ^3.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## **Description**

This monorepo 2.0.0 PR releases version 5.0.0 of `@metamask/design-tokens`. This release includes a major breaking change in how types are exported, fixing an unintentional breaking change that was introduced in v4.2.0 when the package was migrated to the monorepo.

Key changes:
1. Types are now exported from the root index instead of requiring deep imports
2. Added 8 new colors (4 muted-hover & 4 muted-pressed) to design-tokens Figma Json
3. Updated peer dependencies in related packages to require ^5.0.0 of design-tokens

## **Related issues**

Fixes: #340 - Export types from root index
Fixes: #325 - Add new muted colors

## **Manual testing steps**

1. Check changelog, package.json and migration docs align with release.

## **Screenshots/Recordings**

N/A - Infrastructure changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.