### PR TITLE
Small updates to DSR/blockies

### DIFF
--- a/packages/design-system-react-native/src/primitives/Blockies/Blockies.tsx
+++ b/packages/design-system-react-native/src/primitives/Blockies/Blockies.tsx
@@ -7,13 +7,13 @@ import { toDataUrl } from './Blockies.utilities';
 
 import type { BlockiesProps } from './Blockies.types';
 
-const Blockies = ({ address, size = 32, ...imageProps }: BlockiesProps) => {
+const Blockies = ({ address, size = 32, ...props }: BlockiesProps) => {
   return (
     <Image
       source={{ uri: toDataUrl(address) }}
       width={size}
       height={size}
-      {...imageProps}
+      {...props}
     />
   );
 };

--- a/packages/design-system-react/src/components/blockies/Blockies.stories.tsx
+++ b/packages/design-system-react/src/components/blockies/Blockies.stories.tsx
@@ -13,7 +13,16 @@ const meta: Meta<BlockiesProps> = {
       page: README,
     },
   },
+  args: {
+    address: '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8',
+    size: 32,
+  },
   argTypes: {
+    address: {
+      control: 'text',
+      description:
+        'Required address used as a unique identifier to generate the Blockies.',
+    },
     size: {
       control: 'number',
       description: 'Optional prop to control the size of the Blockies.',
@@ -21,13 +30,14 @@ const meta: Meta<BlockiesProps> = {
     className: {
       control: 'text',
       description:
-        'Optional prop for additional CSS classes to be applied to the AvatarBase component',
+        'Optional prop for additional CSS classes to be applied to the Blockies component.',
     },
   },
 };
 
 export default meta;
 type Story = StoryObj<BlockiesProps>;
+
 const sampleAccountAddresses = [
   '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8',
   '0xb9b81f6bd23B953c5257C3b5E2F0c03B07E944eB',
@@ -42,23 +52,27 @@ const sampleAccountAddresses = [
   '0xEC5CE72f2e18B0017C88F7B12d3308119C5Cf129',
   '0xeC56Da21c90Af6b50E4Ba5ec252bD97e735290fc',
 ];
-export const Default: Story = {
-  args: {
-    size: 32,
-  },
-  render: (args) => {
-    return (
-      <Blockies {...args} address={args.address || sampleAccountAddresses[0]} />
-    );
-  },
+
+export const Default: Story = {};
+
+export const Address: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      {sampleAccountAddresses.map((address) => (
+        <Blockies key={address} address={address} size={32} />
+      ))}
+    </div>
+  ),
 };
 
-export const SampleAddresses: Story = {
+export const Size: Story = {
   render: () => (
-    <div className="flex gap-2">
-      {sampleAccountAddresses.map((addressKey) => (
-        <Blockies address={addressKey} key={addressKey} size={32} />
-      ))}
+    <div className="flex items-center gap-4">
+      <Blockies address={sampleAccountAddresses[0]} size={16} />
+      <Blockies address={sampleAccountAddresses[1]} size={24} />
+      <Blockies address={sampleAccountAddresses[2]} size={32} />
+      <Blockies address={sampleAccountAddresses[3]} size={48} />
+      <Blockies address={sampleAccountAddresses[4]} size={64} />
     </div>
   ),
 };

--- a/packages/design-system-react/src/components/blockies/Blockies.test.tsx
+++ b/packages/design-system-react/src/components/blockies/Blockies.test.tsx
@@ -52,4 +52,12 @@ describe('Blockies', () => {
 
     expect(img).toHaveAttribute('title', 'Blockies Title');
   });
+
+  it('applies default alt text when no alt prop is provided', async () => {
+    render(<Blockies address={address} data-testid="blockies" />);
+
+    const img = await waitFor(() => screen.getByTestId('blockies'));
+
+    expect(img).toHaveAttribute('alt', `Blockies for ${address}`);
+  });
 });

--- a/packages/design-system-react/src/components/blockies/Blockies.tsx
+++ b/packages/design-system-react/src/components/blockies/Blockies.tsx
@@ -1,11 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import type { BlockiesProps } from './Blockies.types';
 
