### PR TITLE
overlay.default update

### DIFF
--- a/packages/design-tokens/src/css/dark-theme-colors.css
+++ b/packages/design-tokens/src/css/dark-theme-colors.css
@@ -41,8 +41,8 @@
   --color-border-default: var(--brand-colors-grey-grey400);
   /* Muted color for borders (#858b9a33) */
   --color-border-muted: #858b9a33;
-  /* Default color for overlays (scrim) (black-40%) */
-  --color-overlay-default: #00000066;
+  /* Default color for overlays (scrim) (#3f434a99) */
+  --color-overlay-default: #3f434a99;
   /* Dimmer color for overlays (scrim) (black-80%) */
   --color-overlay-alternative: #000000cc;
   /* For elements placed on top of overlay/alternative (#ffffff) */

--- a/packages/design-tokens/src/css/light-theme-colors.css
+++ b/packages/design-tokens/src/css/light-theme-colors.css
@@ -14,14 +14,14 @@
   --color-background-default-hover: #f6f6f7;
   /* Pressed state surface for background/default (#ebecef) */
   --color-background-default-pressed: #ebecef;
-  /* Hover state surface for background/alternative (#f6f6f7) */
-  --color-background-alternative-hover: #f6f6f7;
-  /* Pressed state surface for background/alternative (#ebecef) */
-  --color-background-alternative-pressed: #ebecef;
-  /* Hover state surface for background/muted (#e7ebee) */
-  --color-background-muted-hover: #e7ebee;
-  /* Pressed state surface for background/muted (#ebecef) */
-  --color-background-muted-pressed: #ebecef;
+  /* Hover state surface for background/alternative (#ebedf1) */
+  --color-background-alternative-hover: #ebedf1;
+  /* Pressed state surface for background/alternative (#e1e4ea) */
+  --color-background-alternative-pressed: #e1e4ea;
+  /* Hover state surface for background/muted (#ebedf1) */
+  --color-background-muted-hover: #ebedf1;
+  /* Pressed state surface for background/muted (#e1e4ea) */
+  --color-background-muted-pressed: #e1e4ea;
   /* General purpose hover state tint (#858b9a14) */
   --color-background-hover: #858b9a14;
   /* General purpose pressed state tint (#858b9a29) */
@@ -42,8 +42,8 @@
   --color-border-default: var(--brand-colors-grey-grey200);
   /* Muted color for borders (b7bbc8-40%) */
   --color-border-muted: #b7bbc866;
-  /* Default color for overlays (scrim) (black-40%) */
-  --color-overlay-default: #00000066;
+  /* Default color for overlays (scrim) (#3f434a66) */
+  --color-overlay-default: #3f434a66;
   /* Dimmer color for overlays (scrim) (black-80%) */
   --color-overlay-alternative: #000000cc;
   /* For elements placed on top of overlay/alternative (#ffffff) */

