### PR TITLE
chore: adding missing info to design token migration docs

### DIFF
--- a/packages/design-tokens/MIGRATION.md
+++ b/packages/design-tokens/MIGRATION.md
@@ -19,7 +19,8 @@ In version 7.0.0, we've simplified the typography system by removing individual 
 ##### CSS Variables
 
 ```css
-/* Typography font family tokens */
+/* Typography font family tokens have been removed in favor of --font-family-default*/
+--font-family-sans
 --typography-s-display-md-font-family
 --typography-s-heading-lg-font-family
 --typography-s-heading-md-font-family
@@ -89,8 +90,10 @@ typography.lBodyXSMedium.fontFamily;
 
 ```css
 /* Font family tokens */
---font-family-accent: 'MMSans', sans-serif;
---font-family-hero: 'MMPoly', sans-serif;
+--font-family-default: 'CentraNo1', 'Helvetica Neue', Helvetica, Arial,
+  sans-serif;
+--font-family-accent: 'MMSans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+--font-family-hero: 'MMPoly', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 ```
 
 ##### JS Tokens
@@ -107,7 +110,7 @@ const FontFamilies = {
 
 1. Remove all references to individual typography font family tokens
 2. Use the base font family tokens instead:
-   - For web: Use `--font-family-default` for all typography variants
+   - For web: Update `--font-family-sans` to `--font-family-default` for all typography variants
    - For React Native: Use the appropriate font family from the base font tokens
 3. Update any CSS or style definitions that were using the removed tokens
 4. Test all typography variants to ensure they're using the correct font family


### PR DESCRIPTION
## **Description**

This PR updates the Migration Guide (v6.0.0 to v7.0.0) to include missing information and improve clarity around font family token changes. The updates include:

1. Added missing `--font-family-sans` to the list of removed CSS variables
2. Enhanced documentation of font family fallbacks in the new tokens
3. Clarified migration steps regarding the transition from `--font-family-sans` to `--font-family-default`

These changes ensure developers have complete information when migrating from v6.0.0 to v7.0.0, particularly around font family token changes.

## **Related issues**

Fixes: [Add issue number if applicable]

## **Manual testing steps**

1. Go to the Migration Guide in `packages/design-tokens/MIGRATION.md`
2. Review the "From version 6.0.0 to 7.0.0" section
3. Verify that the removed tokens list now includes `--font-family-sans`
4. Confirm the new font family tokens show complete fallback chains
5. Check that migration steps clearly explain updating from `--font-family-sans` to `--font-family-default`

## **Screenshots/Recordings**

### **Before**
```css
/* Typography font family tokens */
--typography-s-display-md-font-family
[...]
```

### **After**
```css
/* Typography font family tokens have been removed in favor of --font-family-default*/
--font-family-sans
--typography-s-display-md-font-family
[...]
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
