### PR TITLE
feat: adding avatar token to design system react

### DIFF
--- a/packages/design-system-react/src/components/avatar-token/AvatarToken.stories.tsx
+++ b/packages/design-system-react/src/components/avatar-token/AvatarToken.stories.tsx
@@ -1,0 +1,142 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { AvatarToken } from './AvatarToken';
+import { AvatarTokenSize } from '.';
+import README from './README.mdx';
+
+const meta: Meta<typeof AvatarToken> = {
+  title: 'React Components/AvatarToken',
+  component: AvatarToken,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    name: {
+      control: 'text',
+      description:
+        'Required name of the token. Used as alt text for image and first letter is used as fallback if no fallbackText provided',
+    },
+    src: {
+      control: 'text',
+      description:
+        'Optional URL for the token image. When provided, displays the image instead of fallback text',
+    },
+    imageProps: {
+      control: 'object',
+      description:
+        'Optional prop to pass to the underlying img element. Useful for overriding the default alt text',
+    },
+    size: {
+      control: 'select',
+      options: Object.keys(AvatarTokenSize),
+      mapping: AvatarTokenSize,
+      description:
+        'Optional prop to control the size of the avatar. Defaults to AvatarTokenSize.Md',
+    },
+    fallbackText: {
+      control: 'text',
+      description:
+        'Optional text to display when no image is provided. If not provided, first letter of name will be used',
+    },
+    fallbackTextProps: {
+      control: 'object',
+      description:
+        'Optional props to be passed to the Text component when rendering fallback text. Only used when src is not provided',
+    },
+    className: {
+      control: 'text',
+      description:
+        'Optional additional CSS classes to be applied to the component',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AvatarToken>;
+
+export const Default: Story = {
+  args: {
+    src: 'https://cryptologos.cc/logos/ethereum-eth-logo.png',
+    name: 'Ethereum',
+    fallbackText: 'ETH',
+  },
+};
+
+export const Src: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="ETH"
+        src="https://cryptologos.cc/logos/ethereum-eth-logo.png"
+      />
+      <AvatarToken
+        name="Bitcoin"
+        fallbackText="BTC"
+        src="https://cryptologos.cc/logos/bitcoin-btc-logo.png"
+      />
+      <AvatarToken
+        name="USDC"
+        fallbackText="USDC"
+        src="https://cryptologos.cc/logos/usd-coin-usdc-logo.png"
+      />
+    </div>
+  ),
+};
+
+export const Name: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <AvatarToken
+        name="Ethereum"
+        src="https://cryptologos.cc/logos/ethereum-eth-logo.png"
+      />
+      <AvatarToken
+        name="Bitcoin"
+        src="https://cryptologos.cc/logos/bitcoin-btc-logo.png"
+      />
+      <AvatarToken name="USDC" />
+    </div>
+  ),
+};
+
+export const FallbackText: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <AvatarToken name="Ethereum" fallbackText="ETH" />
+      <AvatarToken name="Bitcoin" fallbackText="BTC" />
+      <AvatarToken name="USDC" fallbackText="USDC" />
+    </div>
+  ),
+};
+
+export const Size: Story = {
+  render: () => (
+    <div className="flex gap-2 items-center">
+      <AvatarToken name="Ethereum" fallbackText="E" size={AvatarTokenSize.Xs} />
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="ETH"
+        size={AvatarTokenSize.Sm}
+      />
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="ETH"
+        size={AvatarTokenSize.Md}
+      />
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="ETH"
+        size={AvatarTokenSize.Lg}
+      />
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="ETH"
+        size={AvatarTokenSize.Xl}
+      />
+    </div>
+  ),
+};

