### PR TITLE
chore: upgrading auto-changelog dependency

### DIFF
--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -53,7 +53,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.23.3",
-    "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/auto-changelog": "^4.1.0",
     "@storybook/react-native": "6.5",
     "@testing-library/react-native": "^12.8.1",
     "@types/babel__preset-env": "^7",

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
-    "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/auto-changelog": "^4.1.0",
     "@metamask/design-system-tailwind-preset": "workspace:^",
     "@storybook/react": "^8.3.5",
     "@storybook/test": "^8.3.5",

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -46,7 +46,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/auto-changelog": "^4.1.0",
     "@ts-bridge/cli": "^0.5.1",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.54",

--- a/packages/design-system-twrnc-preset/package.json
+++ b/packages/design-system-twrnc-preset/package.json
@@ -53,7 +53,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.23.3",
-    "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/auto-changelog": "^4.1.0",
     "@testing-library/react-native": "^12.8.1",
     "@types/babel__preset-env": "^7",
     "@types/jest": "^27.4.1",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -48,7 +48,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/auto-changelog": "^4.1.0",
     "@metamask/design-system-react": "workspace:^",
     "@storybook/react": "^8.3.5",
     "@ts-bridge/cli": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3143,22 +3143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/auto-changelog@npm:^3.4.4":
-  version: 3.4.4
-  resolution: "@metamask/auto-changelog@npm:3.4.4"
-  dependencies:
-    diff: "npm:^5.0.0"
-    execa: "npm:^5.1.1"
-    prettier: "npm:^2.8.8"
-    semver: "npm:^7.3.5"
-    yargs: "npm:^17.0.1"
-  bin:
-    auto-changelog: dist/cli.js
-  checksum: 10/70e98529a153ebeab10410dbc3f567014999f77ed82f2b52f1b36501b28a4e3614c809a90c89600a739d7710595bfecc30e2260410e6afac7539f8db65a48f2c
-  languageName: node
-  linkType: hard
-
-"@metamask/auto-changelog@npm:^4.0.0":
+"@metamask/auto-changelog@npm:^4.0.0, @metamask/auto-changelog@npm:^4.1.0":
   version: 4.1.0
   resolution: "@metamask/auto-changelog@npm:4.1.0"
   dependencies:
@@ -3204,7 +3189,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/preset-react": "npm:^7.25.9"
     "@babel/preset-typescript": "npm:^7.23.3"
-    "@metamask/auto-changelog": "npm:^3.4.4"
+    "@metamask/auto-changelog": "npm:^4.1.0"
     "@metamask/design-system-twrnc-preset": "workspace:^"
     "@storybook/react-native": "npm:6.5"
     "@testing-library/react-native": "npm:^12.8.1"
@@ -3234,7 +3219,7 @@ __metadata:
   resolution: "@metamask/design-system-react@workspace:packages/design-system-react"
   dependencies:
     "@jest/globals": "npm:^29.7.0"
-    "@metamask/auto-changelog": "npm:^3.4.4"
+    "@metamask/auto-changelog": "npm:^4.1.0"
     "@metamask/design-system-tailwind-preset": "workspace:^"
     "@radix-ui/react-slot": "npm:^1.1.0"
     "@storybook/react": "npm:^8.3.5"
@@ -3267,7 +3252,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/design-system-tailwind-preset@workspace:packages/design-system-tailwind-preset"
   dependencies:
-    "@metamask/auto-changelog": "npm:^3.4.4"
+    "@metamask/auto-changelog": "npm:^4.1.0"
     "@ts-bridge/cli": "npm:^0.5.1"
     "@types/jest": "npm:^27.4.1"
     "@types/node": "npm:^16.18.54"
@@ -3290,7 +3275,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/preset-react": "npm:^7.25.9"
     "@babel/preset-typescript": "npm:^7.23.3"
-    "@metamask/auto-changelog": "npm:^3.4.4"
+    "@metamask/auto-changelog": "npm:^4.1.0"
     "@metamask/design-tokens": "workspace:^"
     "@testing-library/react-native": "npm:^12.8.1"
     "@types/babel__preset-env": "npm:^7"
@@ -3314,7 +3299,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/design-tokens@workspace:packages/design-tokens"
   dependencies:
-    "@metamask/auto-changelog": "npm:^3.4.4"
+    "@metamask/auto-changelog": "npm:^4.1.0"
     "@metamask/design-system-react": "workspace:^"
     "@storybook/react": "npm:^8.3.5"
     "@ts-bridge/cli": "npm:^0.5.1"
@@ -16702,7 +16687,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.4.1, prettier@npm:^2.8.7, prettier@npm:^2.8.8":
+"prettier@npm:^2.4.1, prettier@npm:^2.8.7":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:


### PR DESCRIPTION
## Description

Updates the `@metamask/auto-changelog` dependency from v3.4.4 to v4.1.0 across the design system packages. This update includes several breaking changes and new features:

Key changes in v4.1.0:
- Added `--autoCategorize` flag for automatic commit categorization
- Breaking changes from v4.0.0:
  - Dropped support for Node.js <18.18
  - Requires `prettier@>=3.0.0` as peer dependency
  - Enables Prettier formatting by default

## Related issues

Fixes: https://github.com/MetaMask/metamask-design-system/pull/378

## Manual testing steps

1. Run `yarn changelog:update` command to verify it works with the new version
2. Verify changelog formatting is correct with the new Prettier defaults
3. Verify Node.js version compatibility (requires >=18.18)

## Screenshots/Recordings

Changelog commands still work

https://github.com/user-attachments/assets/f3d3fd2c-82dc-4a96-b3d9-851a0e2a777d



## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template
- [x] I've applied appropriate labels (dependencies, javascript)

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR
- [ ] I confirm this PR addresses all acceptance criteria

Note: This PR was previously blocked by other dependency upgrades that needed to be resolved first. Those have now been addressed, making this upgrade possible.