### PR TITLE
chore: add pressed and hover to text color type

### DIFF
--- a/packages/design-system-react/src/components/Text/Text.stories.tsx
+++ b/packages/design-system-react/src/components/Text/Text.stories.tsx
@@ -149,11 +149,23 @@ export const Color: Story = {
       <Text color={TextColor.PrimaryDefault} className="p-4">
         PrimaryDefault
       </Text>
+      <Text color={TextColor.PrimaryDefaultHover} className="p-4">
+        PrimaryDefaultHover
+      </Text>
+      <Text color={TextColor.PrimaryDefaultPressed} className="p-4">
+        PrimaryDefaultPressed
+      </Text>
       <Text color={TextColor.PrimaryInverse} className="bg-primary-default p-4">
         PrimaryInverse on bg-primary-default
       </Text>
       <Text color={TextColor.ErrorDefault} className="p-4">
         ErrorDefault
+      </Text>
+      <Text color={TextColor.ErrorDefaultHover} className="p-4">
+        ErrorDefaultHover
+      </Text>
+      <Text color={TextColor.ErrorDefaultPressed} className="p-4">
+        ErrorDefaultPressed
       </Text>
       <Text color={TextColor.ErrorInverse} className="bg-error-default p-4">
         ErrorInverse on bg-error-default
@@ -161,11 +173,23 @@ export const Color: Story = {
       <Text color={TextColor.SuccessDefault} className="p-4">
         SuccessDefault
       </Text>
+      <Text color={TextColor.SuccessDefaultHover} className="p-4">
+        SuccessDefaultHover
+      </Text>
+      <Text color={TextColor.SuccessDefaultPressed} className="p-4">
+        SuccessDefaultPressed
+      </Text>
       <Text color={TextColor.SuccessInverse} className="bg-success-default p-4">
         SuccessInverse on bg-success-default
       </Text>
       <Text color={TextColor.WarningDefault} className="p-4">
         WarningDefault
+      </Text>
+      <Text color={TextColor.WarningDefaultHover} className="p-4">
+        WarningDefaultHover
+      </Text>
+      <Text color={TextColor.WarningDefaultPressed} className="p-4">
+        WarningDefaultPressed
       </Text>
       <Text color={TextColor.WarningInverse} className="bg-warning-default p-4">
         WarningInverse on bg-warning-default

--- a/packages/design-system-react/src/types/index.ts
+++ b/packages/design-system-react/src/types/index.ts
@@ -206,20 +206,36 @@ export enum TextColor {
   OverlayInverse = 'text-overlay-inverse',
   /** For interactive, active, and selected semantics. Used for text, background, icon or border */
   PrimaryDefault = 'text-primary-default',
+  /** For primary text in a hover state. */
+  PrimaryDefaultHover = 'text-primary-default-hover',
+  /** For primary text in a pressed state. */
+  PrimaryDefaultPressed = 'text-primary-default-pressed',
   /** For elements used on top of primary/default. Used for text, icon or border */
   PrimaryInverse = 'text-primary-inverse',
   /** For the critical alert semantic elements. Used for text, background, icon or border */
   ErrorDefault = 'text-error-default',
+  /** For critical alert text in a hover state. */
+  ErrorDefaultHover = 'text-error-default-hover',
+  /** For critical alert text in a pressed state. */
+  ErrorDefaultPressed = 'text-error-default-pressed',
   /** For the stronger contrast error semantic elements. */
   ErrorAlternative = 'text-error-alternative',
   /** For elements used on top of error/default. Used for text, icon or border */
   ErrorInverse = 'text-error-inverse',
   /** For the positive semantic elements. Used for text, background, icon or border */
   SuccessDefault = 'text-success-default',
+  /** For positive text in a hover state. */
+  SuccessDefaultHover = 'text-success-default-hover',
+  /** For positive text in a pressed state. */
+  SuccessDefaultPressed = 'text-success-default-pressed',
   /** For elements used on top of success/default. Used for text, icon or border */
   SuccessInverse = 'text-success-inverse',
   /** For the caution alert semantic elements. Used for text, background, icon or border */
   WarningDefault = 'text-warning-default',
+  /** For caution text in a hover state. */
+  WarningDefaultHover = 'text-warning-default-hover',
+  /** For caution text in a pressed state. */
+  WarningDefaultPressed = 'text-warning-default-pressed',
   /** For elements used on top of warning/default. Used for text, icon or border */
   WarningInverse = 'text-warning-inverse',
   /** For informational read-only elements. Used for text, background, icon or border */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds hover and pressed states to the TextColor enum in the React design system to match the functionality already present in the React Native design system. This ensures consistency between both design systems and provides better support for interactive text states.
## **Related issues**

Fixes: #573 

## **Manual testing steps**

1. Run Storybook for the React design system
2. Navigate to the Text component stories
3. Verify that all new hover and pressed states are visible in the Color story

## **Screenshots/Recordings**

### **Before**
Text colors didn't contain hover and pressed states

https://github.com/user-attachments/assets/12a451c4-6561-4aec-8b40-9f229ed578e5

### **After**
Added hover and pressed states for all semantic colors, except info which have them at the design token level:

https://github.com/user-attachments/assets/33c3a515-a7a5-4314-a3e2-1f2af090f6cd

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.