### PR TITLE
Updated brandColors.json

### DIFF
--- a/packages/design-tokens/src/figma/brandColors.json
+++ b/packages/design-tokens/src/figma/brandColors.json
@@ -359,7 +359,7 @@
       "description": ""
     },
     "200": {
-      "value": "#ffa47c",
+      "value": "#FFA680",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
@@ -371,7 +371,7 @@
       "description": ""
     },
     "400": {
-      "value": "#f35714",
+      "value": "#FF5C16",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
@@ -389,7 +389,7 @@
       "description": ""
     },
     "700": {
-      "value": "#631800",
+      "value": "#661800",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
@@ -421,7 +421,7 @@
   },
   "purple": {
     "100": {
-      "value": "#efd2ff",
+      "value": "#EAC2FF",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
@@ -433,7 +433,7 @@
       "description": ""
     },
     "300": {
-      "value": "#d27dff",
+      "value": "#D075FF",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
@@ -463,7 +463,7 @@
       "description": ""
     },
     "800": {
-      "value": "#380658",
+      "value": "#3D065F",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
@@ -489,7 +489,7 @@
   },
   "lime": {
     "100": {
-      "value": "#b8ef4a",
+      "value": "#BAF24A",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
@@ -525,7 +525,7 @@
       "description": ""
     },
     "700": {
-      "value": "#093a31",
+      "value": "#013330",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
@@ -549,7 +549,7 @@
       "description": ""
     },
     "050": {
-      "value": "#e3febd",
+      "value": "#E5FFC3",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updated 9 values to match brand-evo colors accurately:

- 3 oranges
- 3 purples
- 3 limes
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
