### PR TITLE
chore: updating deprecated story name usage

### DIFF
--- a/packages/design-system-react-native/src/components/Text/Text.stories.tsx
+++ b/packages/design-system-react-native/src/components/Text/Text.stories.tsx
@@ -114,8 +114,8 @@ export const FontWeightStory: Story = {
       <Text fontWeight={FontWeight.Bold}>Bold (700)</Text>
     </View>
   ),
+  name: 'Font Weight',
 };
-FontWeightStory.storyName = 'Font Weight';
 
 export const FontStyleStory: Story = {
   render: () => (
@@ -124,5 +124,5 @@ export const FontStyleStory: Story = {
       <Text fontStyle={FontStyle.Italic}>Italic</Text>
     </View>
   ),
+  name: 'Font Style',
 };
-FontStyleStory.storyName = 'Font Style';

--- a/packages/design-system-react/src/components/text-button/TextButton.stories.tsx
+++ b/packages/design-system-react/src/components/text-button/TextButton.stories.tsx
@@ -93,7 +93,7 @@ export const TextVariantStory: Story = {
       </div>
     </div>
   ),
-  storyName: 'TextVariant',
+  name: 'TextVariant',
 };
 
 export const AsChild: Story = {

--- a/packages/design-system-react/src/components/text/Text.stories.tsx
+++ b/packages/design-system-react/src/components/text/Text.stories.tsx
@@ -180,8 +180,8 @@ export const FontWeightStory: Story = {
       <Text fontWeight={FontWeight.Bold}>Bold (700)</Text>
     </div>
   ),
+  name: 'Font Weight',
 };
-FontWeightStory.storyName = 'Font Weight';
 
 export const FontStyleStory: Story = {
   render: () => (
@@ -190,8 +190,8 @@ export const FontStyleStory: Story = {
       <Text fontStyle={FontStyle.Italic}>Italic</Text>
     </div>
   ),
+  name: 'Font Style',
 };
-FontStyleStory.storyName = 'Font Style';
 
 export const TextTransformStory: Story = {
   render: () => (
@@ -201,8 +201,8 @@ export const TextTransformStory: Story = {
       <Text textTransform={TextTransform.Capitalize}>capitalize</Text>
     </div>
   ),
+  name: 'Text Transform',
 };
-TextTransformStory.storyName = 'Text Transform';
 
 export const TextAlignStory: Story = {
   render: () => (
@@ -213,8 +213,8 @@ export const TextAlignStory: Story = {
       <Text textAlign={TextAlign.Justify}>Justify aligned</Text>
     </div>
   ),
+  name: 'Text Align',
 };
-TextAlignStory.storyName = 'Text Align';
 
 export const OverflowWrapStory: Story = {
   render: () => (
@@ -227,8 +227,8 @@ export const OverflowWrapStory: Story = {
       </Text>
     </div>
   ),
+  name: 'Overflow Wrap',
 };
-OverflowWrapStory.storyName = 'OverflowWrap';
 
 export const Ellipsis: Story = {
   render: () => (


### PR DESCRIPTION
## **Description**

This PR updates the Storybook story naming convention across multiple components to use the `name` property instead of `storyName`. This change aligns with the latest Storybook best practices and provides a more consistent API for story definitions.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run Storybook locally
2. Navigate to the Text component stories
3. Verify that all stories appear correctly with their proper names
4. Check that the Font Weight, Font Style, Text Transform, Text Align, and Overflow Wrap stories are properly labeled

## **Screenshots/Recordings**

### **Before**
![Screenshot 2025-02-04 at 5 43 39 PM](https://github.com/user-attachments/assets/580396b6-9541-44f0-9bf6-ce04a31aecdd)


### **After**
![Screenshot 2025-02-04 at 5 44 19 PM](https://github.com/user-attachments/assets/0af15203-fdf1-4755-837a-96512a1b4b40)

Updated stories still work as expected

https://github.com/user-attachments/assets/fa664cab-95b6-4434-99c7-589da7847701

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md))

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run Storybook, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.