### PR TITLE
feat: adding avatar base component to design system react

### DIFF
--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
@@ -1,6 +1,6 @@
 import { AvatarBaseSize } from './AvatarBase.types';
 
-export const AVATAR_BASE_SIZE_DIMENSIONS: Record<AvatarBaseSize, string> = {
+export const AVATAR_BASE_SIZE_CLASS_MAP: Record<AvatarBaseSize, string> = {
   [AvatarBaseSize.Xs]: 'h-4 w-4 text-s-body-xs',
   [AvatarBaseSize.Sm]: 'h-6 w-6 text-s-body-sm',
   [AvatarBaseSize.Md]: 'h-8 w-8 text-s-body-md',

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
@@ -1,0 +1,9 @@
+import { AvatarBaseSize } from './AvatarBase.types';
+
+export const AVATAR_BASE_SIZE_DIMENSIONS: Record<AvatarBaseSize, string> = {
+  [AvatarBaseSize.Xs]: 'h-4 w-4 text-s-body-xs',
+  [AvatarBaseSize.Sm]: 'h-6 w-6 text-s-body-sm',
+  [AvatarBaseSize.Md]: 'h-8 w-8 text-s-body-md',
+  [AvatarBaseSize.Lg]: 'h-10 w-10 text-s-body-lg',
+  [AvatarBaseSize.Xl]: 'h-12 w-12 text-s-body-lg',
+};

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
@@ -1,4 +1,5 @@
 import { AvatarBaseSize } from './AvatarBase.types';
+import { TextVariant } from '../text';
 
 export const AVATAR_BASE_SIZE_CLASS_MAP: Record<AvatarBaseSize, string> = {
   [AvatarBaseSize.Xs]: 'h-4 w-4',
@@ -6,4 +7,15 @@ export const AVATAR_BASE_SIZE_CLASS_MAP: Record<AvatarBaseSize, string> = {
   [AvatarBaseSize.Md]: 'h-8 w-8',
   [AvatarBaseSize.Lg]: 'h-10 w-10',
   [AvatarBaseSize.Xl]: 'h-12 w-12',
+};
+
+export const AVATAR_BASE_SIZE_TO_TEXT_VARIANT_MAP: Record<
+  AvatarBaseSize,
+  TextVariant
+> = {
+  [AvatarBaseSize.Xs]: TextVariant.BodyXs,
+  [AvatarBaseSize.Sm]: TextVariant.BodyXs,
+  [AvatarBaseSize.Md]: TextVariant.BodySm,
+  [AvatarBaseSize.Lg]: TextVariant.BodyMd,
+  [AvatarBaseSize.Xl]: TextVariant.BodyMd,
 };

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
@@ -1,9 +1,9 @@
 import { AvatarBaseSize } from './AvatarBase.types';
 
 export const AVATAR_BASE_SIZE_CLASS_MAP: Record<AvatarBaseSize, string> = {
-  [AvatarBaseSize.Xs]: 'h-4 w-4 text-s-body-xs',
-  [AvatarBaseSize.Sm]: 'h-6 w-6 text-s-body-sm',
-  [AvatarBaseSize.Md]: 'h-8 w-8 text-s-body-md',
-  [AvatarBaseSize.Lg]: 'h-10 w-10 text-s-body-lg',
-  [AvatarBaseSize.Xl]: 'h-12 w-12 text-s-body-lg',
+  [AvatarBaseSize.Xs]: 'h-4 w-4',
+  [AvatarBaseSize.Sm]: 'h-6 w-6',
+  [AvatarBaseSize.Md]: 'h-8 w-8',
+  [AvatarBaseSize.Lg]: 'h-10 w-10',
+  [AvatarBaseSize.Xl]: 'h-12 w-12',
 };

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
@@ -18,7 +18,16 @@ const meta: Meta<typeof AvatarBase> = {
     children: {
       control: 'text',
       description:
-        'Required prop for the content to be rendered within the AvatarBase',
+        'Optional prop for the content to be rendered within the AvatarBase. Not required if fallbackText is provided',
+    },
+    fallbackText: {
+      control: 'text',
+      description: 'Optional text to display when no children are provided',
+    },
+    fallbackTextProps: {
+      control: 'object',
+      description:
+        'Optional props to be passed to the Text component when rendering fallback text',
     },
     className: {
       control: 'text',
@@ -44,25 +53,16 @@ export default meta;
 type Story = StoryObj<typeof AvatarBase>;
 
 export const Default: Story = {
-  render: (args) => (
-    <AvatarBase {...args}>
-      <Text>{args.children}</Text>
-    </AvatarBase>
-  ),
   args: {
-    children: 'A',
+    fallbackText: 'A',
   },
 };
 
 export const Shape: Story = {
   render: () => (
     <div className="flex gap-2 items-center">
-      <AvatarBase shape={AvatarBaseShape.Circle}>
-        <Text variant={TextVariant.BodySm}>C</Text>
-      </AvatarBase>
-      <AvatarBase shape={AvatarBaseShape.Square}>
-        <Text variant={TextVariant.BodySm}>S</Text>
-      </AvatarBase>
+      <AvatarBase shape={AvatarBaseShape.Circle} fallbackText="C" />
+      <AvatarBase shape={AvatarBaseShape.Square} fallbackText="S" />
     </div>
   ),
 };
@@ -71,39 +71,68 @@ export const Size: Story = {
   render: () => (
     <div className="flex flex-col gap-2">
       <div className="flex gap-2 items-center">
-        <AvatarBase size={AvatarBaseSize.Xs}>
-          <Text variant={TextVariant.BodyXs}>Xs</Text>
-        </AvatarBase>
-        <AvatarBase size={AvatarBaseSize.Sm}>
-          <Text variant={TextVariant.BodyXs}>Sm</Text>
-        </AvatarBase>
-        <AvatarBase size={AvatarBaseSize.Md}>
-          <Text variant={TextVariant.BodySm}>Md</Text>
-        </AvatarBase>
-        <AvatarBase size={AvatarBaseSize.Lg}>
-          <Text variant={TextVariant.BodyMd}>Lg</Text>
-        </AvatarBase>
-        <AvatarBase size={AvatarBaseSize.Xl}>
-          <Text variant={TextVariant.BodyMd}>Xl</Text>
-        </AvatarBase>
+        <AvatarBase size={AvatarBaseSize.Xs} fallbackText="XS" />
+        <AvatarBase size={AvatarBaseSize.Sm} fallbackText="SM" />
+        <AvatarBase size={AvatarBaseSize.Md} fallbackText="MD" />
+        <AvatarBase size={AvatarBaseSize.Lg} fallbackText="LG" />
+        <AvatarBase size={AvatarBaseSize.Xl} fallbackText="XL" />
       </div>
       <div className="flex gap-2 items-center">
-        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Xs}>
-          <Text variant={TextVariant.BodyXs}>Xs</Text>
-        </AvatarBase>
-        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Sm}>
-          <Text variant={TextVariant.BodyXs}>Sm</Text>
-        </AvatarBase>
-        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Md}>
-          <Text variant={TextVariant.BodySm}>Md</Text>
-        </AvatarBase>
-        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Lg}>
-          <Text variant={TextVariant.BodyMd}>Lg</Text>
-        </AvatarBase>
-        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Xl}>
-          <Text variant={TextVariant.BodyMd}>Xl</Text>
-        </AvatarBase>
+        <AvatarBase
+          shape={AvatarBaseShape.Square}
+          size={AvatarBaseSize.Xs}
+          fallbackText="XS"
+        />
+        <AvatarBase
+          shape={AvatarBaseShape.Square}
+          size={AvatarBaseSize.Sm}
+          fallbackText="SM"
+        />
+        <AvatarBase
+          shape={AvatarBaseShape.Square}
+          size={AvatarBaseSize.Md}
+          fallbackText="MD"
+        />
+        <AvatarBase
+          shape={AvatarBaseShape.Square}
+          size={AvatarBaseSize.Lg}
+          fallbackText="LG"
+        />
+        <AvatarBase
+          shape={AvatarBaseShape.Square}
+          size={AvatarBaseSize.Xl}
+          fallbackText="XL"
+        />
       </div>
+    </div>
+  ),
+};
+
+export const FallbackText: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <AvatarBase fallbackText="A" />
+      <AvatarBase fallbackText="B" />
+      <AvatarBase fallbackText="C" />
+    </div>
+  ),
+};
+
+export const FallbackTextWithProps: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <AvatarBase
+        fallbackText="A"
+        fallbackTextProps={{ color: TextColor.PrimaryDefault }}
+      />
+      <AvatarBase
+        fallbackText="B"
+        fallbackTextProps={{ color: TextColor.ErrorDefault }}
+      />
+      <AvatarBase
+        fallbackText="C"
+        fallbackTextProps={{ color: TextColor.SuccessDefault }}
+      />
     </div>
   ),
 };
