### PR TITLE
fix: removing circular dependencies from avatar favicon

### DIFF
--- a/packages/design-system-react/src/components/avatar-favicon/AvatarFavicon.constants.ts
+++ b/packages/design-system-react/src/components/avatar-favicon/AvatarFavicon.constants.ts
@@ -1,0 +1,13 @@
+import { AvatarBaseSize } from '../avatar-base';
+import { AvatarFaviconSize } from './AvatarFavicon.types';
+
+export const AVATAR_FAVICON_TO_AVATAR_BASE_SIZE_MAP: Record<
+  AvatarFaviconSize,
+  AvatarBaseSize
+> = {
+  [AvatarFaviconSize.Xs]: AvatarBaseSize.Xs,
+  [AvatarFaviconSize.Sm]: AvatarBaseSize.Sm,
+  [AvatarFaviconSize.Md]: AvatarBaseSize.Md,
+  [AvatarFaviconSize.Lg]: AvatarBaseSize.Lg,
+  [AvatarFaviconSize.Xl]: AvatarBaseSize.Xl,
+};

--- a/packages/design-system-react/src/components/avatar-favicon/AvatarFavicon.tsx
+++ b/packages/design-system-react/src/components/avatar-favicon/AvatarFavicon.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { AvatarBase, AvatarBaseShape, AvatarBaseSize } from '../avatar-base';
 import type { AvatarFaviconProps } from './AvatarFavicon.types';
+import { AVATAR_FAVICON_TO_AVATAR_BASE_SIZE_MAP } from './AvatarFavicon.constants';
 
 export const AvatarFavicon = React.forwardRef<
   HTMLDivElement,
@@ -27,7 +28,7 @@ export const AvatarFavicon = React.forwardRef<
       <AvatarBase
         ref={ref}
         shape={AvatarBaseShape.Circle}
-        size={size}
+        size={AVATAR_FAVICON_TO_AVATAR_BASE_SIZE_MAP[size]}
         className={className}
         fallbackText={displayText}
         fallbackTextProps={fallbackTextProps}

--- a/packages/design-system-react/src/components/avatar-favicon/AvatarFavicon.types.ts
+++ b/packages/design-system-react/src/components/avatar-favicon/AvatarFavicon.types.ts
@@ -1,12 +1,32 @@
 import type { ComponentProps } from 'react';
 
 import type { TextProps } from '../text';
-import { AvatarFaviconSize } from '.';
+import type { AvatarBaseProps } from '../avatar-base';
 
-export type AvatarFaviconProps = Omit<
-  ComponentProps<'img'>,
-  'children' | 'size'
-> & {
+export enum AvatarFaviconSize {
+  /**
+   * Extra small size (16px)
+   */
+  Xs = 'xs',
+  /**
+   * Small size (24px)
+   */
+  Sm = 'sm',
+  /**
+   * Medium size (32px)
+   */
+  Md = 'md',
+  /**
+   * Large size (40px)
+   */
+  Lg = 'lg',
+  /**
+   * Extra large size (48px)
+   */
+  Xl = 'xl',
+}
+
+export type AvatarFaviconProps = Omit<AvatarBaseProps, 'size'> & {
   /**
    * Required name of the dapp
    * Used as alt text for image and first letter is used as fallback if no fallbackText provided

--- a/packages/design-system-react/src/components/avatar-favicon/index.ts
+++ b/packages/design-system-react/src/components/avatar-favicon/index.ts
@@ -1,3 +1,3 @@
 export { AvatarFavicon } from './AvatarFavicon';
+export { AvatarFaviconSize } from './AvatarFavicon.types';
 export type { AvatarFaviconProps } from './AvatarFavicon.types';
-export { AvatarBaseSize as AvatarFaviconSize } from '../avatar-base';


### PR DESCRIPTION
## **Description**

This PR continues the work to remove circular dependencies by addressing the re-export of `AvatarBaseSize` as `AvatarFaviconSize`. Instead of re-exporting `AvatarBaseSize`, we now define a dedicated `AvatarFaviconSize` enum in the `AvatarFavicon.types.ts` file. This change:

1. Removes the circular dependency between `AvatarFavicon` and `AvatarBase`
2. Makes the `AvatarFavicon` component more self-contained
3. Improves maintainability by explicitly defining size values for `AvatarFavicon`

This is part of a larger effort to clean up circular dependencies in the design system.

## **Related issues**

Partially fixes: https://github.com/MetaMask/metamask-design-system/issues/445

## **Manual testing steps**

1. Run storybook and verify all `AvatarFavicon` stories render correctly
2. Run tests and ensure all tests pass
3. Check build process completes successfully

## **Screenshots/Recordings**

### **Before**
N/A (No visual changes)

### **After**
N/A (No visual changes)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.