--- a/packages/design-system-react/src/components/avatar-token/AvatarToken.test.tsx
+++ b/packages/design-system-react/src/components/avatar-token/AvatarToken.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { TextColor } from '..';
+import { AvatarToken } from './AvatarToken';
+import { AvatarTokenSize } from '.';
+
+describe('AvatarToken', () => {
+  it('renders image when src is provided', () => {
+    render(
+      <AvatarToken src="test-image.jpg" name="Ethereum" fallbackText="Eth" />,
+    );
+
+    const img = screen.getByRole('img');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'test-image.jpg');
+    expect(img).toHaveAttribute('alt', 'Ethereum');
+  });
+
+  it('renders fallbackText when src is not provided', () => {
+    render(<AvatarToken name="Ethereum" fallbackText="Eth" />);
+    expect(screen.getByText('Eth')).toBeInTheDocument();
+  });
+
+  it('applies fallbackTextProps to Text component', () => {
+    render(
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="Eth"
+        fallbackTextProps={{
+          color: TextColor.TextAlternative,
+          className: 'test-class',
+          'data-testid': 'fallback-text',
+        }}
+      />,
+    );
+
+    const text = screen.getByTestId('fallback-text');
+    expect(text).toHaveClass('text-alternative', 'test-class');
+  });
+
+  it('applies custom className to root element', () => {
+    render(
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="Eth"
+        className="custom-class"
+        data-testid="avatar"
+      />,
+    );
+
+    const avatar = screen.getByTestId('avatar');
+    expect(avatar).toHaveClass('custom-class');
+  });
+
+  it('passes through additional image props when src is provided', () => {
+    render(
+      <AvatarToken
+        src="test-image.jpg"
+        name="Ethereum"
+        fallbackText="Eth"
+        imageProps={{
+          loading: 'lazy',
+        }}
+      />,
+    );
+
+    screen.debug();
+
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('loading', 'lazy');
+  });
+
+  it('applies size classes correctly', () => {
+    const { rerender } = render(
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="Eth"
+        size={AvatarTokenSize.Xs}
+        data-testid="avatar"
+      />,
+    );
+
+    let avatar = screen.getByTestId('avatar');
+    expect(avatar).toHaveClass('h-4 w-4');
+
+    rerender(
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="Eth"
+        size={AvatarTokenSize.Sm}
+        data-testid="avatar"
+      />,
+    );
+    avatar = screen.getByTestId('avatar');
+    expect(avatar).toHaveClass('h-6 w-6');
+
+    rerender(
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="Eth"
+        size={AvatarTokenSize.Md}
+        data-testid="avatar"
+      />,
+    );
+    avatar = screen.getByTestId('avatar');
+    expect(avatar).toHaveClass('h-8 w-8');
+
+    rerender(
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="Eth"
+        size={AvatarTokenSize.Lg}
+        data-testid="avatar"
+      />,
+    );
+    avatar = screen.getByTestId('avatar');
+    expect(avatar).toHaveClass('h-10 w-10');
+
+    rerender(
+      <AvatarToken
+        name="Ethereum"
+        fallbackText="Eth"
+        size={AvatarTokenSize.Xl}
+        data-testid="avatar"
+      />,
+    );
+    avatar = screen.getByTestId('avatar');
+    expect(avatar).toHaveClass('h-12 w-12');
+  });
+
+  it('uses medium size by default', () => {
+    render(<AvatarToken name="Ethereum" data-testid="avatar" />);
+    const avatar = screen.getByTestId('avatar');
+    expect(avatar).toHaveClass('h-8 w-8');
+  });
+
+  it('uses name as alt text when fallbackText is not provided', () => {
+    render(<AvatarToken src="test-image.jpg" name="Ethereum" />);
+
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'Ethereum');
+  });
+
+  it('uses first letter of name as fallback text when fallbackText is not provided', () => {
+    render(<AvatarToken name="Ethereum" />);
+    expect(screen.getByText('E')).toBeInTheDocument();
+  });
+
+  it('prioritizes fallbackText over name for both alt text and fallback display', () => {
+    const { rerender } = render(
+      <AvatarToken
+        src="test-image.jpg"
+        name="Ethereum"
+        fallbackText="ETH"
+        imageProps={{ alt: 'ETH' }}
+      />,
+    );
+
+    let img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'ETH');
+
+    rerender(<AvatarToken name="Ethereum" fallbackText="ETH" />);
+
+    expect(screen.getByText('ETH')).toBeInTheDocument();
+  });
+});
+
+describe('text display and alt text logic', () => {
+  it('uses first letter of name when fallbackText is not provided', () => {
+    render(<AvatarToken name="Ethereum" />);
+    expect(screen.getByText('E')).toBeInTheDocument();
+  });
+
+  it('uses fallbackText for display when provided', () => {
+    render(<AvatarToken name="Ethereum" fallbackText="ETH" />);
+    expect(screen.getByText('ETH')).toBeInTheDocument();
+  });
+
+  it('uses name for alt text when src is provided', () => {
+    render(<AvatarToken name="Ethereum" src="test.jpg" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'Ethereum');
+  });
+
+  it('uses name for alt text even when fallbackText is provided', () => {
+    render(<AvatarToken name="Ethereum" fallbackText="ETH" src="test.jpg" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'Ethereum');
+  });
+
+  it('allows alt text override through imageProps', () => {
+    render(
+      <AvatarToken
+        name="Ethereum"
+        src="test.jpg"
+        imageProps={{ alt: 'Custom Alt' }}
+      />,
+    );
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'Custom Alt');
+  });
+
+  it('uses empty string for display text when name is not provided', () => {
+    // @ts-expect-error testing invalid props
+    render(<AvatarToken data-testid="avatar" />);
+    const base = screen.getByTestId('avatar');
+    expect(base.querySelector('span')).toHaveTextContent('');
+  });
+
+  it('uses default "Token logo" for alt text when name is not provided', () => {
+    // @ts-expect-error testing invalid props
+    render(<AvatarToken src="test.jpg" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'Token logo');
+  });
+});

