### PR TITLE
chore: exporting missing types from index

### DIFF
--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -33,10 +33,10 @@ export type { ButtonProps } from './button';
 export { TextButton } from './text-button';
 export type { TextButtonProps } from './text-button';
 
-export { ButtonIcon } from './button-icon';
+export { ButtonIcon, ButtonIconSize } from './button-icon';
 export type { ButtonIconProps } from './button-icon';
 
-export { AvatarBase, AvatarBaseSize } from './avatar-base';
+export { AvatarBase, AvatarBaseSize, AvatarBaseShape } from './avatar-base';
 export type { AvatarBaseProps } from './avatar-base';
 
 export { AvatarNetwork, AvatarNetworkSize } from './avatar-network';


### PR DESCRIPTION
## **Description**

This PR adds missing type exports to the design-system-react package's main index.ts file. During an audit of component exports, we identified that some types and enums were defined but not properly exported, which could prevent consumers from accessing these types.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Import the newly exported types in a consuming project:
```typescript
import { AvatarBaseShape, ButtonIconSize } from '@metamask/design-system-react';
```
2. Verify the types are properly resolved and available
3. Verify existing type exports continue to work as expected

## **Screenshots/Recordings**

N/A - Type system changes only

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.