--- a/packages/design-tokens/src/figma/darkTheme.json
+++ b/packages/design-tokens/src/figma/darkTheme.json
@@ -123,7 +123,7 @@
   },
   "overlay": {
     "default": {
-      "value": "#3F434A99",
+      "value": "#3f434a99",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Default color for overlays(scrim)."

--- a/packages/design-tokens/src/figma/darkTheme.json
+++ b/packages/design-tokens/src/figma/darkTheme.json
@@ -123,7 +123,7 @@
   },
   "overlay": {
     "default": {
-      "value": "#00000066",
+      "value": "#3F434A80",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Default color for overlays(scrim)."

--- a/packages/design-tokens/src/figma/darkTheme.json
+++ b/packages/design-tokens/src/figma/darkTheme.json
@@ -123,7 +123,7 @@
   },
   "overlay": {
     "default": {
-      "value": "#3F434A80",
+      "value": "#3F434A99",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Default color for overlays(scrim)."

--- a/packages/design-tokens/src/figma/lightTheme.json
+++ b/packages/design-tokens/src/figma/lightTheme.json
@@ -123,7 +123,7 @@
   },
   "overlay": {
     "default": {
-      "value": "#00000066",
+      "value": "#3F434A4D",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Default color for overlays(scrim)."

--- a/packages/design-tokens/src/figma/lightTheme.json
+++ b/packages/design-tokens/src/figma/lightTheme.json
@@ -31,25 +31,25 @@
       "description": "Pressed state surface for background/default."
     },
     "alternative-hover": {
-      "value": "#f6f6f7",
+      "value": "#EBEDF1",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Hover state surface for background/alternative."
     },
     "alternative-pressed": {
-      "value": "#ebecef",
+      "value": "#E1E4EA",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Pressed state surface for background/alternative."
     },
     "muted-hover": {
-      "value": "#e7ebee",
+      "value": "#EBEDF1",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Hover state surface for background/muted."
     },
     "muted-pressed": {
-      "value": "#ebecef",
+      "value": "#E1E4EA",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Pressed state surface for background/muted."
@@ -123,7 +123,7 @@
   },
   "overlay": {
     "default": {
-      "value": "#3F434A4D",
+      "value": "#3F434A66",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Default color for overlays(scrim)."

--- a/packages/design-tokens/src/figma/lightTheme.json
+++ b/packages/design-tokens/src/figma/lightTheme.json
@@ -31,25 +31,25 @@
       "description": "Pressed state surface for background/default."
     },
     "alternative-hover": {
-      "value": "#EBEDF1",
+      "value": "#ebedf1",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Hover state surface for background/alternative."
     },
     "alternative-pressed": {
-      "value": "#E1E4EA",
+      "value": "#e1e4ea",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Pressed state surface for background/alternative."
     },
     "muted-hover": {
-      "value": "#EBEDF1",
+      "value": "#ebedf1",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Hover state surface for background/muted."
     },
     "muted-pressed": {
-      "value": "#E1E4EA",
+      "value": "#e1e4ea",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Pressed state surface for background/muted."
@@ -123,7 +123,7 @@
   },
   "overlay": {
     "default": {
-      "value": "#3F434A66",
+      "value": "#3f434a66",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Default color for overlays(scrim)."

--- a/packages/design-tokens/src/js/themes/darkTheme/colors.ts
+++ b/packages/design-tokens/src/js/themes/darkTheme/colors.ts
@@ -49,8 +49,8 @@ export const colors: ThemeColors = {
     muted: '#858b9a33',
   },
   overlay: {
-    /** Default color for overlays (scrim) (#00000066) */
-    default: '#00000066',
+    /** Default color for overlays (scrim) (#3f434a99) */
+    default: '#3f434a99',
     /** Dimmer color for overlays (scrim) (#000000CC) */
     alternative: '#000000cc',
     /** For elements placed on top of overlay/alternative (#FFFFFF) */

--- a/packages/design-tokens/src/js/themes/lightTheme/colors.ts
+++ b/packages/design-tokens/src/js/themes/lightTheme/colors.ts
@@ -13,14 +13,14 @@ export const colors: ThemeColors = {
     defaultHover: '#f6f6f7',
     /** Pressed state surface for background/default (#ebecef) */
     defaultPressed: '#ebecef',
-    /** Hover state surface for background/alternative (#f6f6f7) */
-    alternativeHover: '#f6f6f7',
-    /** Pressed state surface for background/alternative (#ebecef) */
-    alternativePressed: '#ebecef',
-    /** Hover state surface for background/muted (#e7ebee) */
-    mutedHover: '#e7ebee',
-    /** Pressed state surface for background/muted (#ebecef) */
-    mutedPressed: '#ebecef',
+    /** Hover state surface for background/alternative (#ebedf1) */
+    alternativeHover: '#ebedf1',
+    /** Pressed state surface for background/alternative (#e1e4ea) */
+    alternativePressed: '#e1e4ea',
+    /** Hover state surface for background/muted (#ebedf1) */
+    mutedHover: '#ebedf1',
+    /** Pressed state surface for background/muted (#e1e4ea) */
+    mutedPressed: '#e1e4ea',
     /** General purpose hover state tint (#858b9a14) */
     hover: '#858b9a14',
     /** General purpose pressed state tint (#858b9a29) */
@@ -49,8 +49,8 @@ export const colors: ThemeColors = {
     muted: '#b7bbc866',
   },
   overlay: {
-    /** Default color for overlays (scrim) (#00000066) */
-    default: '#00000066',
+    /** Default color for overlays (scrim) (#3f434a66) */
+    default: '#3f434a66',
     /** Dimmer color for overlays (scrim) (#000000CC) */
     alternative: '#000000cc',
     /** For elements placed on top of overlay/alternative (#FFFFFF) */


### PR DESCRIPTION
## **Description**
**1. Updated `overlay.default` as below. This improvement enhances the distinction of modal/bottom sheet from the background layer in dark mode, and also keeps light mode consistent with the dark mode.**

lightTheme :
`overlay.default `: `#000000 66` --> `#3F434A 4D`


darkTheme :
`overlay.default `: `#000000 66` --> `3F434A 80`

    
--
    
**2.  Updated background color bugs in lightTheme.**

- `background.muted-hover` : `#e7ebee` --> `#EBEDF1`
- `background.alternative-hover` : `#f6f6f7` --> `#EBEDF1`

- `background.muted-pressed` : `#ebecef` -->` #E1E4EA`
- `background.alterntive-pressed` : `#ebecef` --> `#E1E4EA`

--


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