--- a/packages/design-system-react/src/components/avatar-token/AvatarToken.tsx
+++ b/packages/design-system-react/src/components/avatar-token/AvatarToken.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { AvatarBase, AvatarBaseShape, AvatarBaseSize } from '../avatar-base';
+import type { AvatarTokenProps } from './AvatarToken.types';
+
+export const AvatarToken = React.forwardRef<HTMLDivElement, AvatarTokenProps>(
+  (
+    {
+      src,
+      name,
+      fallbackText,
+      fallbackTextProps,
+      className,
+      size = AvatarBaseSize.Md,
+      imageProps,
+      ...props
+    },
+    ref,
+  ) => {
+    const displayText = fallbackText || (name ? name[0] : '');
+    const altText = name || 'Token logo'; // TBC: Add localization for default text
+
+    return (
+      <AvatarBase
+        ref={ref}
+        shape={AvatarBaseShape.Circle}
+        size={size}
+        className={className}
+        fallbackText={displayText}
+        fallbackTextProps={fallbackTextProps}
+        {...props}
+      >
+        {src && (
+          <img
+            src={src}
+            alt={altText}
+            className="w-full h-full object-cover"
+            {...imageProps}
+          />
+        )}
+      </AvatarBase>
+    );
+  },
+);
+
+AvatarToken.displayName = 'AvatarToken';

--- a/packages/design-system-react/src/components/avatar-token/AvatarToken.types.ts
+++ b/packages/design-system-react/src/components/avatar-token/AvatarToken.types.ts
@@ -1,0 +1,46 @@
+import type { ComponentProps } from 'react';
+
+import type { TextProps } from '../text';
+import { AvatarTokenSize } from '.';
+
+export type AvatarTokenProps = Omit<
+  ComponentProps<'img'>,
+  'children' | 'size'
+> & {
+  /**
+   * Required name of the token
+   * Used as alt text for image and first letter is used as fallback if no fallbackText provided
+   */
+  name: string;
+  /**
+   * Optional URL for the token image
+   * When provided, displays the image instead of fallback text
+   */
+  src?: string;
+  /**
+   * Optional prop to pass to the underlying img element
+   * Useful for overriding the default alt text which is the token name
+   */
+  imageProps?: ComponentProps<'img'>;
+  /**
+   * Optional prop to control the size of the avatar
+   * @default AvatarTokenSize.Md
+   */
+  size?: AvatarTokenSize;
+  /**
+   * Optional text to display when no image is provided
+   * If not provided, first letter of name will be used
+   */
+  fallbackText?: string;
+  /**
+   * Optional props to be passed to the Text component when rendering fallback text
+   * Only used when src is not provided
+   */
+  fallbackTextProps?: Partial<
+    React.HTMLAttributes<HTMLSpanElement> & TextProps
+  >;
+  /**
+   * Optional additional CSS classes to be applied to the component
+   */
+  className?: string;
+};

--- a/packages/design-system-react/src/components/avatar-token/README.mdx
+++ b/packages/design-system-react/src/components/avatar-token/README.mdx
@@ -1,0 +1,103 @@
+import { Controls, Canvas } from '@storybook/blocks';
+
+import * as AvatarTokenStories from './AvatarToken.stories';
+
+# AvatarToken
+
+Avatar reserved for representing tokens
+
+```tsx
+import { AvatarToken } from '@metamask/design-system-react';
+
+<AvatarToken
+  name="Ethereum"
+  src="path/to/ethereum-logo.png"
+  fallbackText="ETH"
+/>;
+```
+
+<Canvas of={AvatarTokenStories.Default} />
+
+## Props
+
+### Name (required)
+
+The `name` prop is required and serves two purposes:
+
+- Used as alt text for the token image (unless overridden by `imageProps.alt`)
+- First letter is used as fallback display text when `fallbackText` is not provided
+
+<Canvas of={AvatarTokenStories.Name} />
+
+### Src (image source)
+
+The `src` prop is optional and specifies the URL of the token's logo image.
+
+<Canvas of={AvatarTokenStories.Src} />
+
+> Note: The `imageProps` prop allows you to customize the img element when `src` is provided. All standard HTML img attributes are supported and will be passed to the underlying img element when `src` is provided. This is useful for overriding the default alt text (which is the token name) when the AvatarToken is used as an accompaniment to an image.
+
+```tsx
+<AvatarToken
+  name="Ethereum"
+  src="path/to/ethereum-logo.png"
+  fallbackText="ETH"
+  imageProps={{ alt: 'Ethereum Logo', loading: 'lazy' }}
+/>
+```
+
+### Fallback Text
+
+The `fallbackText` prop is optional and is used for display text when no image is provided. If not provided, the first letter of `name` will be used.
+
+<Canvas of={AvatarTokenStories.FallbackText} />
+
+> Note: The `fallbackTextProps` prop allows you to customize the Text component used for the fallback display
+
+```tsx
+<AvatarToken
+  name="Ethereum"
+  fallbackText="ETH"
+  fallbackTextProps={{ color: TextColor.PrimaryDefault }}
+/>
+```
+
+### Size
+
+AvatarToken supports five sizes, each with a corresponding text variant for the fallback text:
+
+- `AvatarTokenSize.Xs` (16px) - uses TextVariant.BodyXs
+- `AvatarTokenSize.Sm` (24px) - uses TextVariant.BodyXs
+- `AvatarTokenSize.Md` (32px) - uses TextVariant.BodySm (default)
+- `AvatarTokenSize.Lg` (40px) - uses TextVariant.BodyMd
+- `AvatarTokenSize.Xl` (48px) - uses TextVariant.BodyMd
+
+<Canvas of={AvatarTokenStories.Size} />
+
+### Class Name
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default
+classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+Example:
+
+```tsx
+// Adding new styles
+<AvatarToken
+  name="Ethereum"
+  src="path/to/ethereum-logo.png"
+  fallbackText="ETH"
+  className="my-4 mx-2"
+/>
+```
+
+## Component API
+
+<Controls of={AvatarTokenStories.Default} />
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/src/components/avatar-token/README.mdx
+++ b/packages/design-system-react/src/components/avatar-token/README.mdx
@@ -64,13 +64,15 @@ The `fallbackText` prop is optional and is used for display text when no image i
 
 ### Size
 
