### PR TITLE
fix: auto fix eslint violations from ignore files

### DIFF
--- a/packages/design-system-react-native/src/components/AvatarAccount/AvatarAccount.test.tsx
+++ b/packages/design-system-react-native/src/components/AvatarAccount/AvatarAccount.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react-native';
 import React from 'react';
 
 import { AvatarAccountSize, AvatarAccountVariant } from '../../types';
+
 import { AvatarAccount } from './AvatarAccount';
 import { SAMPLE_AVATARACCOUNT_ADDRESSES } from './AvatarAccount.constants';
 

--- a/packages/design-system-react-native/src/components/AvatarBase/AvatarBase.test.tsx
+++ b/packages/design-system-react-native/src/components/AvatarBase/AvatarBase.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { AvatarBaseSize, AvatarBaseShape } from '../../types';
 import { Text, TextColor, TextVariant } from '../Text';
+
 import { AvatarBase } from './AvatarBase';
 import {
   TWCLASSMAP_AVATARBASE_SIZE_DIMENSION,
@@ -135,7 +136,7 @@ describe('AvatarBase', () => {
       'rounded-full',
       TWCLASSMAP_AVATARBASE_SIZE_DIMENSION[AvatarBaseSize.Md],
     ].join(' ');
-    const customClasses = baseClasses + ' extra-class';
+    const customClasses = `${baseClasses} extra-class`;
     const expectedStyle = tw`${customClasses}`;
 
     const customStyle = { margin: 42 };

--- a/packages/design-system-react-native/src/components/AvatarFavicon/AvatarFavicon.tsx
+++ b/packages/design-system-react-native/src/components/AvatarFavicon/AvatarFavicon.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import React, { useState } from 'react';
-import { ImageErrorEventData, NativeSyntheticEvent } from 'react-native';
+import type { ImageErrorEventData, NativeSyntheticEvent } from 'react-native';
 
 import { AvatarFaviconSize, AvatarBaseShape } from '../../types';
 import { AvatarBase } from '../AvatarBase';
 import { ImageOrSvg } from '../temp-components/ImageOrSvg';
+
 import type { AvatarFaviconProps } from './AvatarFavicon.types';
 
 export const AvatarFavicon = ({

--- a/packages/design-system-react-native/src/components/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/design-system-react-native/src/components/AvatarGroup/AvatarGroup.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-native';
 import { ScrollView, View } from 'react-native';
 
 import { AvatarGroupSize, AvatarGroupVariant } from '../../types';
+
 import { AvatarGroup } from './AvatarGroup';
 import {
   SAMPLE_AVATARGROUP_AVATARACCOUNTPROPSARR,

--- a/packages/design-system-react-native/src/components/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/design-system-react-native/src/components/AvatarGroup/AvatarGroup.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react-native';
 import React from 'react';
 
 import { AvatarGroupVariant, AvatarGroupSize } from '../../types';
+
 import { AvatarGroup } from './AvatarGroup';
 import {
   SAMPLE_AVATARGROUP_AVATARACCOUNTPROPSARR,

--- a/packages/design-system-react-native/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/packages/design-system-react-native/src/components/AvatarGroup/AvatarGroup.tsx
@@ -3,17 +3,22 @@ import React, { useCallback } from 'react';
 import { View } from 'react-native';
 
 import { AvatarGroupSize, AvatarGroupVariant } from '../../types';
-import { AvatarAccount, AvatarAccountProps } from '../AvatarAccount';
+import type { AvatarAccountProps } from '../AvatarAccount';
+import { AvatarAccount } from '../AvatarAccount';
 import { AvatarBase, AvatarBaseShape } from '../AvatarBase';
-import { AvatarFavicon, AvatarFaviconProps } from '../AvatarFavicon';
-import { AvatarNetwork, AvatarNetworkProps } from '../AvatarNetwork';
-import { AvatarToken, AvatarTokenProps } from '../AvatarToken';
+import type { AvatarFaviconProps } from '../AvatarFavicon';
+import { AvatarFavicon } from '../AvatarFavicon';
+import type { AvatarNetworkProps } from '../AvatarNetwork';
+import { AvatarNetwork } from '../AvatarNetwork';
+import type { AvatarTokenProps } from '../AvatarToken';
+import { AvatarToken } from '../AvatarToken';
 import { Text, TextColor } from '../Text';
+
 import {
   MAP_AVATARGROUP_SIZE_OVERFLOWTEXT_TEXTVARIANT,
   TWCLASSMAP_AVATARGROUP_SIZE_SPACEBETWEENAVATARS,
 } from './AvatarGroup.constants';
-import { AvatarGroupProps } from './AvatarGroup.types';
+import type { AvatarGroupProps } from './AvatarGroup.types';
 
 export const AvatarGroup = ({
   variant,

--- a/packages/design-system-react-native/src/components/AvatarNetwork/AvatarNetwork.tsx
+++ b/packages/design-system-react-native/src/components/AvatarNetwork/AvatarNetwork.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import React, { useState } from 'react';
-import { ImageErrorEventData, NativeSyntheticEvent } from 'react-native';
+import type { ImageErrorEventData, NativeSyntheticEvent } from 'react-native';
 
 import { AvatarNetworkSize, AvatarBaseShape } from '../../types';
 import { AvatarBase } from '../AvatarBase';
 import { ImageOrSvg } from '../temp-components/ImageOrSvg';
+
 import type { AvatarNetworkProps } from './AvatarNetwork.types';
 
 export const AvatarNetwork = ({

--- a/packages/design-system-react-native/src/components/AvatarToken/AvatarToken.tsx
+++ b/packages/design-system-react-native/src/components/AvatarToken/AvatarToken.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import React, { useState } from 'react';
-import { ImageErrorEventData, NativeSyntheticEvent } from 'react-native';
+import type { ImageErrorEventData, NativeSyntheticEvent } from 'react-native';
 
 import { AvatarTokenSize, AvatarBaseShape } from '../../types';
 import { AvatarBase } from '../AvatarBase';
 import { ImageOrSvg } from '../temp-components/ImageOrSvg';
+
 import type { AvatarTokenProps } from './AvatarToken.types';
 
 export const AvatarToken = ({

--- a/packages/design-system-react-native/src/components/BadgeNetwork/BadgeNetwork.test.tsx
+++ b/packages/design-system-react-native/src/components/BadgeNetwork/BadgeNetwork.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react-native';
 import React from 'react';
 
 import { AvatarNetworkSize } from '../AvatarNetwork';
+
 import { BadgeNetwork } from './BadgeNetwork';
 
 const remoteImageSrc = { uri: 'https://example.com/photo.png' };

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -8,6 +8,7 @@ import {
   BadgeWrapperPosition,
 } from '../../types';
 import { Text } from '../Text';
+
 import { BadgeWrapper } from './BadgeWrapper';
 
 // Helper function to round numeric properties to two decimals.
@@ -61,7 +62,7 @@ describe('BadgeWrapper', () => {
 
     // Initially get the wrapper and its children.
     let wrapper = getByTestId('wrapper');
-    const children = wrapper.props.children;
+    const { children } = wrapper.props;
     const anchorContainer = children[0];
     const badgeContainer = children[1];
 
@@ -133,7 +134,7 @@ describe('BadgeWrapper', () => {
 
     // Initially get the wrapper and its children.
     let wrapper = getByTestId('wrapper');
-    const children = wrapper.props.children;
+    const { children } = wrapper.props;
     const anchorContainer = children[0];
     const badgeContainer = children[1];
 
@@ -204,7 +205,7 @@ describe('BadgeWrapper', () => {
 
     // Initially get the wrapper and its children.
     let wrapper = getByTestId('wrapper');
-    const children = wrapper.props.children;
+    const { children } = wrapper.props;
     const anchorContainer = children[0];
     const badgeContainer = children[1];
 
@@ -276,7 +277,7 @@ describe('BadgeWrapper', () => {
 
     // Initially get the wrapper and its children.
     let wrapper = getByTestId('wrapper');
-    const children = wrapper.props.children;
+    const { children } = wrapper.props;
     const anchorContainer = children[0];
     const badgeContainer = children[1];
 
@@ -347,7 +348,7 @@ describe('BadgeWrapper', () => {
 
     // Initially get the wrapper and its children.
     let wrapper = getByTestId('wrapper');
-    const children = wrapper.props.children;
+    const { children } = wrapper.props;
     const anchorContainer = children[0];
     const badgeContainer = children[1];
 
@@ -419,7 +420,7 @@ describe('BadgeWrapper', () => {
 
     // Initially get the wrapper and its children.
     let wrapper = getByTestId('wrapper');
-    const children = wrapper.props.children;
+    const { children } = wrapper.props;
     const anchorContainer = children[0];
     const badgeContainer = children[1];
 
@@ -490,7 +491,7 @@ describe('BadgeWrapper', () => {
 
     // Initially get the wrapper and its children.
     let wrapper = getByTestId('wrapper');
-    const children = wrapper.props.children;
+    const { children } = wrapper.props;
     const anchorContainer = children[0];
     const badgeContainer = children[1];
 
@@ -562,7 +563,7 @@ describe('BadgeWrapper', () => {
 
     // Initially get the wrapper and its children.
     let wrapper = getByTestId('wrapper');
-    const children = wrapper.props.children;
+    const { children } = wrapper.props;
     const anchorContainer = children[0];
     const badgeContainer = children[1];
 
@@ -619,7 +620,7 @@ describe('BadgeWrapper', () => {
       getByTestId('expectedBadgeStyle').props.children,
     );
     const wrapper = getByTestId('wrapper');
-    const children = wrapper.props.children;
+    const { children } = wrapper.props;
     const badgeContainer = children[1];
     expect(badgeContainer.props.style[1]).toStrictEqual(expectedBadgeStyle[1]);
   });
@@ -651,6 +652,6 @@ describe('BadgeWrapper', () => {
       alignSelf: 'flex-start',
       margin: 10,
     });
-    expect(wrapper.props.accessibilityLabel).toStrictEqual('badge-wrapper');
+    expect(wrapper.props.accessibilityLabel).toBe('badge-wrapper');
   });
 });

--- a/packages/design-system-react-native/src/components/Button/Button.tsx
+++ b/packages/design-system-react-native/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { ButtonVariant } from '../../types';
+
 import type { ButtonProps } from './Button.types';
 import { ButtonPrimary } from './variants/ButtonPrimary';
 import { ButtonSecondary } from './variants/ButtonSecondary';

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
@@ -4,6 +4,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import React from 'react';
 
 import { ButtonBaseSize } from '../../../../types';
+
 import { ButtonPrimary } from './ButtonPrimary';
 
 describe('ButtonPrimary', () => {
@@ -14,6 +15,10 @@ describe('ButtonPrimary', () => {
     tw = result.current;
   });
 
+  /**
+   *
+   * @param styleProp
+   */
   function flattenStyles(styleProp: any): Record<string, any>[] {
     if (styleProp == null) {
       return [];
@@ -28,6 +33,11 @@ describe('ButtonPrimary', () => {
     return [];
   }
 
+  /**
+   *
+   * @param styleProp
+   * @param tailwindClass
+   */
   function expectBackground(styleProp: any, tailwindClass: string) {
     const expected = tw`${tailwindClass}`;
     const allStyles = flattenStyles(styleProp);

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.tsx
@@ -7,8 +7,10 @@ import React, { useState } from 'react';
 import type { GestureResponderEvent } from 'react-native';
 
 import { ButtonBase } from '../../../ButtonBase';
-import { IconColor, IconSize } from '../../../Icon';
+import type { IconColor } from '../../../Icon';
+import { IconSize } from '../../../Icon';
 import { TextVariant, FontWeight } from '../../../Text';
+
 import type { ButtonPrimaryProps } from './ButtonPrimary.types';
 
 const ButtonPrimaryBase = ({

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
@@ -4,6 +4,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import React from 'react';
 
 import { ButtonBaseSize } from '../../../../types';
+
 import { ButtonSecondary } from './ButtonSecondary';
 
 describe('ButtonSecondary', () => {
@@ -14,6 +15,10 @@ describe('ButtonSecondary', () => {
     tw = result.current;
   });
 
+  /**
+   *
+   * @param styleProp
+   */
   function flattenStyles(styleProp: any): Record<string, any>[] {
     if (styleProp == null) {
       return [];
@@ -28,6 +33,11 @@ describe('ButtonSecondary', () => {
     return [];
   }
 
+  /**
+   *
+   * @param styleProp
+   * @param tailwindClass
+   */
   function expectBackground(styleProp: any, tailwindClass: string) {
     const expected = tw`${tailwindClass}`;
     const allStyles = flattenStyles(styleProp);
@@ -40,6 +50,11 @@ describe('ButtonSecondary', () => {
     );
   }
 
+  /**
+   *
+   * @param styleProp
+   * @param tailwindClass
+   */
   function expectBorder(styleProp: any, tailwindClass: string) {
     const expected = tw`${tailwindClass}`;
     const allStyles = flattenStyles(styleProp);

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.tsx
@@ -3,8 +3,10 @@ import React, { useState } from 'react';
 import type { GestureResponderEvent } from 'react-native';
 
 import { ButtonBase } from '../../../ButtonBase';
-import { IconColor, IconSize } from '../../../Icon';
+import type { IconColor } from '../../../Icon';
+import { IconSize } from '../../../Icon';
 import { TextVariant, FontWeight } from '../../../Text';
+
 import type { ButtonSecondaryProps } from './ButtonSecondary.types';
 
 export const ButtonSecondary = ({

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.test.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.test.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
-import { renderHook } from '@testing-library/react-hooks';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { ButtonTertiary } from './ButtonTertiary';
+import { renderHook } from '@testing-library/react-hooks';
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+
 import { ButtonBaseSize } from '../../../../types';
+
+import { ButtonTertiary } from './ButtonTertiary';
 
 describe('ButtonTertiary', () => {
   let tw: ReturnType<typeof useTailwind>;
@@ -13,6 +15,10 @@ describe('ButtonTertiary', () => {
     tw = result.current;
   });
 
+  /**
+   *
+   * @param styleProp
+   */
   function flattenStyles(styleProp: any): Record<string, any>[] {
     if (styleProp == null) {
       return [];
@@ -26,6 +32,11 @@ describe('ButtonTertiary', () => {
     return [];
   }
 
+  /**
+   *
+   * @param styleProp
+   * @param tailwindClass
+   */
   function expectBackground(styleProp: any, tailwindClass: string) {
     const expected = tw`${tailwindClass}`;
     const all = flattenStyles(styleProp);
@@ -36,6 +47,11 @@ describe('ButtonTertiary', () => {
     );
   }
 
+  /**
+   *
+   * @param styleProp
+   * @param tailwindClass
+   */
   function expectBorder(styleProp: any, tailwindClass: string) {
     const expected = tw`${tailwindClass}`;
     const all = flattenStyles(styleProp);

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.tsx
@@ -3,8 +3,10 @@ import React, { useState } from 'react';
 import type { GestureResponderEvent } from 'react-native';
 
 import { ButtonBase } from '../../../ButtonBase';
-import { IconColor, IconSize } from '../../../Icon';
+import type { IconColor } from '../../../Icon';
+import { IconSize } from '../../../Icon';
 import { TextVariant, FontWeight } from '../../../Text';
+
 import type { ButtonTertiaryProps } from './ButtonTertiary.types';
 
 export const ButtonTertiary = ({

--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.test.tsx
@@ -6,6 +6,7 @@ import { View } from 'react-native';
 
 import { ButtonBaseSize } from '../../types';
 import { IconName } from '../Icon';
+
 import { ButtonBase } from './ButtonBase';
 
 describe('ButtonBase', () => {

--- a/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.tsx
@@ -1,11 +1,12 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useState } from 'react';
 import type { GestureResponderEvent } from 'react-native';
 
 import { ButtonIconSize } from '../../types';
-import { Icon, IconColor } from '../Icon';
+import type { IconColor } from '../Icon';
+import { Icon } from '../Icon';
 import { ButtonAnimated } from '../temp-components/ButtonAnimated';
+
 import {
   MAP_BUTTONICON_SIZE_ICONSIZE,
   TWCLASSMAP_BUTTONICON_SIZE_DIMENSION,

--- a/packages/design-system-react-native/src/components/Icon/Icon.stories.tsx
+++ b/packages/design-system-react-native/src/components/Icon/Icon.stories.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { ScrollView, View } from 'react-native';
 
 import { IconColor, IconName, IconSize } from '../../types';
+
 import { Icon } from './Icon';
 import type { IconProps } from './Icon.types';
 

--- a/packages/design-system-react-native/src/components/Icon/Icon.test.tsx
+++ b/packages/design-system-react-native/src/components/Icon/Icon.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react-native';
 import React from 'react';
 
 import { IconColor, IconName, IconSize } from '../../types';
+
 import { Icon } from './Icon';
 import { generateIconClassNames } from './Icon.utilities';
 

--- a/packages/design-system-react-native/src/components/Icon/Icon.tsx
+++ b/packages/design-system-react-native/src/components/Icon/Icon.tsx
@@ -2,6 +2,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useMemo } from 'react';
 
 import { IconColor, IconSize } from '../../types';
+
 import { assetByIconName } from './Icon.assets';
 import type { IconProps } from './Icon.types';
 import { generateIconClassNames } from './Icon.utilities';

--- a/packages/design-system-react-native/src/components/TextButton/TextButton.test.tsx
+++ b/packages/design-system-react-native/src/components/TextButton/TextButton.test.tsx
@@ -6,6 +6,7 @@ import { View } from 'react-native';
 
 import { TextButtonSize } from '../../types';
 import { IconName, IconSize } from '../Icon';
+
 import { TextButton } from './TextButton';
 import { MAP_TEXTBUTTON_SIZE_TEXTVARIANT } from './TextButton.constants';
 

--- a/packages/design-system-react-native/src/components/temp-components/Blockies/Blockies.test.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/Blockies/Blockies.test.tsx
@@ -1,6 +1,6 @@
 // Blockies.test.tsx
-import React from 'react';
 import { render } from '@testing-library/react-native';
+import React from 'react';
 
 import { Blockies } from './Blockies';
 // @ts-ignore

--- a/packages/design-system-react-native/src/components/temp-components/Blockies/Blockies.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/Blockies/Blockies.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import React from 'react';
 import { Image } from 'react-native';
 
 // @ts-ignore
-import { toDataUrl } from './Blockies.utilities';
 import type { BlockiesProps } from './Blockies.types';
+import { toDataUrl } from './Blockies.utilities';
 
 export const Blockies = ({ address, size = 32, ...props }: BlockiesProps) => {
   return (

--- a/packages/design-system-react-native/src/components/temp-components/Blockies/Blockies.utilities.js
+++ b/packages/design-system-react-native/src/components/temp-components/Blockies/Blockies.utilities.js
@@ -15,10 +15,14 @@
    * @copyright Copyright (c) 2010, Robert Eisele
    * @link http://www.xarg.org/2010/03/generate-client-side-png-files-using-javascript/
    * @license http://www.opensource.org/licenses/bsd-license.php BSD License
-   *
    */
 
   // helper functions for that ctx
+  /**
+   *
+   * @param buffer
+   * @param offs
+   */
   function write(buffer, offs) {
     for (let i = 2; i < arguments.length; i++) {
       for (let j = 0; j < arguments[i].length; j++) {
@@ -27,10 +31,18 @@
     }
   }
 
+  /**
+   *
+   * @param w
+   */
   function byte2(w) {
     return String.fromCharCode((w >> 8) & 255, w & 255);
   }
 
+  /**
+   *
+   * @param w
+   */
   function byte4(w) {
     return String.fromCharCode(
       (w >> 24) & 255,
@@ -40,6 +52,10 @@
     );
   }
 
+  /**
+   *
+   * @param w
+   */
   function byte2lsb(w) {
     return String.fromCharCode(w & 255, (w >> 8) & 255);
   }
@@ -146,7 +162,9 @@
       const color = (((((alpha << 8) | red) << 8) | green) << 8) | blue;
 
       if (typeof this.palette[color] === 'undefined') {
-        if (this.pindex == this.depth) return '\x00';
+        if (this.pindex == this.depth) {
+          return '\x00';
+        }
 
         const ndx = this.plte_offs + 8 + 3 * this.pindex;
 
@@ -222,6 +240,12 @@
       );
 
       // compute crc32 of the PNG chunks
+      /**
+       *
+       * @param png
+       * @param offs
+       * @param size
+       */
       function crc32(png, offs, size) {
         let crc = -1;
         for (let i = 4; i < size - 4; i += 1) {
@@ -239,7 +263,7 @@
       crc32(this.buffer, this.iend_offs, this.iend_size);
 
       // convert PNG to string
-      return '\x89PNG\r\n\x1A\n' + this.buffer.join('');
+      return `\x89PNG\r\n\x1A\n${this.buffer.join('')}`;
     };
 
     this.fillRect = function (x, y, w, h, color) {
@@ -258,21 +282,43 @@
    * Assumes h, s, and l are contained in the set [0, 1] and
    * returns r, g, and b in the set [0, 255].
    *
-   * @param   {number}  h       The hue
-   * @param   {number}  s       The saturation
-   * @param   {number}  l       The lightness
-   * @return  {Array}           The RGB representation
+   * @param {number} h - The hue
+   * @param {number} s - The saturation
+   * @param {number} l - The lightness
+   * @returns {Array} The RGB representation
    */
 
+  /**
+   *
+   * @param p
+   * @param q
+   * @param t
+   */
   function hue2rgb(p, q, t) {
-    if (t < 0) t += 1;
-    if (t > 1) t -= 1;
-    if (t < 1 / 6) return p + (q - p) * 6 * t;
-    if (t < 1 / 2) return q;
-    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    if (t < 0) {
+      t += 1;
+    }
+    if (t > 1) {
+      t -= 1;
+    }
+    if (t < 1 / 6) {
+      return p + (q - p) * 6 * t;
+    }
+    if (t < 1 / 2) {
+      return q;
+    }
+    if (t < 2 / 3) {
+      return p + (q - p) * (2 / 3 - t) * 6;
+    }
     return p;
   }
 
+  /**
+   *
+   * @param h
+   * @param s
+   * @param l
+   */
   function hsl2rgb(h, s, l) {
     let r, g, b;
 
@@ -292,6 +338,10 @@
   // The random number is a js implementation of the Xorshift PRNG
   const randseed = new Array(4); // Xorshift: [x, y, z, w] 32 bit values
 
+  /**
+   *
+   * @param seed
+   */
   function seedrand(seed) {
     for (var i = 0; i < randseed.length; i++) {
       randseed[i] = 0;
@@ -302,6 +352,9 @@
     }
   }
 
+  /**
+   *
+   */
   function rand() {
     // based on Java's String.hashCode(), expanded to 4 32bit values
     const t = randseed[0] ^ (randseed[0] << 11);
@@ -314,17 +367,24 @@
     return (randseed[3] >>> 0) / ((1 << 31) >>> 0);
   }
 
+  /**
+   *
+   */
   function createColor() {
-    //saturation is the whole color spectrum
+    // saturation is the whole color spectrum
     const h = Math.floor(rand() * 360);
-    //saturation goes from 40 to 100, it avoids greyish colors
+    // saturation goes from 40 to 100, it avoids greyish colors
     const s = rand() * 60 + 40;
-    //lightness can be anything from 0 to 100, but probabilities are a bell curve around 50%
+    // lightness can be anything from 0 to 100, but probabilities are a bell curve around 50%
     const l = (rand() + rand() + rand() + rand()) * 25;
 
     return [h / 360, s / 100, l / 100];
   }
 
+  /**
+   *
+   * @param size
+   */
   function createImageData(size) {
     const width = size; // Only support square icons for now
     const height = size;
@@ -352,6 +412,10 @@
     return data;
   }
 
+  /**
+   *
+   * @param opts
+   */
   function buildOpts(opts) {
     if (!opts.seed) {
       throw new Error('No seed provided');
@@ -371,6 +435,10 @@
     );
   }
 
+  /**
+   *
+   * @param address
+   */
   function toDataUrl(address) {
     const cache = Blockies.cache[address];
     if (address && cache) {

--- a/packages/design-system-react-native/src/components/temp-components/ImageOrSvg/ImageOrSvg.stories.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/ImageOrSvg/ImageOrSvg.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-native';
 
+import SampleLocalSvg from './assets/ethereum-eth-logo.svg';
 import { ImageOrSvg } from './ImageOrSvg';
 import type { ImageOrSvgProps } from './ImageOrSvg.types';
 
@@ -46,6 +47,7 @@ export const RemoteSvg: Story = {
 };
 
 const sampleLocalPng = require('./assets/ethereum-eth-logo.png');
+
 export const LocalImage: Story = {
   args: {
     width: 200,
@@ -53,8 +55,6 @@ export const LocalImage: Story = {
   },
   render: (args) => <ImageOrSvg {...args} src={sampleLocalPng} />,
 };
-
-import SampleLocalSvg from './assets/ethereum-eth-logo.svg';
 export const LocalSvg: Story = {
   args: {
     width: 200,

--- a/packages/design-system-react-native/src/components/temp-components/ImageOrSvg/ImageOrSvg.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/ImageOrSvg/ImageOrSvg.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import React, { useState, useCallback, useEffect } from 'react';
 import { Image } from 'react-native';
 import { SvgUri } from 'react-native-svg';
@@ -76,16 +75,15 @@ export const ImageOrSvg = ({
         {...svgProps}
       />
     );
-  } else {
-    return (
-      <Image
-        source={src as any}
-        style={[{ width, height } as any, style]}
-        resizeMode="contain"
-        onLoad={onImageLoad}
-        onError={onImageError}
-        {...imageProps}
-      />
-    );
   }
+  return (
+    <Image
+      source={src as any}
+      style={[{ width, height } as any, style]}
+      resizeMode="contain"
+      onLoad={onImageLoad}
+      onError={onImageError}
+      {...imageProps}
+    />
+  );
 };

--- a/packages/design-system-react-native/src/components/temp-components/Spinner/Spinner.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/Spinner/Spinner.tsx
@@ -13,6 +13,7 @@ import type { IconProps } from '../../Icon';
 import { Icon, IconColor, IconName, IconSize } from '../../Icon';
 import type { TextProps } from '../../Text';
 import { Text, TextVariant, TextColor } from '../../Text';
+
 import type { SpinnerProps } from './Spinner.types';
 
 export const Spinner = ({

--- a/packages/design-system-react/src/components/temp-components/Jazzicon/Jazzicon.test.tsx
+++ b/packages/design-system-react/src/components/temp-components/Jazzicon/Jazzicon.test.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
+import { KnownCaipNamespace, stringToBytes } from '@metamask/utils';
 import { render, screen, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
 import { Jazzicon } from './Jazzicon';
 import * as utilities from './Jazzicon.utilities';
-import { KnownCaipNamespace, stringToBytes } from '@metamask/utils';
 
 // Mock the external dependency for Bitcoin address validation.
 jest.mock('bitcoin-address-validation', () => ({
   validate: (address: string, network: any) => {
     // For our test Bitcoin address, return true; for others, return false.
-    if (address === '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa') return true;
+    if (address === '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa') {
+      return true;
+    }
     return false;
   },
   Network: {
@@ -239,7 +242,7 @@ describe('Jazzicon', () => {
       // Even though the component renders a div, the effect sees containerRef.current as null,
       // so it should not append any children.
       const container = screen.getByTestId('jazzicon');
-      expect(container.childNodes.length).toBe(0);
+      expect(container.childNodes).toHaveLength(0);
       useRefSpy.mockRestore();
     });
 
@@ -274,7 +277,7 @@ describe('Jazzicon', () => {
 
       // Wait for the effect to run and remove the dummy nodes.
       await waitFor(() => {
-        expect(container.childNodes.length).toBe(1); // Only the new Jazzicon should remain
+        expect(container.childNodes).toHaveLength(1); // Only the new Jazzicon should remain
       });
 
       // Verify all dummy elements were removed.
@@ -285,7 +288,7 @@ describe('Jazzicon', () => {
 
     it('clears pre-existing children on initial mount using delayed effect', async () => {
       // Capture effect callbacks instead of letting them run automatically.
-      const effectCallbacks: Array<() => void> = [];
+      const effectCallbacks: (() => void)[] = [];
       const originalUseEffect = React.useEffect;
       jest
         .spyOn(React, 'useEffect')

--- a/packages/design-system-react/src/components/temp-components/Jazzicon/Jazzicon.tsx
+++ b/packages/design-system-react/src/components/temp-components/Jazzicon/Jazzicon.tsx
@@ -3,7 +3,8 @@ import { KnownCaipNamespace } from '@metamask/utils';
 import React, { useEffect, useRef } from 'react';
 
 import { twMerge } from '../../../utils/tw-merge';
-import { JazziconProps } from './Jazzicon.types';
+
+import type { JazziconProps } from './Jazzicon.types';
 import {
   generateSeedEthereum,
   generateSeedNonEthereum,


### PR DESCRIPTION

# **Description**

This PR temporarily uncomments the ESLint ignore rules for the design system React Native components and runs `yarn lint:fix` to automatically fix linting violations. This helps improve code quality and consistency across the codebase.

The automated fixes include:
- Adding newlines between import groups
- Using proper type imports instead of value imports
- Using destructuring for object properties
- Replacing string concatenation with template literals
- Adding JSDoc comments to functions
- Removing unnecessary eslint-disable comments
- Fixing import ordering

# **Related issues**

Part of: #657 

# **Manual testing steps**

1. Check out this branch
2. Run `yarn lint` to verify that the linting errors are fixed
3. Run the storybook to make sure components still render correctly

# **Screenshots/Recordings**

N/A

# **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md))

# **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
