### PR TITLE
[DSRN] Align BadgeStatus

### DIFF
--- a/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.constants.ts
+++ b/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.constants.ts
@@ -6,9 +6,8 @@ export const TWCLASSMAP_BADGESTATUS_STATUS_CIRCLE: Record<
   string
 > = {
   [BadgeStatusStatus.Active]: 'bg-success-default border-success-default',
-  [BadgeStatusStatus.PartiallyActive]:
-    'bg-background-default border-success-default',
-  [BadgeStatusStatus.Inactive]: 'bg-icon-muted border-icon-muted',
+  [BadgeStatusStatus.Inactive]: 'bg-background-default border-success-default',
+  [BadgeStatusStatus.Disconnected]: 'bg-icon-muted border-icon-muted',
   [BadgeStatusStatus.New]: 'bg-primary-default border-primary-default',
   [BadgeStatusStatus.Attention]: 'bg-error-default border-error-default',
 };

--- a/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.test.tsx
+++ b/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.test.tsx
@@ -24,9 +24,7 @@ describe('BadgeStatus', () => {
     const { getByTestId } = render(<TestComponent />);
     const badge = getByTestId('badge');
     expect(badge.props.style[0]).toStrictEqual(expectedOuter);
-    // The inner view is rendered as the child of the outer View.
-    const inner = badge.props.children[1];
-    expect(inner.props.style[0]).toStrictEqual(expectedInner);
+    expect(badge.props.children.props.style[0]).toStrictEqual(expectedInner);
   });
 
   it('renders without border when hasBorder is false', () => {
@@ -53,7 +51,7 @@ describe('BadgeStatus', () => {
     const TestComponent = () => {
       return (
         <BadgeStatus
-          status={BadgeStatusStatus.Inactive}
+          status={BadgeStatusStatus.Disconnected}
           style={customStyle}
           testID="badge"
         />
@@ -83,15 +81,15 @@ describe('BadgeStatus', () => {
     expect(badge.props.accessibilityLabel).toStrictEqual('status-badge');
   });
 
-  it('renders with custom size and status PartiallyActive', () => {
+  it('renders with custom size and status Inactive', () => {
     let expectedInner;
     const customSize = BadgeStatusSize.Lg; // For example, '10'
     const TestComponent = () => {
       const tw = useTailwind();
-      expectedInner = tw`rounded-full border-2 ${TWCLASSMAP_BADGESTATUS_SIZE[customSize]} ${TWCLASSMAP_BADGESTATUS_STATUS_CIRCLE[BadgeStatusStatus.PartiallyActive]} `;
+      expectedInner = tw`rounded-full border-2 ${TWCLASSMAP_BADGESTATUS_SIZE[customSize]} ${TWCLASSMAP_BADGESTATUS_STATUS_CIRCLE[BadgeStatusStatus.Inactive]} `;
       return (
         <BadgeStatus
-          status={BadgeStatusStatus.PartiallyActive}
+          status={BadgeStatusStatus.Inactive}
           size={customSize}
           testID="badge"
         />
@@ -100,8 +98,7 @@ describe('BadgeStatus', () => {
 
     const { getByTestId } = render(<TestComponent />);
     const badge = getByTestId('badge');
-    const inner = badge.props.children[1];
-    expect(inner.props.style[0]).toStrictEqual(expectedInner);
+    expect(badge.props.children.props.style[0]).toStrictEqual(expectedInner);
   });
 
   it('uses default size and hasBorder when not provided', () => {
@@ -118,7 +115,6 @@ describe('BadgeStatus', () => {
     const { getByTestId } = render(<TestComponent />);
     const badge = getByTestId('badge');
     expect(badge.props.style[0]).toStrictEqual(expectedOuter);
-    const inner = badge.props.children[1];
-    expect(inner.props.style[0]).toStrictEqual(expectedInner);
+    expect(badge.props.children.props.style[0]).toStrictEqual(expectedInner);
   });
 });

--- a/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.tsx
+++ b/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.tsx
@@ -29,9 +29,6 @@ const BadgeStatus = ({
       {...props}
     >
       <View
-        style={tw`bg-background-default absolute bottom-0 left-0 right-0 top-0 rounded-full`}
-      />
-      <View
         style={[
           tw`rounded-full border-2 ${TWCLASSMAP_BADGESTATUS_SIZE[size]} ${TWCLASSMAP_BADGESTATUS_STATUS_CIRCLE[status]} `,
         ]}

--- a/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.types.ts
+++ b/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.types.ts
@@ -9,9 +9,9 @@ export type BadgeStatusProps = {
   /**
    * Optional prop to control the status of the badge
    * Possible values:
-   * - BadgeStatusStatus.Active.
-   * - BadgeStatusStatus.PartiallyActive.
-   * - BadgeStatusStatus.Inactive.
+   * - BadgeStatusStatus.Active. (Connected)
+   * - BadgeStatusStatus.Inactive. (Connected)
+   * - BadgeStatusStatus.Disconnected.
    * - BadgeStatusStatus.New.
    * - BadgeStatusStatus.Attention.
    */

--- a/packages/design-system-react-native/src/components/BadgeStatus/README.md
+++ b/packages/design-system-react-native/src/components/BadgeStatus/README.md
@@ -1,6 +1,6 @@
 # BadgeStatus
 
-`BadgeStatus` indicates the status an entity is on.
+`BadgeStatus` indicates the state of an item through color
 
 ---
 
@@ -16,21 +16,21 @@ Controls the status of the badge.
 
 Available statuses:
 
-- `Active`
-- `PartiallyActive`
-- `Inactive`
+- `Active` (Connected)
+- `Inactive` (Connected)
+- `Disconnected`
 - `New`
 - `Attention`
 
 Each status maps to a different background and border color:
 
-| Status            | Background Color        | Border Color             |
-| ----------------- | ----------------------- | ------------------------ |
-| `Active`          | `bg-success-default`    | `border-success-default` |
-| `PartiallyActive` | `bg-background-default` | `border-success-default` |
-| `Inactive`        | `bg-icon-muted`         | `border-icon-muted`      |
-| `New`             | `bg-primary-default`    | `border-primary-default` |
-| `Attention`       | `bg-error-default`      | `border-error-default`   |
+| Status         | Background Color        | Border Color             |
+| -------------- | ----------------------- | ------------------------ |
+| `Active`       | `bg-success-default`    | `border-success-default` |
+| `Inactive`     | `bg-background-default` | `border-success-default` |
+| `Disconnected` | `bg-icon-muted`         | `border-icon-muted`      |
+| `New`          | `bg-primary-default`    | `border-primary-default` |
+| `Attention`    | `bg-error-default`      | `border-error-default`   |
 
 ---
 

--- a/packages/design-system-react-native/src/types/index.ts
+++ b/packages/design-system-react-native/src/types/index.ts
@@ -94,9 +94,9 @@ export enum BadgeCountSize {
  * BadgeStatus - status
  */
 export enum BadgeStatusStatus {
-  Active = 'active',
-  PartiallyActive = 'partiallyactive',
-  Inactive = 'inactive',
+  Active = 'active', // Connected
+  Inactive = 'inactive', //Connected
+  Disconnected = 'disconnected',
   New = 'new',
   Attention = 'attention',
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates the `BadgeStatus` component in the `@metamask/design-system-react-native` package
- Updated description to BadgeStatus indicates the state of an item through color
- Update component to remove absolute positioned background color element
- Update props status to Active (Green), Inactive (Green Border), Disconnected (Gray), New (Blue), Attention (Red)
- Update docs to add (Connected) to the Active and Inactive option for status
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #646 

## **Manual testing steps**

1. Run `yarn storybook:ios`
2. Check BadgeStatus
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/259e36a8-b6a7-473d-b4ca-0673718f3334

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
