### PR TITLE
chore: setting sans in tailwind preset

### DIFF
--- a/packages/design-system-tailwind-preset/src/typography.ts
+++ b/packages/design-system-tailwind-preset/src/typography.ts
@@ -20,6 +20,7 @@ export const typography = {
     'l-body-xs': 'var(--typography-l-body-xs-font-size)',
   },
   fontFamily: {
+    sans: 'var(--font-family-default)',
     default: 'var(--font-family-default)',
     accent: 'var(--font-family-accent)',
     hero: 'var(--font-family-hero)',


### PR DESCRIPTION
## **Description**

This PR adds back the `sans` property to the typography configuration in the Tailwind preset. This is a critical fix to ensure proper font rendering across the design system.

The `sans` property was missing from the `fontFamily` configuration, which caused any text not explicitly using the `font-default` class to fall back to the system font instead of using our design system's default font. By adding `sans: 'var(--font-family-default)'`, we ensure that the base CSS font family is set correctly, maintaining consistency with our design system's typography.

This change is particularly important because:
1. It maintains the expected font behavior for all text elements
2. It prevents unintended system font fallbacks
3. It aligns with our design system's typography standards

## **Related issues**

Fixes: N/A (Bug fix for font rendering)

## **Manual testing steps**

1. Pull the latest changes and build the design system
2. Check that text elements without explicit font classes render with the correct font
3. Verify that the font matches the design system's default font family
4. Test across different components to ensure consistent font rendering

## **Screenshots/Recordings**

### **Before**
Text without explicit font classes was rendering with system font

### **After**
All text elements now correctly use the design system's default font family

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md))

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots

The changes are minimal but important for maintaining consistent typography across the design system. The PR adds a single line to the `fontFamily` configuration in the Tailwind preset, ensuring that the base font family is properly set for all text elements.
