### PR TITLE
chore: storybook preview build for PRs

### DIFF
--- a/.github/workflows/build-storybook-main.yml
+++ b/.github/workflows/build-storybook-main.yml
@@ -21,8 +21,7 @@ jobs:
 
       - name: Build required packages
         working-directory: .
-        run: |
-          yarn build
+        run: yarn build
 
       - name: Build Storybook
         run: |

--- a/.github/workflows/build-storybook-pr.yml
+++ b/.github/workflows/build-storybook-pr.yml
@@ -1,0 +1,61 @@
+name: Build Storybook PR
+
+on:
+  pull_request:
+
+jobs:
+  build-storybook:
+    name: Build Storybook PR
+    permissions:
+      pull-requests: write
+      contents: read
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/storybook-react
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
+        with:
+          is-high-risk-environment: false
+          skip-allow-scripts: true
+
+      - name: Build required packages
+        working-directory: .
+        run: |
+          yarn build
+
+      - name: Build storybook
+        run: yarn build-storybook
+
+      - name: Get PR commit info
+        id: pr-info
+        working-directory: .
+        run: |
+          PR_SHA="$(git rev-parse --short HEAD)"
+          echo "sha=${PR_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload 'storybook-build' to S3
+        if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
+        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_IAM_ROLE }}
+          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.event.pull_request.number }}/storybook-build
+          path: apps/storybook-react/storybook-static
+
+      - name: Generate Preview Message
+        working-directory: .
+        run: |
+          cat > storybook-preview-message.txt << EOL
+          ### 📖 Storybook Preview
+          - [View PR Storybook](https://${{ vars.AWS_S3_BUCKET }}.s3.${{ vars.AWS_REGION }}.amazonaws.com/${{ github.event.repository.name }}/${{ github.event.pull_request.number }}/storybook-build/index.html)
+          EOL
+
+      - name: Post Preview Comment
+        working-directory: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --body-file storybook-preview-message.txt

--- a/.github/workflows/build-storybook-pr.yml
+++ b/.github/workflows/build-storybook-pr.yml
@@ -23,18 +23,10 @@ jobs:
 
       - name: Build required packages
         working-directory: .
-        run: |
-          yarn build
+        run: yarn build
 
       - name: Build storybook
         run: yarn build-storybook
-
-      - name: Get PR commit info
-        id: pr-info
-        working-directory: .
-        run: |
-          PR_SHA="$(git rev-parse --short HEAD)"
-          echo "sha=${PR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Upload 'storybook-build' to S3
         if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
@@ -42,21 +34,16 @@ jobs:
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
-          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.event.pull_request.number }}/storybook-build
-          path: apps/storybook-react/storybook-static
-
-      - name: Generate Preview Message
-        working-directory: .
-        run: |
-          cat > storybook-preview-message.txt << EOL
-          ### 📖 Storybook Preview
-          - [View PR Storybook](https://${{ vars.AWS_S3_BUCKET }}.s3.${{ vars.AWS_REGION }}.amazonaws.com/${{ github.event.repository.name }}/${{ github.event.pull_request.number }}/storybook-build/index.html)
-          EOL
+          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/storybook-build
+          path: storybook-build
 
       - name: Post Preview Comment
         working-directory: .
+        if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr comment "${PR_NUMBER}" --body-file storybook-preview-message.txt
+          BASE_URL="${{ vars.AWS_CLOUDFRONT_URL || format('https://{0}.s3.{1}.amazonaws.com', vars.AWS_S3_BUCKET, vars.AWS_REGION) }}"
+          gh pr comment "${PR_NUMBER}" --body "### 📖 Storybook Preview
+          - [View PR Storybook](${BASE_URL}/${{ github.event.repository.name }}/${{ github.run_id }}/storybook-build/index.html)"

--- a/.github/workflows/build-storybook-pr.yml
+++ b/.github/workflows/build-storybook-pr.yml
@@ -39,11 +39,11 @@ jobs:
 
       - name: Post Preview Comment
         working-directory: .
-        if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
+        if: ${{ vars.AWS_CLOUDFRONT_URL }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ github.run_id }}
         run: |
-          BASE_URL="${{ vars.AWS_CLOUDFRONT_URL || format('https://{0}.s3.{1}.amazonaws.com', vars.AWS_S3_BUCKET, vars.AWS_REGION) }}"
           gh pr comment "${PR_NUMBER}" --body "### 📖 Storybook Preview
-          - [View PR Storybook](${BASE_URL}/${{ github.event.repository.name }}/${{ github.run_id }}/storybook-build/index.html)"
+          - [View PR Storybook](${HOST_URL}/storybook-build/index.html)"

--- a/.github/workflows/build-storybook-pr.yml
+++ b/.github/workflows/build-storybook-pr.yml
@@ -35,7 +35,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
           s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/storybook-build
-          path: storybook-build
+          path: storybook-static
 
       - name: Post Preview Comment
         working-directory: .

--- a/.github/workflows/build-storybook-pr.yml
+++ b/.github/workflows/build-storybook-pr.yml
@@ -35,7 +35,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
           s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/storybook-build
-          path: storybook-static
+          path: apps/storybook-react/storybook-static
 
       - name: Post Preview Comment
         working-directory: .

--- a/.github/workflows/build-storybook-pr.yml
+++ b/.github/workflows/build-storybook-pr.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## **Description**

This PR adds a new GitHub Actions workflow that automatically builds and deploys Storybook previews for each pull request. When a PR is created or updated, the workflow:

1. Builds the Storybook for the PR's code
2. Uploads the build to AWS S3
3. Comments on the PR with a link to the Storybook preview

This improvement enhances our PR review process by making it easier to see component changes in context before merging. Reviewers can now directly view a working Storybook instance specific to each PR rather than having to check out and build the branch locally.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/4

## **Manual testing steps**

1. Check 📖 Storybook Preview comment on this PR goes to storybook build

## **Screenshots/Recordings**

### **Before**

No Storybook preview links were available directly from PRs. Reviewers had to either check out and build the branch locally or wait until it was merged to main.

### **After**

Each PR now includes a comment with a direct link to view the PR-specific Storybook build.


https://github.com/user-attachments/assets/f12e696f-805e-42b5-8a0c-af9588c3c17b



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

The workflow currently has conditional logic to handle cases where these variables are not yet configured. Once they are set up, the workflow will automatically upload Storybook builds to S3 and include links in PR comments.
