### PR TITLE
[DSR] Aligned BadgeStatus

### DIFF
--- a/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.constants.ts
+++ b/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.constants.ts
@@ -6,9 +6,8 @@ export const CLASSMAP_BADGESTATUS_STATUS_CIRCLE: Record<
   string
 > = {
   [BadgeStatusStatus.Active]: 'bg-success-default border-success-default',
-  [BadgeStatusStatus.PartiallyActive]:
-    'bg-background-default border-success-default',
-  [BadgeStatusStatus.Inactive]: 'bg-icon-muted border-icon-muted',
+  [BadgeStatusStatus.Inactive]: 'bg-background-default border-success-default',
+  [BadgeStatusStatus.Disconnected]: 'bg-icon-muted border-icon-muted',
   [BadgeStatusStatus.New]: 'bg-primary-default border-primary-default',
   [BadgeStatusStatus.Attention]: 'bg-error-default border-error-default',
 };

--- a/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.tsx
+++ b/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.tsx
@@ -23,7 +23,7 @@ export const BadgeStatus = React.forwardRef<HTMLDivElement, BadgeStatusProps>(
   ) => {
     const mergedClassName = twMerge(
       // Base styles
-      'relative inline-flex rounded-full',
+      'inline-flex rounded-full',
       // hasBorder style
       hasBorder ? 'border-2 border-background-default' : '',
       // Custom classes
@@ -41,7 +41,6 @@ export const BadgeStatus = React.forwardRef<HTMLDivElement, BadgeStatusProps>(
 
     return (
       <div ref={ref} className={mergedClassName} style={style} {...props}>
-        <div className="absolute bottom-0 left-0 right-0 top-0 rounded-full bg-background-default" />
         <div className={mergedCircleClassName} />
       </div>
     );

--- a/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.types.ts
+++ b/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.types.ts
@@ -9,9 +9,9 @@ export type BadgeStatusProps = ComponentProps<'div'> & {
   /**
    * Optional prop to control the status of the badge
    * Possible values:
-   * - BadgeStatusStatus.Active.
-   * - BadgeStatusStatus.PartiallyActive.
-   * - BadgeStatusStatus.Inactive.
+   * - BadgeStatusStatus.Active. (Connected)
+   * - BadgeStatusStatus.Inactive. (Connected)
+   * - BadgeStatusStatus.Disconnected.
    * - BadgeStatusStatus.New.
    * - BadgeStatusStatus.Attention.
    */

--- a/packages/design-system-react/src/components/BadgeStatus/README.mdx
+++ b/packages/design-system-react/src/components/BadgeStatus/README.mdx
@@ -4,7 +4,7 @@ import * as BadgeStatusStories from './BadgeStatus.stories';
 
 # BadgeStatus
 
-BadgeStatus indicates the status an entity is on.
+`BadgeStatus` indicates the state of an item through color.
 
 ```tsx
 import { BadgeStatus } from '@metamask/design-system-react';
@@ -20,9 +20,9 @@ import { BadgeStatus } from '@metamask/design-system-react';
 
 Use the `status` prop to indicate the visual state of the badge. Supported values:
 
-- `BadgeStatusStatus.Active`
-- `BadgeStatusStatus.PartiallyActive`
-- `BadgeStatusStatus.Inactive`
+- `BadgeStatusStatus.Active` (Connected)
+- `BadgeStatusStatus.Inactive` (Connected)
+- `BadgeStatusStatus.Disconnected`
 - `BadgeStatusStatus.New`
 - `BadgeStatusStatus.Attention`
 

--- a/packages/design-system-react/src/types/index.ts
+++ b/packages/design-system-react/src/types/index.ts
@@ -94,9 +94,9 @@ export enum BadgeCountSize {
  * BadgeStatus - status
  */
 export enum BadgeStatusStatus {
-  Active = 'active',
-  PartiallyActive = 'partiallyactive',
-  Inactive = 'inactive',
+  Active = 'active', // Connected
+  Inactive = 'inactive', // Connected
+  Disconnected = 'disconnected',
   New = 'new',
   Attention = 'attention',
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates the `BadgeStatus` component in the `@metamask/design-system-react` package
- Updated description to BadgeStatus indicates the state of an item through color
- Update component to remove absolute positioned background color element
- Update props status to Active (Green), Inactive (Green Border), Disconnected (Gray), New (Blue), Attention (Red)
- Update docs to add (Connected) to the Active and Inactive option for status
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #645 

## **Manual testing steps**

1. Run `yarn storybook`
2. Check BadgeStatus
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/66e774ec-2a02-4516-a87c-e650ed63f3eb

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