-AvatarToken supports five sizes, each with a corresponding text variant for the fallback text:
+AvatarToken supports five sizes:
 
-- `AvatarTokenSize.Xs` (16px) - uses TextVariant.BodyXs
-- `AvatarTokenSize.Sm` (24px) - uses TextVariant.BodyXs
-- `AvatarTokenSize.Md` (32px) - uses TextVariant.BodySm (default)
-- `AvatarTokenSize.Lg` (40px) - uses TextVariant.BodyMd
-- `AvatarTokenSize.Xl` (48px) - uses TextVariant.BodyMd
+- `AvatarTokenSize.Xs` (16px)
+- `AvatarTokenSize.Sm` (24px)
+- `AvatarTokenSize.Md` (32px) - default
+- `AvatarTokenSize.Lg` (40px)
+- `AvatarTokenSize.Xl` (48px)
+
+The fallback text uses TextVariant.BodySm for all sizes to maintain consistency.
 
 <Canvas of={AvatarTokenStories.Size} />
 

--- a/packages/design-system-react/src/components/avatar-token/index.ts
+++ b/packages/design-system-react/src/components/avatar-token/index.ts
@@ -1,0 +1,3 @@
+export { AvatarToken } from './AvatarToken';
+export type { AvatarTokenProps } from './AvatarToken.types';
+export { AvatarBaseSize as AvatarTokenSize } from '../avatar-base';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -41,3 +41,6 @@ export type { AvatarBaseProps } from './avatar-base';
 
 export { AvatarNetwork, AvatarNetworkSize } from './avatar-network';
 export type { AvatarNetworkProps } from './avatar-network';
+
+export { AvatarToken, AvatarTokenSize } from './avatar-token';
+export type { AvatarTokenProps } from './avatar-token';


### PR DESCRIPTION
Has a dependency on `AvatarBase` https://github.com/MetaMask/metamask-design-system/pull/390

## **Description**

This PR adds the new AvatarToken component to design system react

Key features:
- Displays token logos with consistent sizing and styling
- Provides fallback text display when images are unavailable
- Supports multiple size variants
- Built on top of the AvatarBase component
- Fully tested and documented

## **Related issues**

Fixes: #364

## **Manual testing steps**

1. Run Storybook (`yarn storybook`)
2. Navigate to React Components/AvatarToken
3. Test different component variations:
   - With and without images
   - Different sizes
   - Fallback text behavior
   - Custom className application
4. Verify responsive behavior and image handling
5. Check accessibility features (alt text, etc.)

## **Screenshots/Recordings**

### **Before**
N/A (New component)

### **After**

https://github.com/user-attachments/assets/81103ad2-7124-4971-92fb-fdb799ecac9f


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included comprehensive tests for the AvatarToken component
- [x] I've documented the code using [JSDoc](https://jsdoc.app/) format
- [x] I've applied the right labels on the PR
- [x] I've ensured the component meets accessibility standards

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR in Storybook
- [ ] I confirm that this PR addresses all acceptance criteria for the AvatarToken component
- [ ] I've verified the component works correctly with and without images
- [ ] I've checked that the component integrates properly with the existing design system