@@ -112,9 +141,7 @@ export const Children: Story = {
   render: () => (
     <div className="flex gap-2 items-center">
       {/* Text */}
-      <AvatarBase>
-        <Text>A</Text>
-      </AvatarBase>
+      <AvatarBase fallbackText="A" />
       {/* Image */}
       <AvatarBase>
         <img

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { Icon, IconName, IconSize } from '..';
+import { AvatarBase } from './AvatarBase';
+import { AvatarBaseSize } from './AvatarBase.types';
+import README from './README.mdx';
+
+const meta: Meta<typeof AvatarBase> = {
+  title: 'React Components/AvatarBase',
+  component: AvatarBase,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    children: {
+      control: 'text',
+      description:
+        'Required prop for the content to be rendered within the AvatarBase',
+    },
+    className: {
+      control: 'text',
+      description:
+        'Optional prop for additional CSS classes to be applied to the AvatarBase component',
+    },
+    size: {
+      control: 'select',
+      options: Object.keys(AvatarBaseSize),
+      mapping: AvatarBaseSize,
+      description: 'Optional prop to control the size of the AvatarBase',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AvatarBase>;
+
+export const Default: Story = {
+  args: {
+    children: 'A',
+  },
+};
+
+export const Size: Story = {
+  render: () => (
+    <div className="flex gap-2 items-center">
+      <AvatarBase size={AvatarBaseSize.Xs}>Xs</AvatarBase>
+      <AvatarBase size={AvatarBaseSize.Sm}>Sm</AvatarBase>
+      <AvatarBase size={AvatarBaseSize.Md}>Md</AvatarBase>
+      <AvatarBase size={AvatarBaseSize.Lg}>Lg</AvatarBase>
+      <AvatarBase size={AvatarBaseSize.Xl}>Xl</AvatarBase>
+    </div>
+  ),
+};
+
+export const Children: Story = {
+  render: () => (
+    <div className="flex gap-2 items-center">
+      {/* Text */}
+      <AvatarBase>A</AvatarBase>
+      {/* Image */}
+      <AvatarBase>
+        <img
+          src="https://cryptologos.cc/logos/avalanche-avax-logo.png?v=040"
+          alt="Avalanche"
+          className="w-full h-full object-cover"
+        />
+      </AvatarBase>
+      {/* Icon */}
+      <AvatarBase>
+        <Icon
+          name={IconName.User}
+          size={IconSize.Sm}
+          className="text-inherit"
+        />
+      </AvatarBase>
+    </div>
+  ),
+};
+
+export const ClassName: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <AvatarBase className="bg-success-default text-success-inverse">
+        S
+      </AvatarBase>
+      <AvatarBase className="bg-error-default text-error-inverse">E</AvatarBase>
+      <AvatarBase className="bg-warning-default text-warning-inverse">
+        W
+      </AvatarBase>
+    </div>
+  ),
+};

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Icon, IconName, IconSize, Text, TextVariant } from '..';
+import { Icon, IconName, IconSize, Text, TextVariant, TextColor } from '..';
 import { AvatarBase } from './AvatarBase';
 import { AvatarBaseSize, AvatarBaseShape } from './AvatarBase.types';
 import README from './README.mdx';
@@ -44,6 +44,11 @@ export default meta;
 type Story = StoryObj<typeof AvatarBase>;
 
 export const Default: Story = {
+  render: (args) => (
+    <AvatarBase {...args}>
+      <Text>{args.children}</Text>
+    </AvatarBase>
+  ),
   args: {
     children: 'A',
   },
@@ -107,7 +112,9 @@ export const Children: Story = {
   render: () => (
     <div className="flex gap-2 items-center">
       {/* Text */}
-      <AvatarBase>A</AvatarBase>
+      <AvatarBase>
+        <Text>A</Text>
+      </AvatarBase>
       {/* Image */}
       <AvatarBase>
         <img
@@ -118,25 +125,7 @@ export const Children: Story = {
       </AvatarBase>
       {/* Icon */}
       <AvatarBase>
-        <Icon
-          name={IconName.User}
-          size={IconSize.Sm}
-          className="text-inherit"
-        />
-      </AvatarBase>
-    </div>
-  ),
-};
-
-export const ClassName: Story = {
-  render: () => (
-    <div className="flex gap-2">
-      <AvatarBase className="bg-success-default text-success-inverse">
-        S
-      </AvatarBase>
-      <AvatarBase className="bg-error-default text-error-inverse">E</AvatarBase>
-      <AvatarBase className="bg-warning-default text-warning-inverse">
-        W
+        <Icon name={IconName.User} size={IconSize.Sm} />
       </AvatarBase>
     </div>
   ),

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { Icon, IconName, IconSize, Text, TextVariant } from '..';
 import { AvatarBase } from './AvatarBase';
-import { AvatarBaseSize } from './AvatarBase.types';
+import { AvatarBaseSize, AvatarBaseShape } from './AvatarBase.types';
 import README from './README.mdx';
 
 const meta: Meta<typeof AvatarBase> = {
@@ -31,6 +31,12 @@ const meta: Meta<typeof AvatarBase> = {
       mapping: AvatarBaseSize,
       description: 'Optional prop to control the size of the AvatarBase',
     },
+    shape: {
+      control: 'select',
+      options: Object.keys(AvatarBaseShape),
+      mapping: AvatarBaseShape,
+      description: 'Optional prop to control the shape of the AvatarBase',
+    },
   },
 };
 
@@ -43,24 +49,56 @@ export const Default: Story = {
   },
 };
 
-export const Size: Story = {
+export const Shape: Story = {
   render: () => (
     <div className="flex gap-2 items-center">
-      <AvatarBase size={AvatarBaseSize.Xs}>
-        <Text variant={TextVariant.BodyXs}>Xs</Text>
+      <AvatarBase shape={AvatarBaseShape.Circle}>
+        <Text variant={TextVariant.BodySm}>C</Text>
       </AvatarBase>
-      <AvatarBase size={AvatarBaseSize.Sm}>
-        <Text variant={TextVariant.BodyXs}>Sm</Text>
+      <AvatarBase shape={AvatarBaseShape.Square}>
+        <Text variant={TextVariant.BodySm}>S</Text>
       </AvatarBase>
-      <AvatarBase size={AvatarBaseSize.Md}>
-        <Text variant={TextVariant.BodySm}>Md</Text>
-      </AvatarBase>
-      <AvatarBase size={AvatarBaseSize.Lg}>
-        <Text variant={TextVariant.BodyMd}>Lg</Text>
-      </AvatarBase>
-      <AvatarBase size={AvatarBaseSize.Xl}>
-        <Text variant={TextVariant.BodyMd}>Xl</Text>
-      </AvatarBase>
+    </div>
+  ),
+};
+
+export const Size: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-2 items-center">
+        <AvatarBase size={AvatarBaseSize.Xs}>
+          <Text variant={TextVariant.BodyXs}>Xs</Text>
+        </AvatarBase>
+        <AvatarBase size={AvatarBaseSize.Sm}>
+          <Text variant={TextVariant.BodyXs}>Sm</Text>
+        </AvatarBase>
+        <AvatarBase size={AvatarBaseSize.Md}>
+          <Text variant={TextVariant.BodySm}>Md</Text>
+        </AvatarBase>
+        <AvatarBase size={AvatarBaseSize.Lg}>
+          <Text variant={TextVariant.BodyMd}>Lg</Text>
+        </AvatarBase>
+        <AvatarBase size={AvatarBaseSize.Xl}>
+          <Text variant={TextVariant.BodyMd}>Xl</Text>
+        </AvatarBase>
+      </div>
+      <div className="flex gap-2 items-center">
+        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Xs}>
+          <Text variant={TextVariant.BodyXs}>Xs</Text>
+        </AvatarBase>
+        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Sm}>
+          <Text variant={TextVariant.BodyXs}>Sm</Text>
+        </AvatarBase>
+        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Md}>
+          <Text variant={TextVariant.BodySm}>Md</Text>
+        </AvatarBase>
+        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Lg}>
+          <Text variant={TextVariant.BodyMd}>Lg</Text>
+        </AvatarBase>
+        <AvatarBase shape={AvatarBaseShape.Square} size={AvatarBaseSize.Xl}>
+          <Text variant={TextVariant.BodyMd}>Xl</Text>
+        </AvatarBase>
+      </div>
     </div>
   ),
 };

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Icon, IconName, IconSize } from '..';
+import { Icon, IconName, IconSize, Text, TextVariant } from '..';
 import { AvatarBase } from './AvatarBase';
 import { AvatarBaseSize } from './AvatarBase.types';
 import README from './README.mdx';
