### PR TITLE
Release/4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -81,7 +81,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^5.1.0",
+    "@metamask/design-tokens": "^6.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "tailwindcss": "^3.0.0"

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -9,10 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0]
 
-### Uncategorized
+### Changed
 
-- chore: adding centra fonts to design system ([#499](https://github.com/MetaMask/metamask-design-system/pull/499))
-- chore: upgrade design tokens in monorepo ([#498](https://github.com/MetaMask/metamask-design-system/pull/498))
+- Updated to use new font family configuration from @metamask/design-tokens@6.0.0 ([#499](https://github.com/MetaMask/metamask-design-system/pull/499)). Note: This includes breaking changes in the design-tokens package - see the [@metamask/design-tokens migration guide](../design-tokens/MIGRATION.md#from-version-510-to-600) for details.
 
 ## [0.1.0]
 

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0]
+
+### Uncategorized
+
+- chore: adding centra fonts to design system ([#499](https://github.com/MetaMask/metamask-design-system/pull/499))
+- chore: upgrade design tokens in monorepo ([#498](https://github.com/MetaMask/metamask-design-system/pull/498))
+
 ## [0.1.0]
 
 ### Added
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.2.0...HEAD
+[0.2.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.1.0...@metamask/design-system-tailwind-preset@0.2.0
 [0.1.0]: https://github.com/MetaMask/metamask-design-system/releases/tag/@metamask/design-system-tailwind-preset@0.1.0

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-tailwind-preset",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Design System Tailwind CSS preset for MetaMask projects",
   "keywords": [
     "MetaMask",
@@ -57,7 +57,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^5.1.0",
+    "@metamask/design-tokens": "^6.0.0",
     "tailwindcss": "^3.0.0"
   },
   "engines": {

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,19 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking Changes
+## [6.0.0]
+
+### Changed
 
 - **BREAKING:** Replaced Euclid Circular B with Centra No1 as the primary font family ([#499](https://github.com/MetaMask/metamask-design-system/pull/499)). See the [migration guide](./MIGRATION.md#from-version-510-to-600) for details.
+
   - Removed `--font-family-euclid-circular-b` and `--font-family-roboto` CSS variables
   - Changed `--font-family-sans` to use Centra No1 with updated fallback chain
   - Updated font files from Euclid Circular B to Centra No1 (where 'Book' is the 400 weight variant)
   - Applications using the design system will need to update font imports and references
-
-## [6.0.0]
-
-### Uncategorized
-
-- chore: adding centra fonts to design system ([#499](https://github.com/MetaMask/metamask-design-system/pull/499))
 
 ## [5.1.0]
 

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **BREAKING:** Replaced Euclid Circular B with Centra No1 as the primary font family ([#499](https://github.com/MetaMask/metamask-design-system/pull/499)). See the [migration guide](./MIGRATION.md#from-version-510-to-600) for details.
+  - Removed `--font-family-euclid-circular-b` and `--font-family-roboto` CSS variables
+  - Changed `--font-family-sans` to use Centra No1 with updated fallback chain
+  - Updated font files from Euclid Circular B to Centra No1 (where 'Book' is the 400 weight variant)
+  - Applications using the design system will need to update font imports and references
+
+## [6.0.0]
+
+### Uncategorized
+
+- chore: adding centra fonts to design system ([#499](https://github.com/MetaMask/metamask-design-system/pull/499))
+
 ## [5.1.0]
 
 ### Changed
@@ -331,7 +345,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@5.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@6.0.0...HEAD
+[6.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@5.1.0...@metamask/design-tokens@6.0.0
 [5.1.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@5.0.0...@metamask/design-tokens@5.1.0
 [5.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.2.0...@metamask/design-tokens@5.0.0
 [4.2.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@4.1.0...@metamask/design-tokens@4.2.0

--- a/packages/design-tokens/MIGRATION.md
+++ b/packages/design-tokens/MIGRATION.md
@@ -2,9 +2,83 @@
 
 This guide provides detailed instructions for migrating your project from one version of the `@metamask/design-tokens` to another.
 
+- [From version 5.1.0 to 6.0.0](#from-version-510-to-600)
 - [From version 4.1.0 to 5.0.0](#from-version-410-to-500)
 - [From version 3.0.0 to 4.0.0](#from-version-300-to-400)
 - [From version 2.1.1 to 3.0.0](#from-version-211-to-300)
+
+## From version 5.1.0 to 6.0.0
+
+### Font Family Changes (Breaking Changes)
+
+In version 6.0.0, we've completely replaced Euclid Circular B with Centra No1 as our primary font family. This is a breaking change that affects both web and React Native applications.
+
+#### CSS Changes
+
+##### Removed
+
+```css
+--font-family-euclid-circular-b
+--font-family-roboto
+```
+
+##### Changed
+
+```css
+/* Before */
+--font-family-sans: 'Euclid Circular B', 'Roboto', sans-serif;
+
+/* After */
+--font-family-sans: 'Centra No1', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+```
+
+#### React Native Font Changes
+
+##### Before
+
+```javascript
+'EuclidCircularB-Regular';
+'EuclidCircularB-Bold';
+'EuclidCircularB-RegularItalic';
+'EuclidCircularB-BoldItalic';
+'EuclidCircularB-Medium';
+'EuclidCircularB-MediumItalic';
+```
+
+##### After
+
+```javascript
+'CentraNo1-Book';
+'CentraNo1-BookItalic';
+'CentraNo1-Medium';
+'CentraNo1-MediumItalic';
+'CentraNo1-Bold';
+'CentraNo1-BoldItalic';
+```
+
+#### Font Weight Mapping Changes
+
+The font weight tokens remain the same (400, 500, 700), but the font file names have changed:
+
+- Weight 400 uses 'CentraNo1-Book' (previously 'EuclidCircularB-Regular')
+- Weight 500 uses 'CentraNo1-Medium' (previously 'EuclidCircularB-Medium')
+- Weight 700 uses 'CentraNo1-Bold' (previously 'EuclidCircularB-Bold')
+
+### Migration Steps
+
+1. Update font imports to use Centra No1 instead of Euclid Circular B
+2. Replace all instances of `font-family: 'Euclid Circular B'` with `font-family: 'Centra No1'`
+3. Update font file references:
+   - Use 'CentraNo1-Book' for weight 400 (previously 'EuclidCircularB-Regular')
+   - Use 'CentraNo1-Medium' for weight 500
+   - Use 'CentraNo1-Bold' for weight 700
+4. For React Native applications:
+   - Update font file imports to use new Centra No1 .otf files
+   - Update font family references in your styles
+5. For web applications:
+   - Update font file imports to use new Centra No1 .woff2 files
+   - Update @font-face declarations
+6. Remove any references to Roboto font family as it's no longer included in the fallback chain
 
 ## From version 4.1.0 to 5.0.0
 

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3250,7 +3250,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^5.1.0
+    "@metamask/design-tokens": ^6.0.0
     react: ^16.0.0
     react-dom: ^16.0.0
     tailwindcss: ^3.0.0
@@ -3271,7 +3271,7 @@ __metadata:
     ts-jest: "npm:^29.2.5"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^5.1.0
+    "@metamask/design-tokens": ^6.0.0
     tailwindcss: ^3.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## **Description**

This PR releases version 4.0.0 of the MetaMask Design System monorepo, which includes significant updates to the font system across all packages. The main change is replacing Euclid Circular B with Centra No1 as the primary font family, along with version bumps across the packages.

Key changes include:
1. Monorepo version bump to 4.0.0
2. Major version bump of design-tokens to 6.0.0 with breaking font changes
3. Minor version bump of design-system-tailwind-preset to 0.2.0
4. Updated peer dependencies to reflect new design-tokens version

## **Related issues**

Fixes: #499 (Font family replacement from Euclid Circular B to Centra No1)

## **Manual testing steps**

1. Install the updated packages in a test project
2. Verify that Centra No1 fonts are loading correctly
3. Check that all font weights (400/Book, 500/Medium, 700/Bold) render properly
4. Verify that font fallback chain works as expected

## **Screenshots/Recordings**

N/A - Font changes should be verified in implementation

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included migration documentation for breaking changes
- [x] I've documented the changes in CHANGELOG.md files
- [x] I've applied the appropriate version bumps across packages

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots

Note: This is a significant release with breaking changes in the design-tokens package. Users will need to follow the migration guide when updating to this version, particularly regarding the font family changes from Euclid Circular B to Centra No1.
