### PR TITLE
chore: avatar base react fallback updates

### DIFF
--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
@@ -7,3 +7,14 @@ export const AVATAR_BASE_SIZE_CLASS_MAP: Record<AvatarBaseSize, string> = {
   [AvatarBaseSize.Lg]: 'h-10 w-10',
   [AvatarBaseSize.Xl]: 'h-12 w-12',
 };
+
+export const AVATAR_BASE_SQUARE_BORDER_RADIUS_MAP: Record<
+  AvatarBaseSize,
+  string
+> = {
+  [AvatarBaseSize.Xs]: 'rounded-[4px]',
+  [AvatarBaseSize.Sm]: 'rounded-[6px]',
+  [AvatarBaseSize.Md]: 'rounded-[8px]',
+  [AvatarBaseSize.Lg]: 'rounded-[10px]',
+  [AvatarBaseSize.Xl]: 'rounded-[12px]',
+};

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
@@ -12,9 +12,9 @@ export const AVATAR_BASE_SQUARE_BORDER_RADIUS_MAP: Record<
   AvatarBaseSize,
   string
 > = {
-  [AvatarBaseSize.Xs]: 'rounded-[4px]',
-  [AvatarBaseSize.Sm]: 'rounded-[6px]',
-  [AvatarBaseSize.Md]: 'rounded-[8px]',
-  [AvatarBaseSize.Lg]: 'rounded-[10px]',
-  [AvatarBaseSize.Xl]: 'rounded-[12px]',
+  [AvatarBaseSize.Xs]: 'rounded-sm', // 4px
+  [AvatarBaseSize.Sm]: 'rounded-md', // 6px
+  [AvatarBaseSize.Md]: 'rounded-lg', // 8px
+  [AvatarBaseSize.Lg]: 'rounded-[10px]', // 10px (No tailwind class for this)
+  [AvatarBaseSize.Xl]: 'rounded-xl', // 12px
 };

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.constants.ts
@@ -1,5 +1,4 @@
 import { AvatarBaseSize } from './AvatarBase.types';
