### PR TITLE
Release/6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [6.1.0]
 
-### Uncategorized
+### Added
 
-- Updated brandColor.json ([#524](https://github.com/MetaMask/metamask-design-system/pull/524))
+- Updated brand colors to match branding and marketing color values ([#524](https://github.com/MetaMask/metamask-design-system/pull/524))
 
 ## [6.0.1]
 

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0]
+
 ### Uncategorized
 
 - Updated brandColor.json ([#524](https://github.com/MetaMask/metamask-design-system/pull/524))
@@ -352,7 +354,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@6.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@6.1.0...HEAD
+[6.1.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@6.0.1...@metamask/design-tokens@6.1.0
 [6.0.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@6.0.0...@metamask/design-tokens@6.0.1
 [6.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@5.1.0...@metamask/design-tokens@6.0.0
 [5.1.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@5.0.0...@metamask/design-tokens@5.1.0

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Updated brandColor.json ([#524](https://github.com/MetaMask/metamask-design-system/pull/524))
+
 ## [6.0.1]
 
 ### Fixed

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## **Description**

This PR releases version 6.1.0 of the MetaMask Design System monorepo, specifically updating the @metamask/design-tokens package. The main changes include updating brand colors to match branding and marketing color values.

Key changes:
1. Bump @metamask/design-tokens from 6.0.1 to 6.1.0
2. Update monorepo version from 5.0.0 to 6.0.0
3. Update CHANGELOG.md to reflect the new version and changes

## **Related issues**

Fixes: N/A (Release PR)

## **Manual testing steps**

1. Pull down the branch
2. Run yarn install to verify package updates
3. Verify the updated brand colors match the expected branding and marketing values
4. Verify the CHANGELOG.md reflects the correct version changes and links

## **Screenshots/Recordings**

N/A - Version/documentation updates only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.