### PR TITLE
chore: ignoring coverage folder from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,6 @@ node_modules/
 
 .expo
 
+# Coverage directories
+packages/*/coverage
+

--- a/apps/storybook-react-native/.storybook/storybook.requires.js
+++ b/apps/storybook-react-native/.storybook/storybook.requires.js
@@ -6,30 +6,30 @@ import {
   addParameters,
   addArgsEnhancer,
   clearDecorators,
-} from "@storybook/react-native";
+} from '@storybook/react-native';
 
 global.STORIES = [
   {
-    titlePrefix: "",
-    directory: "../../packages/design-system-react-native/src",
-    files: "**/*.stories.@(js|jsx|ts|tsx)",
+    titlePrefix: '',
+    directory: '../../packages/design-system-react-native/src',
+    files: '**/*.stories.@(js|jsx|ts|tsx)',
     importPathMatcher:
-      "^(?:\\.\\.\\/\\.\\.\\/packages\\/design-system-react-native\\/src(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(js|jsx|ts|tsx))$",
+      '^(?:\\.\\.\\/\\.\\.\\/packages\\/design-system-react-native\\/src(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(js|jsx|ts|tsx))$',
   },
 ];
 
-import "@storybook/addon-ondevice-controls/register";
-import "@storybook/addon-ondevice-actions/register";
+import '@storybook/addon-ondevice-controls/register';
+import '@storybook/addon-ondevice-actions/register';
 
-import { argsEnhancers } from "@storybook/addon-actions/dist/modern/preset/addArgs";
+import { argsEnhancers } from '@storybook/addon-actions/dist/modern/preset/addArgs';
 
-import { decorators, parameters } from "./preview";
+import { decorators, parameters } from './preview';
 
 if (decorators) {
   if (__DEV__) {
     // stops the warning from showing on every HMR
-    require("react-native").LogBox.ignoreLogs([
-      "`clearDecorators` is deprecated and will be removed in Storybook 7.0",
+    require('react-native').LogBox.ignoreLogs([
+      '`clearDecorators` is deprecated and will be removed in Storybook 7.0',
     ]);
   }
   // workaround for global decorators getting infinitely applied on HMR, see https://github.com/storybookjs/react-native/issues/185
@@ -47,8 +47,8 @@ try {
 
 const getStories = () => {
   return {
-    "./../../packages/design-system-react-native/src/components/Icon/Icon.stories.tsx": require("../../../packages/design-system-react-native/src/components/Icon/Icon.stories.tsx"),
-    "./../../packages/design-system-react-native/src/components/Text/Text.stories.tsx": require("../../../packages/design-system-react-native/src/components/Text/Text.stories.tsx"),
+    './../../packages/design-system-react-native/src/components/Icon/Icon.stories.tsx': require('../../../packages/design-system-react-native/src/components/Icon/Icon.stories.tsx'),
+    './../../packages/design-system-react-native/src/components/Text/Text.stories.tsx': require('../../../packages/design-system-react-native/src/components/Text/Text.stories.tsx'),
   };
 };
 


### PR DESCRIPTION
## **Description**

This PR adds coverage directories to the `.prettierignore` file to prevent Prettier from attempting to format coverage files during test runs. This fixes CI failures that occur when running tests in @design-system-react.

Additionally, it includes some automatic formatting fixes to the storybook requires file, converting double quotes to single quotes for consistency.

1. Reason for change: Coverage files are being picked up by Prettier during test runs, causing CI failures
2. Solution: Add coverage directories to `.prettierignore` to exclude them from Prettier formatting

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run tests in @design-system-react package
2. Verify that Prettier no longer attempts to format coverage files
3. Verify that CI checks pass successfully

## **Screenshots/Recordings**

Not applicable for this change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.