### PR TITLE
chore: spreading props in the text component for design system react

### DIFF
--- a/packages/design-system-react/src/components/text/Text.test.tsx
+++ b/packages/design-system-react/src/components/text/Text.test.tsx
@@ -14,6 +14,15 @@ import {
 import { TEXT_CLASS_MAP } from './Text.constants';
 
 describe('Text Component', () => {
+  it('renders with props applied to the underlying element', () => {
+    render(
+      <Text variant={TextVariant.BodyMd} data-testid="text">
+        Hello, World!
+      </Text>,
+    );
+    expect(screen.getByTestId('text')).toBeInTheDocument();
+  });
+
   it('renders children correctly', () => {
     render(<Text variant={TextVariant.BodyMd}>Hello, World!</Text>);
     expect(screen.getByText('Hello, World!')).toBeInTheDocument();

--- a/packages/design-system-react/src/components/text/Text.tsx
+++ b/packages/design-system-react/src/components/text/Text.tsx
@@ -19,6 +19,7 @@ export const Text: React.FC<TextProps> = ({
   asChild,
   color = TextColor.TextDefault,
   style,
+  ...props
 }) => {
   // When asChild is true, use Radix Slot to merge props onto the child component.
   // Otherwise, render the semantic HTML element mapped to this variant (e.g. h1-h4, p).
@@ -37,7 +38,7 @@ export const Text: React.FC<TextProps> = ({
   );
 
   return (
-    <Component className={mergedClassName} style={style}>
+    <Component className={mergedClassName} style={style} {...props}>
       {children}
     </Component>
   );

--- a/packages/design-system-react/src/components/text/Text.types.ts
+++ b/packages/design-system-react/src/components/text/Text.types.ts
@@ -60,6 +60,10 @@ export type TextProps = {
    * @default TextColor.TextDefault
    */
   color?: TextColor;
+  /**
+   * Optional prop for testing purposes
+   */
+  'data-testid'?: string;
 };
 
 export enum TextVariant {


### PR DESCRIPTION
## **Description**

This PR adds support for spreading additional HTML attributes to the Text component, allowing for better component flexibility and testing capabilities. The changes include:

1. Adding spread operator support in the Text component to pass through additional props
2. Adding a test case to verify props are correctly applied to the underlying element
3. Adding data-test id

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Import the Text component
2. Verify that HTML attributes (like data-testid) can be passed and are applied correctly
4. Verify existing functionality continues to work as expected

## **Screenshots/Recordings**

N/A - Component behavior change only

### **Before**

HTML attributes could not be passed through to the underlying element

### **After**

HTML attributes can now be passed through and applied to the underlying element

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.