@@ -46,11 +46,21 @@ export const Default: Story = {
 export const Size: Story = {
   render: () => (
     <div className="flex gap-2 items-center">
-      <AvatarBase size={AvatarBaseSize.Xs}>Xs</AvatarBase>
-      <AvatarBase size={AvatarBaseSize.Sm}>Sm</AvatarBase>
-      <AvatarBase size={AvatarBaseSize.Md}>Md</AvatarBase>
-      <AvatarBase size={AvatarBaseSize.Lg}>Lg</AvatarBase>
-      <AvatarBase size={AvatarBaseSize.Xl}>Xl</AvatarBase>
+      <AvatarBase size={AvatarBaseSize.Xs}>
+        <Text variant={TextVariant.BodyXs}>Xs</Text>
+      </AvatarBase>
+      <AvatarBase size={AvatarBaseSize.Sm}>
+        <Text variant={TextVariant.BodyXs}>Sm</Text>
+      </AvatarBase>
+      <AvatarBase size={AvatarBaseSize.Md}>
+        <Text variant={TextVariant.BodySm}>Md</Text>
+      </AvatarBase>
+      <AvatarBase size={AvatarBaseSize.Lg}>
+        <Text variant={TextVariant.BodyMd}>Lg</Text>
+      </AvatarBase>
+      <AvatarBase size={AvatarBaseSize.Xl}>
+        <Text variant={TextVariant.BodyMd}>Xl</Text>
+      </AvatarBase>
     </div>
   ),
 };

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { AvatarBase } from './AvatarBase';
-import { AVATAR_BASE_SIZE_DIMENSIONS } from './AvatarBase.constants';
+import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
 import { AvatarBaseSize } from './AvatarBase.types';
 
 describe('AvatarBase', () => {
@@ -26,7 +26,7 @@ describe('AvatarBase', () => {
       <AvatarBase size={AvatarBaseSize.Xs}>A</AvatarBase>,
     );
 
-    Object.entries(AVATAR_BASE_SIZE_DIMENSIONS).forEach(([size, classes]) => {
+    Object.entries(AVATAR_BASE_SIZE_CLASS_MAP).forEach(([size, classes]) => {
       rerender(<AvatarBase size={size as AvatarBaseSize}>A</AvatarBase>);
       const avatar = screen.getByText('A');
       const classArray = classes.split(' ');

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { AvatarBase } from './AvatarBase';
+import { AVATAR_BASE_SIZE_DIMENSIONS } from './AvatarBase.constants';
+import { AvatarBaseSize } from './AvatarBase.types';
+
+describe('AvatarBase', () => {
+  it('renders with default styles', () => {
+    render(<AvatarBase>A</AvatarBase>);
+
+    const avatar = screen.getByText('A');
+    expect(avatar).toHaveClass(
+      'inline-flex',
+      'items-center',
+      'justify-center',
+      'rounded-full',
+      'bg-background-alternative',
+      'text-default',
+      'uppercase',
+    );
+  });
+
+  it('applies size classes correctly', () => {
+    const { rerender } = render(
+      <AvatarBase size={AvatarBaseSize.Xs}>A</AvatarBase>,
+    );
+
+    Object.entries(AVATAR_BASE_SIZE_DIMENSIONS).forEach(([size, classes]) => {
+      rerender(<AvatarBase size={size as AvatarBaseSize}>A</AvatarBase>);
+      const avatar = screen.getByText('A');
+      const classArray = classes.split(' ');
+      classArray.forEach((className) => {
+        expect(avatar).toHaveClass(className);
+      });
+    });
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <AvatarBase>
+        <img src="test.jpg" alt="test" data-testid="avatar-image" />
+      </AvatarBase>,
+    );
+
+    expect(screen.getByTestId('avatar-image')).toBeInTheDocument();
+  });
+
+  it('merges custom className with default classes', () => {
+    render(<AvatarBase className="custom-class">A</AvatarBase>);
+
+    const avatar = screen.getByText('A');
+    expect(avatar).toHaveClass('custom-class');
+    expect(avatar).toHaveClass('rounded-full');
+  });
+
+  it('renders as child component when asChild is true', () => {
+    render(
+      <AvatarBase asChild>
+        <span>A</span>
+      </AvatarBase>,
+    );
+
+    const avatar = screen.getByText('A');
+    expect(avatar.tagName).toBe('SPAN');
+  });
+
+  it('applies custom styles when provided', () => {
+    render(<AvatarBase style={{ backgroundColor: 'red' }}>A</AvatarBase>);
+
+    const avatar = screen.getByText('A');
+    expect(avatar).toHaveStyle({ backgroundColor: 'red' });
+  });
+});

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { AvatarBase } from './AvatarBase';
 import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
-import { AvatarBaseSize } from './AvatarBase.types';
+import { AvatarBaseSize, AvatarBaseShape } from './AvatarBase.types';
 
 describe('AvatarBase', () => {
   it('renders with default styles', () => {
@@ -62,5 +62,25 @@ describe('AvatarBase', () => {
 
     const avatar = screen.getByText('A');
     expect(avatar).toHaveStyle({ backgroundColor: 'red' });
+  });
+
+  it('applies correct shape classes', () => {
+    const { rerender } = render(
+      <AvatarBase shape={AvatarBaseShape.Circle}>A</AvatarBase>,
+    );
+
+    let avatar = screen.getByText('A');
+    expect(avatar).toHaveClass('rounded-full');
+
+    rerender(<AvatarBase shape={AvatarBaseShape.Square}>A</AvatarBase>);
+    avatar = screen.getByText('A');
+    expect(avatar).toHaveClass('rounded-lg');
+  });
+
+  it('uses circle shape by default', () => {
+    render(<AvatarBase>A</AvatarBase>);
+
+    const avatar = screen.getByText('A');
+    expect(avatar).toHaveClass('rounded-full');
   });
 });

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
@@ -10,15 +10,7 @@ describe('AvatarBase', () => {
     render(<AvatarBase>A</AvatarBase>);
 
     const avatar = screen.getByText('A');
-    expect(avatar).toHaveClass(
-      'inline-flex',
-      'items-center',
-      'justify-center',
-      'rounded-full',
-      'bg-background-alternative',
-      'text-default',
-      'uppercase',
-    );
+    expect(avatar).toBeInTheDocument();
   });
 
   it('applies size classes correctly', () => {

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
@@ -1,26 +1,37 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { TextColor } from '../text';
 import { AvatarBase } from './AvatarBase';
 import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
 import { AvatarBaseSize, AvatarBaseShape } from './AvatarBase.types';
 
 describe('AvatarBase', () => {
   it('renders with default styles', () => {
-    render(<AvatarBase>A</AvatarBase>);
+    render(<AvatarBase fallbackText="A" data-testid="avatar" />);
 
-    const avatar = screen.getByText('A');
-    expect(avatar).toBeInTheDocument();
+    const avatar = screen.getByTestId('avatar');
+    expect(screen.getByText('A')).toBeInTheDocument();
   });
 
   it('applies size classes correctly', () => {
     const { rerender } = render(
-      <AvatarBase size={AvatarBaseSize.Xs}>A</AvatarBase>,
+      <AvatarBase
+        size={AvatarBaseSize.Xs}
+        fallbackText="A"
+        data-testid="avatar"
+      />,
     );
 
     Object.entries(AVATAR_BASE_SIZE_CLASS_MAP).forEach(([size, classes]) => {
-      rerender(<AvatarBase size={size as AvatarBaseSize}>A</AvatarBase>);
-      const avatar = screen.getByText('A');
+      rerender(
+        <AvatarBase
+          size={size as AvatarBaseSize}
+          fallbackText="A"
+          data-testid="avatar"
+        />,
+      );
+      const avatar = screen.getByTestId('avatar');
       const classArray = classes.split(' ');
       classArray.forEach((className) => {
         expect(avatar).toHaveClass(className);
@@ -39,9 +50,15 @@ describe('AvatarBase', () => {
   });
 
   it('merges custom className with default classes', () => {
-    render(<AvatarBase className="custom-class">A</AvatarBase>);
+    render(
+      <AvatarBase
+        className="custom-class"
+        fallbackText="A"
+        data-testid="avatar"
+      />,
+    );
 
-    const avatar = screen.getByText('A');
+    const avatar = screen.getByTestId('avatar');
     expect(avatar).toHaveClass('custom-class');
     expect(avatar).toHaveClass('rounded-full');
   });
@@ -58,29 +75,110 @@ describe('AvatarBase', () => {
   });
 
   it('applies custom styles when provided', () => {
-    render(<AvatarBase style={{ backgroundColor: 'red' }}>A</AvatarBase>);
+    render(
+      <AvatarBase
+        style={{ backgroundColor: 'red' }}
+        fallbackText="A"
+        data-testid="avatar"
+      />,
+    );
 
-    const avatar = screen.getByText('A');
+    const avatar = screen.getByTestId('avatar');
     expect(avatar).toHaveStyle({ backgroundColor: 'red' });
   });
 
   it('applies correct shape classes', () => {
     const { rerender } = render(
-      <AvatarBase shape={AvatarBaseShape.Circle}>A</AvatarBase>,
+      <AvatarBase
+        shape={AvatarBaseShape.Circle}
+        fallbackText="A"
+        data-testid="avatar"
+      />,
     );
 
-    let avatar = screen.getByText('A');
+    let avatar = screen.getByTestId('avatar');
     expect(avatar).toHaveClass('rounded-full');
 
-    rerender(<AvatarBase shape={AvatarBaseShape.Square}>A</AvatarBase>);
-    avatar = screen.getByText('A');
+    rerender(
+      <AvatarBase
+        shape={AvatarBaseShape.Square}
+        fallbackText="A"
+        data-testid="avatar"
+      />,
+    );
+    avatar = screen.getByTestId('avatar');
     expect(avatar).toHaveClass('rounded-lg');
   });
 
   it('uses circle shape by default', () => {
-    render(<AvatarBase>A</AvatarBase>);
+    render(<AvatarBase fallbackText="A" data-testid="avatar" />);
 
-    const avatar = screen.getByText('A');
+    const avatar = screen.getByTestId('avatar');
     expect(avatar).toHaveClass('rounded-full');
+  });
+
+  it('renders fallbackText when no children are provided', () => {
+    render(<AvatarBase fallbackText="Test" />);
+    expect(screen.getByText('Test')).toBeInTheDocument();
+  });
+
+  it('prioritizes children over fallbackText', () => {
+    render(
+      <AvatarBase fallbackText="Fallback">
+        <span>Child</span>
+      </AvatarBase>,
+    );
+    expect(screen.getByText('Child')).toBeInTheDocument();
+    expect(screen.queryByText('Fallback')).not.toBeInTheDocument();
+  });
+
+  it('applies fallbackTextProps correctly', () => {
+    render(
+      <AvatarBase
+        fallbackText="Test"
+        fallbackTextProps={{
+          color: TextColor.PrimaryDefault,
+          'data-testid': 'fallback-text',
+        }}
+      />,
+    );
+    const fallbackText = screen.getByTestId('fallback-text');
+    expect(fallbackText).toHaveClass('text-primary-default');
+  });
+
+  it('uses correct text variant based on size', () => {
+    const { rerender } = render(
+      <AvatarBase
+        size={AvatarBaseSize.Xs}
+        fallbackText="A"
+        fallbackTextProps={{ 'data-testid': 'fallback-text' }}
+      />,
+    );
+
+    // Test XS size
+    let fallbackText = screen.getByTestId('fallback-text');
+    expect(fallbackText).toHaveClass('text-s-body-xs');
+
+    // Test MD size
+    rerender(
+      <AvatarBase
+        size={AvatarBaseSize.Md}
+        fallbackText="A"
+        fallbackTextProps={{ 'data-testid': 'fallback-text' }}
+      />,
+    );
+    fallbackText = screen.getByTestId('fallback-text');
+    expect(fallbackText).toHaveClass('text-s-body-sm');
+
+    // Test XL size
+    rerender(
+      <AvatarBase
+        size={AvatarBaseSize.Xl}
+        fallbackText="A"
+        fallbackTextProps={{ 'data-testid': 'fallback-text' }}
+      />,
+    );
+    fallbackText = screen.getByTestId('fallback-text');
+    expect(fallbackText).toHaveClass('text-s-body-md');
   });
 });

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
@@ -2,7 +2,11 @@ import { Slot } from '@radix-ui/react-slot';
 import React from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
-import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
+import { Text, FontWeight } from '..';
+import {
+  AVATAR_BASE_SIZE_CLASS_MAP,
+  AVATAR_BASE_SIZE_TO_TEXT_VARIANT_MAP,
+} from './AvatarBase.constants';
 import type { AvatarBaseProps } from './AvatarBase.types';
 import { AvatarBaseShape, AvatarBaseSize } from './AvatarBase.types';
 
@@ -10,6 +14,8 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
   (
     {
       children,
+      fallbackText,
+      fallbackTextProps,
       className,
       size = AvatarBaseSize.Md,
       shape = AvatarBaseShape.Circle,
@@ -25,7 +31,7 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
       // Base styles
       'inline-flex items-center justify-center',
       shape === AvatarBaseShape.Circle ? 'rounded-full' : 'rounded-lg',
-      'bg-alternative',
+      'bg-muted',
       'overflow-hidden',
       // Size
       AVATAR_BASE_SIZE_CLASS_MAP[size],
@@ -35,7 +41,17 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
 
     return (
       <Component ref={ref} className={mergedClassName} style={style} {...props}>
-        {children}
+        {children || (
+          <Text
+            variant={AVATAR_BASE_SIZE_TO_TEXT_VARIANT_MAP[size]}
+            fontWeight={FontWeight.Bold}
+            asChild
+            {...fallbackTextProps}
+          >
+            {/* asChild prop renders Text component as a span, it does not create an additional element */}
+            <span>{fallbackText}</span>
+          </Text>
+        )}
       </Component>
     );
   },

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
@@ -1,0 +1,37 @@
+import { Slot } from '@radix-ui/react-slot';
+import React from 'react';
+
+import { twMerge } from '../../utils/tw-merge';
+import { AVATAR_BASE_SIZE_DIMENSIONS } from './AvatarBase.constants';
+import type { AvatarBaseProps } from './AvatarBase.types';
+import { AvatarBaseSize } from './AvatarBase.types';
+
+export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
+  (
+    { children, className, size = AvatarBaseSize.Md, asChild, style, ...props },
+    ref,
+  ) => {
+    const Component = asChild ? Slot : 'div';
+
+    const mergedClassName = twMerge(
+      // Base styles
+      'inline-flex items-center justify-center',
+      'rounded-full',
+      'bg-background-alternative',
+      'text-default uppercase font-medium',
+      'overflow-hidden',
+      // Size
+      AVATAR_BASE_SIZE_DIMENSIONS[size],
+      // Custom classes
+      className,
+    );
+
+    return (
+      <Component ref={ref} className={mergedClassName} style={style} {...props}>
+        {children}
+      </Component>
+    );
+  },
+);
+
+AvatarBase.displayName = 'AvatarBase';

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
@@ -2,7 +2,7 @@ import { Slot } from '@radix-ui/react-slot';
 import React from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
-import { AVATAR_BASE_SIZE_DIMENSIONS } from './AvatarBase.constants';
+import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
 import type { AvatarBaseProps } from './AvatarBase.types';
 import { AvatarBaseSize } from './AvatarBase.types';
 
@@ -21,7 +21,7 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
       'text-default uppercase font-medium',
       'overflow-hidden',
       // Size
-      AVATAR_BASE_SIZE_DIMENSIONS[size],
+      AVATAR_BASE_SIZE_CLASS_MAP[size],
       // Custom classes
       className,
     );

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
@@ -4,11 +4,19 @@ import React from 'react';
 import { twMerge } from '../../utils/tw-merge';
 import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
 import type { AvatarBaseProps } from './AvatarBase.types';
-import { AvatarBaseSize } from './AvatarBase.types';
+import { AvatarBaseShape, AvatarBaseSize } from './AvatarBase.types';
 
 export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
   (
-    { children, className, size = AvatarBaseSize.Md, asChild, style, ...props },
+    {
+      children,
+      className,
+      size = AvatarBaseSize.Md,
+      shape = AvatarBaseShape.Circle,
+      asChild,
+      style,
+      ...props
+    },
     ref,
   ) => {
     const Component = asChild ? Slot : 'div';
@@ -16,7 +24,7 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
     const mergedClassName = twMerge(
       // Base styles
       'inline-flex items-center justify-center',
-      'rounded-full',
+      shape === AvatarBaseShape.Circle ? 'rounded-full' : 'rounded-lg',
       'bg-alternative',
       'overflow-hidden',
       // Size

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
@@ -17,8 +17,7 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
       // Base styles
       'inline-flex items-center justify-center',
       'rounded-full',
-      'bg-background-alternative',
-      'text-default uppercase font-medium',
+      'bg-alternative',
       'overflow-hidden',
       // Size
       AVATAR_BASE_SIZE_CLASS_MAP[size],

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.types.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.types.ts
@@ -1,4 +1,5 @@
 import type { ComponentProps } from 'react';
+import type { TextProps } from '../text';
 
 export enum AvatarBaseSize {
   /**
@@ -37,8 +38,20 @@ export enum AvatarBaseShape {
 export type AvatarBaseProps = ComponentProps<'div'> & {
   /**
    * Required prop for the content to be rendered within the AvatarBase
+   * Not required if fallbackText is provided
    */
-  children: React.ReactNode;
+  children?: React.ReactNode;
+  /**
+   * Optional text to display when no children are provided
+   */
+  fallbackText?: string;
+  /**
+   * Optional props to be passed to the Text component when rendering fallback text
+   * Only used when fallbackText is provided and no children
+   */
+  fallbackTextProps?: Partial<
+    React.HTMLAttributes<HTMLSpanElement> & TextProps
+  >;
   /**
    * Optional prop for additional CSS classes to be applied to the AvatarBase component.
    * These classes will be merged with the component's default classes using twMerge.

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.types.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.types.ts
@@ -23,6 +23,17 @@ export enum AvatarBaseSize {
   Xl = 'xl',
 }
 
+export enum AvatarBaseShape {
+  /**
+   * Circular shape with fully rounded corners
+   */
+  Circle = 'circle',
+  /**
+   * Square shape with slight rounded corners
+   */
+  Square = 'square',
+}
+
 export type AvatarBaseProps = ComponentProps<'div'> & {
   /**
    * Required prop for the content to be rendered within the AvatarBase
@@ -49,4 +60,9 @@ export type AvatarBaseProps = ComponentProps<'div'> & {
    * Should be used sparingly and only for dynamic styles that can't be achieved with className.
    */
   style?: React.CSSProperties;
+  /**
+   * Optional prop to control the shape of the AvatarBase
+   * @default AvatarBaseShape.Circle
+   */
+  shape?: AvatarBaseShape;
 };

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.types.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.types.ts
@@ -1,0 +1,52 @@
+import type { ComponentProps } from 'react';
+
+export enum AvatarBaseSize {
+  /**
+   * Extra small size (16px)
+   */
+  Xs = 'xs',
+  /**
+   * Small size (24px)
+   */
+  Sm = 'sm',
+  /**
+   * Medium size (32px)
+   */
+  Md = 'md',
+  /**
+   * Large size (40px)
+   */
+  Lg = 'lg',
+  /**
+   * Extra large size (48px)
+   */
+  Xl = 'xl',
+}
+
+export type AvatarBaseProps = ComponentProps<'div'> & {
+  /**
+   * Required prop for the content to be rendered within the AvatarBase
+   */
+  children: React.ReactNode;
+  /**
+   * Optional prop for additional CSS classes to be applied to the AvatarBase component.
+   * These classes will be merged with the component's default classes using twMerge.
+   */
+  className?: string;
+  /**
+   * Optional prop to control the size of the AvatarBase
+   * @default AvatarBaseSize.Md
+   */
+  size?: AvatarBaseSize;
+  /**
+   * Optional boolean that determines if the component should merge its props onto its immediate child
+   * instead of rendering a div element
+   * @default false
+   */
+  asChild?: boolean;
+  /**
+   * Optional CSS styles to be applied to the component.
+   * Should be used sparingly and only for dynamic styles that can't be achieved with className.
+   */
+  style?: React.CSSProperties;
+};

--- a/packages/design-system-react/src/components/avatar-base/README.mdx
+++ b/packages/design-system-react/src/components/avatar-base/README.mdx
@@ -1,0 +1,66 @@
+import { Controls, Canvas } from '@storybook/blocks';
+
+import * as AvatarBaseStories from './AvatarBase.stories';
+
+# AvatarBase
+
+The AvatarBase is the base component for avatars
+
+```tsx
+import { AvatarBase } from '@metamask/design-system-react';
+
+<AvatarBase>A</AvatarBase>;
+```
+
+<Canvas of={AvatarBaseStories.Default} />
+
+## Props
+
+### Size
+
+AvatarBase supports five sizes:
+
+- `AvatarBaseSize.Xs` (16px)
+- `AvatarBaseSize.Sm` (24px)
+- `AvatarBaseSize.Md` (32px) - default
+- `AvatarBaseSize.Lg` (40px)
+- `AvatarBaseSize.Xl` (48px)
+
+<Canvas of={AvatarBaseStories.Size} />
+
+### Children
+
+AvatarBase can contain different types of content including text, images, and icons:
+
+<Canvas of={AvatarBaseStories.Children} />
+
+### ClassName
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+<Canvas of={AvatarBaseStories.ClassName} />
+
+Example:
+
+```tsx
+// Adding new styles
+<AvatarBase className="my-4 mx-2">A</AvatarBase>
+
+// Overriding default styles
+<AvatarBase className="bg-success-default text-success-inverse">S</AvatarBase>
+```
+
+### Style
+
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with className alone. For static styles, prefer using className with Tailwind classes.
+
+## Component API
+
+<Controls of={AvatarBaseStories.Default} />
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/src/components/avatar-base/README.mdx
+++ b/packages/design-system-react/src/components/avatar-base/README.mdx
@@ -7,11 +7,9 @@ import * as AvatarBaseStories from './AvatarBase.stories';
 The AvatarBase is the base component for avatars
 
 ```tsx
-import { AvatarBase, Text } from '@metamask/design-system-react';
+import { AvatarBase } from '@metamask/design-system-react';
 
-<AvatarBase>
-  <Text>A</Text>
-</AvatarBase>;
+<AvatarBase fallbackText="A" />;
 ```
 
 <Canvas of={AvatarBaseStories.Default} />
@@ -37,11 +35,23 @@ AvatarBase supports five sizes:
 - `AvatarBaseSize.Lg` (40px)
 - `AvatarBaseSize.Xl` (48px)
 
+Each size automatically maps to an appropriate text size for the fallback text.
+
 <Canvas of={AvatarBaseStories.Size} />
+
+### Fallback Text
+
+The `fallbackText` prop provides a simple way to display text within the avatar. The text size automatically adjusts based on the avatar size.
+
+<Canvas of={AvatarBaseStories.FallbackText} />
+
+You can customize the appearance of the fallback text using `fallbackTextProps`:
+
+<Canvas of={AvatarBaseStories.FallbackTextWithProps} />
 
 ### Children
 
-AvatarBase can contain different types of content including text, images, and icons:
+While `fallbackText` is the recommended way to display text, AvatarBase can also contain custom content like images and icons:
 
 <Canvas of={AvatarBaseStories.Children} />
 
@@ -56,14 +66,14 @@ Example:
 
 ```tsx
 // Adding new styles
-<AvatarBase className="my-4 mx-2">
-  <Text>A</Text>
-</AvatarBase>
+<AvatarBase fallbackText="A" className="my-4 mx-2" />
 
 // Overriding default styles
-<AvatarBase className="bg-success-default">
-  <Text color={TextColor.SuccessInverse}>A</Text>
-</AvatarBase>
+<AvatarBase
+  fallbackText="A"
+  className="bg-success-default"
+  fallbackTextProps={{ color: TextColor.SuccessInverse }}
+/>
 ```
 
 ### Style

--- a/packages/design-system-react/src/components/avatar-base/README.mdx
+++ b/packages/design-system-react/src/components/avatar-base/README.mdx
@@ -7,9 +7,11 @@ import * as AvatarBaseStories from './AvatarBase.stories';
 The AvatarBase is the base component for avatars
 
 ```tsx
-import { AvatarBase } from '@metamask/design-system-react';
+import { AvatarBase, Text } from '@metamask/design-system-react';
 
-<AvatarBase>A</AvatarBase>;
+<AvatarBase>
+  <Text>A</Text>
+</AvatarBase>;
 ```
 
 <Canvas of={AvatarBaseStories.Default} />
@@ -43,23 +45,25 @@ AvatarBase can contain different types of content including text, images, and ic
 
 <Canvas of={AvatarBaseStories.Children} />
 
-### ClassName
+### Class Name
 
 Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
 
 - Add new styles that don't exist in the default component
 - Override the component's default styles when needed
 
-<Canvas of={AvatarBaseStories.ClassName} />
-
 Example:
 
 ```tsx
 // Adding new styles
-<AvatarBase className="my-4 mx-2">A</AvatarBase>
+<AvatarBase className="my-4 mx-2">
+  <Text>A</Text>
+</AvatarBase>
 
 // Overriding default styles
-<AvatarBase className="bg-success-default text-success-inverse">S</AvatarBase>
+<AvatarBase className="bg-success-default">
+  <Text color={TextColor.SuccessInverse}>A</Text>
+</AvatarBase>
 ```
 
 ### Style

--- a/packages/design-system-react/src/components/avatar-base/README.mdx
+++ b/packages/design-system-react/src/components/avatar-base/README.mdx
@@ -16,6 +16,15 @@ import { AvatarBase } from '@metamask/design-system-react';
 
 ## Props
 
+### Shape
+
+AvatarBase supports two shapes:
+
+- `AvatarBaseShape.Circle` (fully rounded) - default
+- `AvatarBaseShape.Square` (slightly rounded corners)
+
+<Canvas of={AvatarBaseStories.Shape} />
+
 ### Size
 
 AvatarBase supports five sizes:

--- a/packages/design-system-react/src/components/avatar-base/index.ts
+++ b/packages/design-system-react/src/components/avatar-base/index.ts
@@ -1,0 +1,3 @@
+export { AvatarBase } from './AvatarBase';
+export type { AvatarBaseProps } from './AvatarBase.types';
+export { AvatarBaseSize, AvatarBaseShape } from './AvatarBase.types';


### PR DESCRIPTION
## **Description**

This PR adds the initial `AvatarBase` component to design system react. 

Key features:
1. Five size variants: xs (16px), sm (24px), md (32px), lg (40px), and xl (48px)
2. Support for different content types: text, images, and icons
3. Customizable styling through className prop using Tailwind classes
4. Built-in accessibility features through Radix UI's Slot primitive
5. Comprehensive test coverage and Storybook documentation

## **Related issues**

Fixes: #359 

## **Manual testing steps**

1. Run Storybook locally (`yarn storybook`)
2. Navigate to React Components/AvatarBase
3. Check the docs align with component and make sense
4. Verify controls work

## **Screenshots/Recordings**

### **Before**
N/A - New component

### **After**



https://github.com/user-attachments/assets/51ef4b5c-8f41-4f67-909d-cc6033a8acaf




## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests (unit tests and Storybook stories)
- [x] I've documented my code using JSDoc format
- [ ] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.