### PR TITLE
feat: adding button icon to design system react

### DIFF
--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.constants.ts
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.constants.ts
@@ -1,0 +1,14 @@
+import { IconSize } from '../icon';
+import { ButtonIconSize } from './ButtonIcon.types';
+
+export const BUTTON_ICON_SIZE_CLASSMAP = {
+  [ButtonIconSize.Sm]: 'h-6 w-6',
+  [ButtonIconSize.Md]: 'h-8 w-8',
+  [ButtonIconSize.Lg]: 'h-10 w-10',
+} as const;
+
+export const BUTTON_ICON_SIZE_TO_ICON_SIZE_MAP = {
+  [ButtonIconSize.Sm]: IconSize.Sm,
+  [ButtonIconSize.Md]: IconSize.Md,
+  [ButtonIconSize.Lg]: IconSize.Lg,
+} as const;

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.constants.ts
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.constants.ts
@@ -1,13 +1,13 @@
 import { IconSize } from '../icon';
 import { ButtonIconSize } from './ButtonIcon.types';
 
-export const BUTTON_ICON_SIZE_CLASSMAP = {
+export const BUTTON_ICON_SIZE_CLASS_MAP = {
   [ButtonIconSize.Sm]: 'h-6 w-6',
   [ButtonIconSize.Md]: 'h-8 w-8',
   [ButtonIconSize.Lg]: 'h-10 w-10',
 } as const;
 
-export const BUTTON_ICON_SIZE_TO_ICON_SIZE_MAP = {
+export const BUTTON_ICON_SIZE_TO_ICON_SIZE_CLASS_MAP = {
   [ButtonIconSize.Sm]: IconSize.Sm,
   [ButtonIconSize.Md]: IconSize.Md,
   [ButtonIconSize.Lg]: IconSize.Lg,

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.stories.tsx
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { IconName } from '..';
+import { ButtonIcon } from './ButtonIcon';
+import { ButtonIconSize } from './ButtonIcon.types';
+import README from './README.mdx';
+
+const meta: Meta<typeof ButtonIcon> = {
+  title: 'React Components/ButtonIcon',
+  component: ButtonIcon,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    iconName: {
+      control: 'select',
+      options: Object.keys(IconName),
+      mapping: IconName,
+      description: 'Required prop to specify the icon to show',
+    },
+    size: {
+      control: 'select',
+      options: Object.keys(ButtonIconSize),
+      mapping: ButtonIconSize,
+      description: 'Optional prop to control the size of the ButtonIcon',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Optional prop that when true, disables the button',
+    },
+    isInverse: {
+      control: 'boolean',
+      description:
+        'Optional prop that when true, applies inverse styling to the button',
+    },
+    isFloating: {
+      control: 'boolean',
+      description:
+        'Optional prop that when true, applies floating/contained styling to the button',
+    },
+    className: {
+      control: 'text',
+      description:
+        'Optional prop for additional CSS classes to be applied to the ButtonIcon',
+    },
+    ariaLabel: {
+      control: 'text',
+      description:
+        'Required prop to provide an accessible label for the button',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonIcon>;
+
+export const Default: Story = {
+  args: {
+    iconName: IconName.Close,
+    ariaLabel: 'Close',
+  },
+};
+
+export const Size: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <ButtonIcon
+        iconName={IconName.Close}
+        size={ButtonIconSize.Sm}
+        ariaLabel="Close small"
+      />
+      <ButtonIcon
+        iconName={IconName.Close}
+        size={ButtonIconSize.Md}
+        ariaLabel="Close medium"
+      />
+      <ButtonIcon
+        iconName={IconName.Close}
+        size={ButtonIconSize.Lg}
+        ariaLabel="Close large"
+      />
+    </div>
+  ),
+};
+
+export const IsFloating: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <ButtonIcon iconName={IconName.Close} isFloating ariaLabel="Close" />
+    </div>
+  ),
+};
+
+export const IsInverse: Story = {
+  render: () => (
+    <div className="bg-primary-default p-4 space-y-4">
+      <div className="flex gap-2">
+        <ButtonIcon iconName={IconName.Close} isInverse ariaLabel="Close" />
+        <ButtonIcon
+          iconName={IconName.Close}
+          isInverse
+          isFloating
+          ariaLabel="Close floating"
+        />
+      </div>
+    </div>
+  ),
+};
+
+export const IsDisabled: Story = {
+  args: {
+    iconName: IconName.Close,
+    isDisabled: true,
+    ariaLabel: 'Close',
+  },
+};
+
+export const AriaLabel: Story = {
+  args: {
+    iconName: IconName.Close,
+    ariaLabel: 'Close dialog',
+  },
+};

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.stories.tsx
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.stories.tsx
@@ -96,16 +96,8 @@ export const IsFloating: Story = {
 
 export const IsInverse: Story = {
   render: () => (
-    <div className="bg-primary-default p-4 space-y-4">
-      <div className="flex gap-2">
-        <ButtonIcon iconName={IconName.Close} isInverse ariaLabel="Close" />
-        <ButtonIcon
-          iconName={IconName.Close}
-          isInverse
-          isFloating
-          ariaLabel="Close floating"
-        />
-      </div>
+    <div className="bg-primary-default p-4">
+      <ButtonIcon iconName={IconName.Close} isInverse ariaLabel="Close" />
     </div>
   ),
 };

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.test.tsx
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.test.tsx
@@ -93,6 +93,7 @@ describe('ButtonIcon', () => {
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
     expect(button).toHaveClass('opacity-50', 'cursor-not-allowed');
+    expect(button).not.toHaveClass('hover:bg-hover', 'active:bg-pressed');
   });
 
   it('merges custom className with default styles', () => {

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.test.tsx
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.test.tsx
@@ -142,8 +142,8 @@ describe('ButtonIcon', () => {
     const button = screen.getByRole('button');
     expect(button).toHaveClass(
       'rounded-full',
-      'text-icon-default',
-      'bg-background-default',
+      'bg-icon-default',
+      'text-background-default',
     );
   });
 });

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.test.tsx
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { IconName, IconSize } from '..';
+import { ButtonIcon } from './ButtonIcon';
+import { ButtonIconSize } from './ButtonIcon.types';
+
+describe('ButtonIcon', () => {
+  it('renders with default props', () => {
+    render(<ButtonIcon iconName={IconName.Close} ariaLabel="Close" />);
+    const button = screen.getByRole('button', { name: 'Close' });
+    expect(button).toHaveClass(
+      'h-8',
+      'w-8',
+      'rounded',
+      'bg-transparent',
+      'hover:bg-hover',
+      'active:bg-pressed',
+      'text-icon-default',
+    );
+  });
+
+  it('renders with different sizes', () => {
+    const { rerender } = render(
+      <ButtonIcon
+        iconName={IconName.Close}
+        size={ButtonIconSize.Sm}
+        ariaLabel="Close small"
+        iconProps={{ 'data-testid': 'button-icon' }}
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveClass('h-6', 'w-6');
+    const icon = screen.getByTestId('button-icon');
+    expect(icon).toHaveClass('text-inherit');
+
+    rerender(
+      <ButtonIcon
+        iconName={IconName.Close}
+        size={ButtonIconSize.Md}
+        ariaLabel="Close medium"
+        iconProps={{ 'data-testid': 'button-icon' }}
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveClass('h-8', 'w-8');
+
+    rerender(
+      <ButtonIcon
+        iconName={IconName.Close}
+        size={ButtonIconSize.Lg}
+        ariaLabel="Close large"
+        iconProps={{ 'data-testid': 'button-icon' }}
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveClass('h-10', 'w-10');
+  });
+
+  it('applies floating styles correctly', () => {
+    render(
+      <ButtonIcon
+        iconName={IconName.Close}
+        isFloating
+        ariaLabel="Close floating"
+      />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass(
+      'rounded-full',
+      'bg-icon-default',
+      'text-background-default',
+    );
+  });
+
+  it('applies inverse styles correctly', () => {
+    render(
+      <ButtonIcon
+        iconName={IconName.Close}
+        isInverse
+        ariaLabel="Close inverse"
+      />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('text-background-default');
+  });
+
+  it('applies disabled styles correctly', () => {
+    render(
+      <ButtonIcon
+        iconName={IconName.Close}
+        isDisabled
+        ariaLabel="Close disabled"
+      />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass('opacity-50', 'cursor-not-allowed');
+  });
+
+  it('merges custom className with default styles', () => {
+    render(
+      <ButtonIcon
+        iconName={IconName.Close}
+        className="custom-class"
+        ariaLabel="Close custom"
+      />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('custom-class');
+  });
+
+  it('passes additional iconProps correctly', () => {
+    render(
+      <ButtonIcon
+        iconName={IconName.Close}
+        iconProps={{
+          className: 'custom-icon-class',
+          'data-testid': 'custom-icon',
+        }}
+        ariaLabel="Close with custom icon"
+      />,
+    );
+    const icon = screen.getByTestId('custom-icon');
+    expect(icon).toHaveClass('custom-icon-class');
+  });
+
+  it('applies aria-label correctly', () => {
+    render(<ButtonIcon iconName={IconName.Close} ariaLabel="Close dialog" />);
+    expect(
+      screen.getByRole('button', { name: 'Close dialog' }),
+    ).toBeInTheDocument();
+  });
+
+  it('applies floating and inverse styles correctly when both are true', () => {
+    render(
+      <ButtonIcon
+        iconName={IconName.Close}
+        isFloating
+        isInverse
+        ariaLabel="Close floating inverse"
+      />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass(
+      'rounded-full',
+      'text-icon-default',
+      'bg-background-default',
+    );
+  });
+});

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.tsx
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import { twMerge } from '../../utils/tw-merge';
+import { ButtonBase } from '../button-base';
+import { Icon } from '../icon';
+import {
+  BUTTON_ICON_SIZE_CLASSMAP,
+  BUTTON_ICON_SIZE_TO_ICON_SIZE_MAP,
+} from './ButtonIcon.constants';
+import type { ButtonIconProps } from './ButtonIcon.types';
+import { ButtonIconSize } from './ButtonIcon.types';
+
+export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
+  (
+    {
+      className,
+      iconName,
+      iconProps,
+      ariaLabel,
+      isDisabled = false,
+      isInverse = false,
+      isFloating = false,
+      size = ButtonIconSize.Md,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const mergedClassName = twMerge(
+      // Base styles
+      'p-0',
+      // Size styles
+      BUTTON_ICON_SIZE_CLASSMAP[size],
+      // Floating styles
+      isFloating && [
+        'rounded-full',
+        !isInverse && 'bg-icon-default text-background-default',
+        isInverse && 'text-icon-default bg-background-default',
+      ],
+      // Non-floating styles
+      !isFloating && [
+        'rounded bg-transparent hover:bg-hover active:bg-pressed',
+        !isInverse && 'text-icon-default',
+        isInverse && 'text-background-default',
+      ],
+      className,
+    );
+
+    return (
+      <ButtonBase
+        ref={ref}
+        className={mergedClassName}
+        isDisabled={isDisabled}
+        aria-label={ariaLabel}
+        {...props}
+      >
+        <Icon
+          name={iconName}
+          size={BUTTON_ICON_SIZE_TO_ICON_SIZE_MAP[size]}
+          className={twMerge('text-inherit', iconProps?.className)}
+          {...iconProps}
+        />
+      </ButtonBase>
+    );
+  },
+);
+
+ButtonIcon.displayName = 'ButtonIcon';

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.tsx
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.tsx
@@ -4,8 +4,8 @@ import { twMerge } from '../../utils/tw-merge';
 import { ButtonBase } from '../button-base';
 import { Icon } from '../icon';
 import {
-  BUTTON_ICON_SIZE_CLASSMAP,
-  BUTTON_ICON_SIZE_TO_ICON_SIZE_MAP,
+  BUTTON_ICON_SIZE_CLASS_MAP,
+  BUTTON_ICON_SIZE_TO_ICON_SIZE_CLASS_MAP,
 } from './ButtonIcon.constants';
 import type { ButtonIconProps } from './ButtonIcon.types';
 import { ButtonIconSize } from './ButtonIcon.types';
@@ -32,7 +32,7 @@ export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
       // Base styles
       'p-0',
       // Size styles
-      BUTTON_ICON_SIZE_CLASSMAP[size],
+      BUTTON_ICON_SIZE_CLASS_MAP[size],
       // Floating styles
       isFloating && [
         'rounded-full',
@@ -60,7 +60,7 @@ export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
       >
         <Icon
           name={iconName}
-          size={BUTTON_ICON_SIZE_TO_ICON_SIZE_MAP[size]}
+          size={BUTTON_ICON_SIZE_TO_ICON_SIZE_CLASS_MAP[size]}
           className={twMerge('text-inherit', iconProps?.className)}
           {...iconProps}
         />

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.tsx
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.tsx
@@ -26,6 +26,8 @@ export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
     },
     ref,
   ) => {
+    const isInteractive = !isDisabled;
+
     const mergedClassName = twMerge(
       // Base styles
       'p-0',
@@ -39,7 +41,9 @@ export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
       ],
       // Non-floating styles
       !isFloating && [
-        'rounded bg-transparent hover:bg-hover active:bg-pressed',
+        'rounded bg-transparent',
+        // Only apply hover/active styles when interactive
+        isInteractive && 'hover:bg-hover active:bg-pressed',
         !isInverse && 'text-icon-default',
         isInverse && 'text-background-default',
       ],

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.tsx
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.tsx
@@ -37,11 +37,11 @@ export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
       isFloating && [
         'rounded-full',
         !isInverse && 'bg-icon-default text-background-default',
-        isInverse && 'text-icon-default bg-background-default',
+        isInverse && 'bg-icon-default text-background-default',
       ],
       // Non-floating styles
       !isFloating && [
-        'rounded bg-transparent',
+        'rounded bg-transparent ',
         // Only apply hover/active styles when interactive
         isInteractive && 'hover:bg-hover active:bg-pressed',
         !isInverse && 'text-icon-default',

--- a/packages/design-system-react/src/components/button-icon/ButtonIcon.types.ts
+++ b/packages/design-system-react/src/components/button-icon/ButtonIcon.types.ts
@@ -1,0 +1,71 @@
+import type { ButtonBaseProps } from '../button-base';
+import type { IconName, IconProps } from '../icon';
+
+export enum ButtonIconSize {
+  /**
+   * Represents a small button size (24px).
+   */
+  Sm = 'sm',
+  /**
+   * Represents a medium button size (32px).
+   */
+  Md = 'md',
+  /**
+   * Represents a large button size (40px).
+   */
+  Lg = 'lg',
+}
+
+export type ButtonIconProps = Omit<
+  ButtonBaseProps,
+  // We handle these props in ButtonIcon
+  | 'className'
+  | 'isDisabled'
+  | 'isLoading'
+  | 'style'
+  | 'children'
+  | 'size'
+  | 'aria-label'
+> & {
+  /**
+   * Required prop to specify the icon to show
+   */
+  iconName: IconName;
+  /**
+   * Required prop to provide an accessible label for the button
+   */
+  ariaLabel: string;
+  /**
+   * Optional prop to pass additional properties to the icon
+   */
+  iconProps?: Partial<IconProps>;
+  /**
+   * Optional prop that when true, disables the button
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Optional prop that when true, applies inverse styling to the button
+   * @default false
+   */
+  isInverse?: boolean;
+  /**
+   * Optional prop that when true, applies floating/contained styling to the button
+   * @default false
+   */
+  isFloating?: boolean;
+  /**
+   * Optional prop to control the size of the button
+   * @default ButtonIconSize.Md
+   */
+  size?: ButtonIconSize;
+  /**
+   * Optional prop for additional CSS classes to be applied to the ButtonIcon component
+   */
+  className?: string;
+  /**
+   * Optional CSS styles to be applied to the component.
+   * Should be used sparingly and only for dynamic styles that can't be achieved with className.
+   */
+  style?: React.CSSProperties;
+};

--- a/packages/design-system-react/src/components/button-icon/README.mdx
+++ b/packages/design-system-react/src/components/button-icon/README.mdx
@@ -9,7 +9,7 @@ A Button Icon is a compact, icon-only button that triggers an action, designed f
 ```tsx
 import { ButtonIcon, IconName } from '@metamask/design-system-react';
 
-<ButtonIcon iconName={IconName.Close} onClick={() => {}} />;
+<ButtonIcon iconName={IconName.Close} ariaLabel="Close" onClick={() => {}} />;
 ```
 
 <Canvas of={ButtonIconStories.Default} />

--- a/packages/design-system-react/src/components/button-icon/README.mdx
+++ b/packages/design-system-react/src/components/button-icon/README.mdx
@@ -7,7 +7,7 @@ import * as ButtonIconStories from './ButtonIcon.stories';
 A Button Icon is a compact, icon-only button that triggers an action, designed for quick, space-efficient interactions
 
 ```tsx
-import { ButtonIcon } from '@metamask/design-system-react';
+import { ButtonIcon, IconName } from '@metamask/design-system-react';
 
 <ButtonIcon iconName={IconName.Close} onClick={() => {}} />;
 ```

--- a/packages/design-system-react/src/components/button-icon/README.mdx
+++ b/packages/design-system-react/src/components/button-icon/README.mdx
@@ -1,0 +1,94 @@
+import { Controls, Canvas } from '@storybook/blocks';
+
+import * as ButtonIconStories from './ButtonIcon.stories';
+
+# ButtonIcon
+
+A Button Icon is a compact, icon-only button that triggers an action, designed for quick, space-efficient interactions
+
+```tsx
+import { ButtonIcon } from '@metamask/design-system-react';
+
+<ButtonIcon iconName={IconName.Close} onClick={() => {}} />;
+```
+
+<Canvas of={ButtonIconStories.Default} />
+
+## Props
+
+### Accessibility
+
+ButtonIcon requires an `ariaLabel` prop to ensure accessibility for screen readers. This label should clearly describe the button's action.
+
+```tsx
+<ButtonIcon
+  iconName={IconName.Close}
+  ariaLabel="Close dialog"
+  onClick={() => closeDialog()}
+/>
+```
+
+<Canvas of={ButtonIconStories.AriaLabel} />
+
+The `ariaLabel` should:
+
+- Be clear and concise
+- Describe the action (e.g., "Close dialog" rather than just "Close")
+- Be unique if multiple ButtonIcons are present
+- Reflect the current state if applicable
+
+### Size
+
+ButtonIcon supports three sizes:
+
+- `ButtonIconSize.Sm` (24px)
+- `ButtonIconSize.Md` (32px)
+- `ButtonIconSize.Lg` (40px)
+
+<Canvas of={ButtonIconStories.Size} />
+
+### IsFloating
+
+Use `isFloating` to apply a contained, floating button style.
+
+<Canvas of={ButtonIconStories.IsFloating} />
+
+### IsInverse
+
+Use `isInverse` when the button needs to be displayed on a dark background.
+
+<Canvas of={ButtonIconStories.IsInverse} />
+
+### IsDisabled
+
+ButtonIcon can be disabled.
+
+<Canvas of={ButtonIconStories.IsDisabled} />
+
+### Class Name
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+Example:
+
+```tsx
+// Adding new styles
+<ButtonIcon className="my-4 mx-2" iconName={IconName.Close} />
+```
+
+Note: When using `className` to override default styles, the custom classes will take precedence over the component's default classes.
+
+### Style
+
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with className alone. For static styles, prefer using className with Tailwind classes.
+
+## Component API
+
+<Controls of={ButtonIconStories.Default} />
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/src/components/button-icon/README.mdx
+++ b/packages/design-system-react/src/components/button-icon/README.mdx
@@ -42,7 +42,7 @@ The `ariaLabel` should:
 ButtonIcon supports three sizes:
 
 - `ButtonIconSize.Sm` (24px)
-- `ButtonIconSize.Md` (32px)
+- `ButtonIconSize.Md` (32px) - default
 - `ButtonIconSize.Lg` (40px)
 
 <Canvas of={ButtonIconStories.Size} />

--- a/packages/design-system-react/src/components/button-icon/index.ts
+++ b/packages/design-system-react/src/components/button-icon/index.ts
@@ -1,0 +1,3 @@
+export { ButtonIcon } from './ButtonIcon';
+export type { ButtonIconProps } from './ButtonIcon.types';
+export { ButtonIconSize } from './ButtonIcon.types';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -32,3 +32,6 @@ export type { ButtonProps } from './button';
 
 export { TextButton } from './text-button';
 export type { TextButtonProps } from './text-button';
+
+export { ButtonIcon } from './button-icon';
+export type { ButtonIconProps } from './button-icon';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -27,7 +27,7 @@ export type { ButtonSecondaryProps } from './button-secondary';
 export { ButtonTertiary, ButtonTertiarySize } from './button-tertiary';
 export type { ButtonTertiaryProps } from './button-tertiary';
 
-export { Button, ButtonVariant } from './button';
+export { Button, ButtonSize, ButtonVariant } from './button';
 export type { ButtonProps } from './button';
 
 export { TextButton } from './text-button';


### PR DESCRIPTION
## **Description**

This PR adds `ButtonIcon` component to the design system react.

Key features include:
1. Three size variants (sm, md, lg)
2. Support for floating/contained style
3. Inverse color mode for dark backgrounds
4. Built-in accessibility with required aria labels
5. Comprehensive test coverage
6. Full Storybook documentation

The component is built on top of our existing ButtonBase component and integrates with our Icon system.

## **Related issues**

Fixes: #387

## **Manual testing steps**

1. Run Storybook (`yarn storybook`)
2. Navigate to React Components/ButtonIcon
3. Test different configurations:
   - Try all size variants (sm, md, lg)
   - Toggle floating mode
   - Toggle inverse mode on dark background
   - Verify disabled state
   - Check hover and active states
   - Check controls
   - Check accessibility tests

## **Screenshots/Recordings**

### **Before**
N/A - New component

### **After**


https://github.com/user-attachments/assets/047b3690-8b89-4459-81d8-475675900ec5




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests (100% coverage for ButtonIcon component)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format
- [ ] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.