-import { TextVariant } from '../text';
 
 export const AVATAR_BASE_SIZE_CLASS_MAP: Record<AvatarBaseSize, string> = {
   [AvatarBaseSize.Xs]: 'h-4 w-4',
@@ -7,15 +6,4 @@ export const AVATAR_BASE_SIZE_CLASS_MAP: Record<AvatarBaseSize, string> = {
   [AvatarBaseSize.Md]: 'h-8 w-8',
   [AvatarBaseSize.Lg]: 'h-10 w-10',
   [AvatarBaseSize.Xl]: 'h-12 w-12',
-};
-
-export const AVATAR_BASE_SIZE_TO_TEXT_VARIANT_MAP: Record<
-  AvatarBaseSize,
-  TextVariant
-> = {
-  [AvatarBaseSize.Xs]: TextVariant.BodyXs,
-  [AvatarBaseSize.Sm]: TextVariant.BodyXs,
-  [AvatarBaseSize.Md]: TextVariant.BodySm,
-  [AvatarBaseSize.Lg]: TextVariant.BodyMd,
-  [AvatarBaseSize.Xl]: TextVariant.BodyMd,
 };

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.stories.tsx
@@ -81,27 +81,27 @@ export const Size: Story = {
         <AvatarBase
           shape={AvatarBaseShape.Square}
           size={AvatarBaseSize.Xs}
-          fallbackText="XS"
+          fallbackText="Xs"
         />
         <AvatarBase
           shape={AvatarBaseShape.Square}
           size={AvatarBaseSize.Sm}
-          fallbackText="SM"
+          fallbackText="Sm"
         />
         <AvatarBase
           shape={AvatarBaseShape.Square}
           size={AvatarBaseSize.Md}
-          fallbackText="MD"
+          fallbackText="Md"
         />
         <AvatarBase
           shape={AvatarBaseShape.Square}
           size={AvatarBaseSize.Lg}
-          fallbackText="LG"
+          fallbackText="Lg"
         />
         <AvatarBase
           shape={AvatarBaseShape.Square}
           size={AvatarBaseSize.Xl}
-          fallbackText="XL"
+          fallbackText="Xl"
         />
       </div>
     </div>

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
@@ -146,7 +146,7 @@ describe('AvatarBase', () => {
     expect(fallbackText).toHaveClass('text-primary-default');
   });
 
-  it('uses correct text variant based on size', () => {
+  it('uses BodySm text variant for all sizes', () => {
     const { rerender } = render(
       <AvatarBase
         size={AvatarBaseSize.Xs}
@@ -157,7 +157,7 @@ describe('AvatarBase', () => {
 
     // Test XS size
     let fallbackText = screen.getByTestId('fallback-text');
-    expect(fallbackText).toHaveClass('text-s-body-xs');
+    expect(fallbackText).toHaveClass('text-s-body-sm');
 
     // Test MD size
     rerender(
@@ -179,6 +179,6 @@ describe('AvatarBase', () => {
       />,
     );
     fallbackText = screen.getByTestId('fallback-text');
-    expect(fallbackText).toHaveClass('text-s-body-md');
+    expect(fallbackText).toHaveClass('text-s-body-sm');
   });
 });

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
@@ -111,7 +111,34 @@ describe('AvatarBase', () => {
       />,
     );
     avatar = screen.getByTestId('avatar');
-    expect(avatar).toHaveClass('rounded-[8px]');
+    expect(avatar).toHaveClass('rounded-lg');
+  });
+
+  it('applies correct border radius for all square sizes', () => {
+    const { rerender } = render(
+      <AvatarBase
+        shape={AvatarBaseShape.Square}
+        size={AvatarBaseSize.Xs}
+        fallbackText="A"
+        data-testid="avatar"
+      />,
+    );
+
+    // Test all sizes
+    Object.entries(AVATAR_BASE_SQUARE_BORDER_RADIUS_MAP).forEach(
+      ([size, borderRadiusClass]) => {
+        rerender(
+          <AvatarBase
+            shape={AvatarBaseShape.Square}
+            size={size as AvatarBaseSize}
+            fallbackText="A"
+            data-testid="avatar"
+          />,
+        );
+        const avatar = screen.getByTestId('avatar');
+        expect(avatar).toHaveClass(borderRadiusClass);
+      },
+    );
   });
 
   it('uses circle shape by default', () => {

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.test.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 
 import { TextColor } from '../text';
 import { AvatarBase } from './AvatarBase';
-import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
+import {
+  AVATAR_BASE_SIZE_CLASS_MAP,
+  AVATAR_BASE_SQUARE_BORDER_RADIUS_MAP,
+} from './AvatarBase.constants';
 import { AvatarBaseSize, AvatarBaseShape } from './AvatarBase.types';
 
 describe('AvatarBase', () => {
@@ -102,12 +105,13 @@ describe('AvatarBase', () => {
     rerender(
       <AvatarBase
         shape={AvatarBaseShape.Square}
+        size={AvatarBaseSize.Md}
         fallbackText="A"
         data-testid="avatar"
       />,
     );
     avatar = screen.getByTestId('avatar');
-    expect(avatar).toHaveClass('rounded-lg');
+    expect(avatar).toHaveClass('rounded-[8px]');
   });
 
   it('uses circle shape by default', () => {

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
@@ -41,7 +41,7 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
         {children || (
           <Text
             variant={TextVariant.BodySm}
-            fontWeight={FontWeight.Bold}
+            fontWeight={FontWeight.Medium}
             asChild
             {...fallbackTextProps}
           >

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
@@ -2,11 +2,8 @@ import { Slot } from '@radix-ui/react-slot';
 import React from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
-import { Text, FontWeight } from '..';
-import {
-  AVATAR_BASE_SIZE_CLASS_MAP,
-  AVATAR_BASE_SIZE_TO_TEXT_VARIANT_MAP,
-} from './AvatarBase.constants';
+import { Text, FontWeight, TextVariant } from '..';
+import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
 import type { AvatarBaseProps } from './AvatarBase.types';
 import { AvatarBaseShape, AvatarBaseSize } from './AvatarBase.types';
 
@@ -43,7 +40,7 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
       <Component ref={ref} className={mergedClassName} style={style} {...props}>
         {children || (
           <Text
-            variant={AVATAR_BASE_SIZE_TO_TEXT_VARIANT_MAP[size]}
+            variant={TextVariant.BodySm}
             fontWeight={FontWeight.Bold}
             asChild
             {...fallbackTextProps}

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
@@ -2,7 +2,7 @@ import { Slot } from '@radix-ui/react-slot';
 import React from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
-import { Text, FontWeight, TextVariant } from '..';
+import { Text, FontWeight, TextVariant, TextColor } from '..';
 import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
 import type { AvatarBaseProps } from './AvatarBase.types';
 import { AvatarBaseShape, AvatarBaseSize } from './AvatarBase.types';
@@ -42,7 +42,9 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
           <Text
             variant={TextVariant.BodySm}
             fontWeight={FontWeight.Medium}
+            color={TextColor.TextMuted}
             asChild
+            className="uppercase"
             {...fallbackTextProps}
           >
             {/* asChild prop renders Text component as a span, it does not create an additional element */}

--- a/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/avatar-base/AvatarBase.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
 import { Text, FontWeight, TextVariant, TextColor } from '..';
-import { AVATAR_BASE_SIZE_CLASS_MAP } from './AvatarBase.constants';
+import {
+  AVATAR_BASE_SIZE_CLASS_MAP,
+  AVATAR_BASE_SQUARE_BORDER_RADIUS_MAP,
+} from './AvatarBase.constants';
 import type { AvatarBaseProps } from './AvatarBase.types';
 import { AvatarBaseShape, AvatarBaseSize } from './AvatarBase.types';
 
@@ -27,7 +30,9 @@ export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
     const mergedClassName = twMerge(
       // Base styles
       'inline-flex items-center justify-center',
-      shape === AvatarBaseShape.Circle ? 'rounded-full' : 'rounded-lg',
+      shape === AvatarBaseShape.Circle
+        ? 'rounded-full'
+        : AVATAR_BASE_SQUARE_BORDER_RADIUS_MAP[size],
       'bg-muted',
       'overflow-hidden',
       // Size

--- a/packages/design-system-react/src/components/avatar-base/README.mdx
+++ b/packages/design-system-react/src/components/avatar-base/README.mdx
@@ -35,13 +35,13 @@ AvatarBase supports five sizes:
 - `AvatarBaseSize.Lg` (40px)
 - `AvatarBaseSize.Xl` (48px)
 
-Each size automatically maps to an appropriate text size for the fallback text.
+The fallback text uses TextVariant.BodySm for all sizes to maintain consistency.
 
 <Canvas of={AvatarBaseStories.Size} />
 
 ### Fallback Text
 
-The `fallbackText` prop provides a simple way to display text within the avatar. The text size automatically adjusts based on the avatar size.
+The `fallbackText` prop provides a simple way to display text within the avatar. The text uses TextVariant.BodySm for consistent sizing across all avatar sizes.
 
 <Canvas of={AvatarBaseStories.FallbackText} />
 

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -35,3 +35,6 @@ export type { TextButtonProps } from './text-button';
 
 export { ButtonIcon } from './button-icon';
 export type { ButtonIconProps } from './button-icon';
+
+export { AvatarBase, AvatarBaseSize } from './avatar-base';
+export type { AvatarBaseProps } from './avatar-base';


### PR DESCRIPTION
## **Description**

This PR updates the AvatarBase component with the following changes:

1. **Text Consistency**:
   - All fallback text now uses `TextVariant.BodySm` consistently across all avatar sizes
   - Removed the `AVATAR_BASE_SIZE_TO_TEXT_VARIANT_MAP` constant
   - Updated tests to verify consistent text variant usage

2. **Styling Updates**:
   - Added `TextColor.TextMuted` for fallback text
   - Added `uppercase` class for fallback text
   - Updated font weight from `Bold` to `Medium`

3. **Square Border Radius**:
   - Added `AVATAR_BASE_SQUARE_BORDER_RADIUS_MAP` with specific radius values for each size
   - Updated the shape logic to use the new border radius map
   - Updated tests to verify the new border radius values

4. **Fallback Text Formatting**:
   - Updated storybook examples to use consistent text formatting (e.g., "Xs" instead of "XS") to test casing
   - Updated documentation to reflect the consistent text variant usage

## **Related issues**

Fixes: #411

## **Manual testing steps**

1. Go to the AvatarBase component in Storybook
2. Test different sizes (Xs, Sm, Md, Lg, Xl) with fallback text
3. Verify that:
   - All sizes show the same text variant (BodySm)
   - Text color is muted
   - Text is uppercase
   - Square avatars have the correct border radius for each size
4. Verify both circle and square shapes render correctly

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/c5b42062-a9b5-4b69-a865-98fde856f820

### **After**

https://github.com/user-attachments/assets/48529e89-6d92-426f-8122-3c4cf68dcd31

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