-export const Blockies = ({
-  address,
-  size = 32,
-  ...imageProps
-}: BlockiesProps) => {
+export const Blockies = ({ address, size = 32, ...props }: BlockiesProps) => {
   const [bloModule, setBloModule] = useState<{
     blo: (address: string) => string;
   } | null>(null);
@@ -25,7 +21,8 @@ export const Blockies = ({
       src={bloModule.blo(address)}
       height={size}
       width={size}
-      {...imageProps}
+      alt={`Blockies for ${address}`} // TODO: Add localization for this
+      {...props}
     />
   );
 };

--- a/packages/design-system-react/src/components/blockies/README.mdx
+++ b/packages/design-system-react/src/components/blockies/README.mdx
@@ -17,82 +17,71 @@ import { Blockies } from '@metamask/design-system-react';
 
 ### Address
 
-- **Type:** `string`
-- **Description:**  
-  The `address` prop is required and used as a unique identifier to generate the Blockies image.
+The `address` prop is required and used as a unique identifier to generate the Blockies image. Each address will generate a unique, deterministic pattern.
 
-<Canvas of={BlockiesStories.SampleAddresses} />
+<Canvas of={BlockiesStories.Address} />
 
 ### Size
 
-- **Type:** `number`
-- **Default:** `32`
-- **Description:**  
-  Controls the dimensions (both height and width) of the Blockies image in pixels.
+The `size` prop controls the dimensions (both height and width) of the Blockies image in pixels. The default size is 32px.
 
-### Additional Image Attributes
+<Canvas of={BlockiesStories.Size} />
 
-Blockies extends the standard HTML `<img>` attributes (e.g., `alt`, `title`, etc.). Any additional props provided will be passed directly to the underlying `<img>` element.
+### Accessibility
+
+The `alt` attribute provides alternative text for screen readers. By default, it includes the address for context (`Blockies for {address}`). You can override this with custom alt text:
+
+#### Default alt text
+
+```tsx
+// Default alt text
+<Blockies address="0x1234567890abcdef" />
+```
+
+```html
+<!-- Renders: -->
+<img alt="Blockies for 0x1234567890abcdef" />
+```
+
+#### Custom alt text
+
+```tsx
+// Custom alt text
+<Blockies address="0x1234567890abcdef" alt="User avatar for John Doe" />
+```
+
+```html
+<!-- Renders: -->
+<img alt="User avatar for John Doe" />
+```
+
+### Class Name
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed (Blockies has no default styles)
+
+Example:
+
+```tsx
+// Adding new styles
+<Blockies
+  address="0x1234567890abcdef1234567890abcdef12345678"
+  className="my-4 mx-2"
+/>
+```
+
+Note: When using `className` to override default styles, the custom classes will take precedence over the component's default classes.
+
+### Style
+
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with className alone. For static styles, prefer using className with Tailwind classes.
 
 ## Component API
 
 <Controls of={BlockiesStories.Default} />
 
-## Code Details
-
-Below is the implementation of the **Blockies** component:
-
-```tsx
-// Blockies.types
-import type { ComponentProps } from 'react';
-
-export type BlockiesProps = ComponentProps<'img'> & {
-  /**
-   * Required address used as a unique identifier to generate the Blockies.
-   */
-  address: string;
-  /**
-   * Optional prop to control the size of the Blockies.
-   */
-  size?: number;
-};
-
-// Blockies
-import React, { useState, useEffect } from 'react';
-import type { BlockiesProps } from './Blockies.types';
-
-export const Blockies = ({
-  address,
-  size = 32,
-  ...imageProps
-}: BlockiesProps) => {
-  const [bloModule, setBloModule] = useState<{
-    blo: (address: string) => string;
-  } | null>(null);
-
-  useEffect(() => {
-    import('blo')
-      .then((module) => setBloModule(module))
-      .catch((error) => console.error('Failed to load blo module:', error));
-  }, []);
-
-  if (!bloModule) {
-    return null;
-  }
-
-  return (
-    <img
-      src={bloModule.blo(address)}
-      height={size}
-      width={size}
-      {...imageProps}
-    />
-  );
-};
-
-Blockies.displayName = 'Blockies';
-```
-
 ## References
 
-- [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/tsconfig.build.json
+++ b/packages/design-system-react/tsconfig.build.json
@@ -7,7 +7,7 @@
     "jsx": "react",
     "types": ["react"],
     "lib": ["ES2020", "DOM"],
-    "skipLibCheck": true
+    "skipLibCheck": true // TODO: Remove this once we have a proper type definition for the blo module for blockies
   },
   "references": [],
   "include": ["./src"]


### PR DESCRIPTION
## **Description**

This PR makes some small updates to the DSR Blockies component by better aligning it with other React components in our design system and enhancing accessibility. The changes include:

1. Added default alt text for improved accessibility
2. Updated documentation to include an accessibility section
3. Added test coverage for alt text behavior

These changes make the Blockies component more consistent with our other components and improve the experience for users relying on screen readers.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to the Blockies component in Storybook
2. Verify that the default alt text appears when inspecting the component
3. Test with a screen reader to confirm the alt text is being read
4. Override the alt text with a custom value and verify it works as expected

## **Screenshots/Recordings**

### Before


https://github.com/user-attachments/assets/e60543df-c868-4ac4-8fbc-986215b0b29e



### After


https://github.com/user-attachments/assets/9e726781-8da0-4807-a06e-4087d9d7638f



## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests (added test for alt text behavior)
- [x] I've documented my code using JSDoc format (updated types and documentation)
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria