### PR TITLE
fix: import-x/no-named-as-default-member violations dsr

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -27,78 +27,9 @@
     "@typescript-eslint/no-base-to-string": 1,
     "@typescript-eslint/no-shadow": 1
   },
-  "packages/design-system-react/src/components/AvatarAccount/AvatarAccount.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/AvatarBase/AvatarBase.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/AvatarFavicon/AvatarFavicon.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/AvatarIcon/AvatarIcon.test.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/AvatarIcon/AvatarIcon.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/AvatarToken/AvatarToken.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/BadgeCount/BadgeCount.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/BadgeIcon/BadgeIcon.test.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/BadgeIcon/BadgeIcon.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/BadgeNetwork/BadgeNetwork.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/BadgeStatus/BadgeStatus.test.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/BadgeStatus/BadgeStatus.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/Button/Button.test.tsx": {
-    "import-x/no-named-as-default-member": 3
-  },
-  "packages/design-system-react/src/components/Button/Button.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.test.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/ButtonBase/ButtonBase.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
-  "packages/design-system-react/src/components/ButtonIcon/ButtonIcon.tsx": {
-    "import-x/no-named-as-default-member": 1
-  },
   "packages/design-system-react/src/components/Icon/template.test.ts": {
     "@typescript-eslint/no-base-to-string": 1,
     "jest/no-conditional-in-test": 1
-  },
-  "packages/design-system-react/src/components/TextButton/TextButton.tsx": {
-    "import-x/no-named-as-default-member": 1
   },
   "packages/design-system-react/src/components/temp-components/Jazzicon/Jazzicon.utilities.ts": {
     "jsdoc/require-param-description": 3,

--- a/packages/design-system-react/src/components/AvatarAccount/AvatarAccount.tsx
+++ b/packages/design-system-react/src/components/AvatarAccount/AvatarAccount.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import {
   AvatarAccountVariant,
@@ -13,10 +13,7 @@ import { Maskicon } from '../temp-components/Maskicon';
 import { MAP_AVATARACCOUNT_SIZE_SIZENUMBER } from './AvatarAccount.constants';
 import type { AvatarAccountProps } from './AvatarAccount.types';
 
-export const AvatarAccount = React.forwardRef<
-  HTMLDivElement,
-  AvatarAccountProps
->(
+export const AvatarAccount = forwardRef<HTMLDivElement, AvatarAccountProps>(
   (
     {
       address,

--- a/packages/design-system-react/src/components/AvatarBase/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/AvatarBase/AvatarBase.tsx
@@ -1,5 +1,5 @@
 import { Slot } from '@radix-ui/react-slot';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { AvatarBaseSize, AvatarBaseShape } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
@@ -13,7 +13,7 @@ import {
 } from './AvatarBase.constants';
 import type { AvatarBaseProps } from './AvatarBase.types';
 
-export const AvatarBase = React.forwardRef<HTMLDivElement, AvatarBaseProps>(
+export const AvatarBase = forwardRef<HTMLDivElement, AvatarBaseProps>(
   (
     {
       children,

--- a/packages/design-system-react/src/components/AvatarFavicon/AvatarFavicon.tsx
+++ b/packages/design-system-react/src/components/AvatarFavicon/AvatarFavicon.tsx
@@ -1,14 +1,11 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 import { AvatarFaviconSize, AvatarBaseShape } from '../../types';
 import { AvatarBase } from '../AvatarBase';
 
 import type { AvatarFaviconProps } from './AvatarFavicon.types';
 
-export const AvatarFavicon = React.forwardRef<
-  HTMLDivElement,
-  AvatarFaviconProps
->(
+export const AvatarFavicon = forwardRef<HTMLDivElement, AvatarFaviconProps>(
   (
     {
       src,

--- a/packages/design-system-react/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/packages/design-system-react/src/components/AvatarGroup/AvatarGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 
 import { AvatarGroupSize, AvatarGroupVariant } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
@@ -16,7 +16,7 @@ import {
 } from './AvatarGroup.constants';
 import { AvatarGroupProps } from './AvatarGroup.types';
 
-export const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
+export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
   (
     {
       variant,

--- a/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.test.tsx
+++ b/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { AvatarIconSize, AvatarIconSeverity } from '../../types';
 import { IconName } from '../Icon';
@@ -100,7 +100,7 @@ describe('AvatarIcon', () => {
   });
 
   it('forwards ref to AvatarBase', () => {
-    const ref = React.createRef<HTMLDivElement>();
+    const ref = createRef<HTMLDivElement>();
     render(<AvatarIcon ref={ref} iconName={IconName.AddSquare} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });

--- a/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.tsx
+++ b/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { AvatarIconSize, AvatarIconSeverity } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
@@ -12,7 +12,7 @@ import {
 } from './AvatarIcon.constants';
 import type { AvatarIconProps } from './AvatarIcon.types';
 
-export const AvatarIcon = React.forwardRef<HTMLDivElement, AvatarIconProps>(
+export const AvatarIcon = forwardRef<HTMLDivElement, AvatarIconProps>(
   (
     {
       iconName,

--- a/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.tsx
+++ b/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.tsx
@@ -1,14 +1,11 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 import { AvatarNetworkSize, AvatarBaseShape } from '../../types';
 import { AvatarBase } from '../AvatarBase';
 
 import type { AvatarNetworkProps } from './AvatarNetwork.types';
 
-export const AvatarNetwork = React.forwardRef<
-  HTMLDivElement,
-  AvatarNetworkProps
->(
+export const AvatarNetwork = forwardRef<HTMLDivElement, AvatarNetworkProps>(
   (
     {
       src,

--- a/packages/design-system-react/src/components/AvatarToken/AvatarToken.tsx
+++ b/packages/design-system-react/src/components/AvatarToken/AvatarToken.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 import { AvatarTokenSize, AvatarBaseShape } from '../../types';
 import { AvatarBase } from '../AvatarBase';
 
 import type { AvatarTokenProps } from './AvatarToken.types';
 
-export const AvatarToken = React.forwardRef<HTMLDivElement, AvatarTokenProps>(
+export const AvatarToken = forwardRef<HTMLDivElement, AvatarTokenProps>(
   (
     {
       src,

--- a/packages/design-system-react/src/components/BadgeCount/BadgeCount.tsx
+++ b/packages/design-system-react/src/components/BadgeCount/BadgeCount.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { BadgeCountSize } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
@@ -10,7 +10,7 @@ import {
 } from './BadgeCount.constants';
 import type { BadgeCountProps } from './BadgeCount.types';
 
-export const BadgeCount = React.forwardRef<HTMLDivElement, BadgeCountProps>(
+export const BadgeCount = forwardRef<HTMLDivElement, BadgeCountProps>(
   (
     {
       size = BadgeCountSize.Md,

--- a/packages/design-system-react/src/components/BadgeIcon/BadgeIcon.test.tsx
+++ b/packages/design-system-react/src/components/BadgeIcon/BadgeIcon.test.tsx
@@ -1,6 +1,6 @@
 // BadgeIcon.test.tsx
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { IconName, IconColor } from '../Icon';
 import { ICON_SIZE_CLASS_MAP } from '../Icon/Icon.constants';
@@ -59,7 +59,7 @@ describe('BadgeIcon', () => {
   });
 
   it('forwards ref to the root div', () => {
-    const ref = React.createRef<HTMLDivElement>();
+    const ref = createRef<HTMLDivElement>();
     render(<BadgeIcon ref={ref} iconName={IconName.User} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });

--- a/packages/design-system-react/src/components/BadgeIcon/BadgeIcon.tsx
+++ b/packages/design-system-react/src/components/BadgeIcon/BadgeIcon.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
 import { Icon, IconSize } from '../Icon';
 
 import type { BadgeIconProps } from './BadgeIcon.types';
 
-export const BadgeIcon = React.forwardRef<HTMLDivElement, BadgeIconProps>(
+export const BadgeIcon = forwardRef<HTMLDivElement, BadgeIconProps>(
   ({ iconName, iconProps, className = '', style, ...props }, ref) => {
     const mergedClassName = twMerge(
       'inline-flex h-4 w-4 items-center justify-center rounded-full bg-icon-default',

--- a/packages/design-system-react/src/components/BadgeNetwork/BadgeNetwork.tsx
+++ b/packages/design-system-react/src/components/BadgeNetwork/BadgeNetwork.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { AvatarNetwork, AvatarNetworkSize } from '../AvatarNetwork';
 
 import type { BadgeNetworkProps } from './BadgeNetwork.types';
 
-export const BadgeNetwork = React.forwardRef<HTMLDivElement, BadgeNetworkProps>(
+export const BadgeNetwork = forwardRef<HTMLDivElement, BadgeNetworkProps>(
   ({ name, src, fallbackText, ...props }, ref) => {
     return (
       <AvatarNetwork

--- a/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.test.tsx
+++ b/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { BadgeStatusSize, BadgeStatusStatus } from '../../types';
 
@@ -96,7 +96,7 @@ describe('BadgeStatus', () => {
   });
 
   it('forwards ref to the root div', () => {
-    const ref = React.createRef<HTMLDivElement>();
+    const ref = createRef<HTMLDivElement>();
     render(<BadgeStatus ref={ref} status={BadgeStatusStatus.Active} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });

--- a/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.tsx
+++ b/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { BadgeStatusSize } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
@@ -9,7 +9,7 @@ import {
 } from './BadgeStatus.constants';
 import type { BadgeStatusProps } from './BadgeStatus.types';
 
-export const BadgeStatus = React.forwardRef<HTMLDivElement, BadgeStatusProps>(
+export const BadgeStatus = forwardRef<HTMLDivElement, BadgeStatusProps>(
   (
     {
       status,

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -1,5 +1,11 @@
 import type { CSSProperties } from 'react';
-import React, { useState, useLayoutEffect, useMemo, useRef } from 'react';
+import React, {
+  forwardRef,
+  useState,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
 
 import {
   BadgeWrapperPosition,
@@ -9,7 +15,7 @@ import { twMerge } from '../../utils/tw-merge';
 
 import type { BadgeWrapperProps } from './BadgeWrapper.types';
 
-export const BadgeWrapper = React.forwardRef<HTMLDivElement, BadgeWrapperProps>(
+export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
   (
     {
       children,

--- a/packages/design-system-react/src/components/Button/Button.test.tsx
+++ b/packages/design-system-react/src/components/Button/Button.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { ButtonVariant } from '../../types';
 import { IconName } from '../Icon';
@@ -238,15 +238,13 @@ describe('Button', () => {
 
   describe('Ref Forwarding', () => {
     it('forwards ref to the button element for all variants', () => {
-      const { rerender } = render(
-        <Button ref={React.createRef()}>Button</Button>,
-      );
+      const { rerender } = render(<Button ref={createRef()}>Button</Button>);
 
       let button = screen.getByRole('button');
       expect(button).toBeInTheDocument();
 
       rerender(
-        <Button variant={ButtonVariant.Secondary} ref={React.createRef()}>
+        <Button variant={ButtonVariant.Secondary} ref={createRef()}>
           Button
         </Button>,
       );
@@ -254,7 +252,7 @@ describe('Button', () => {
       expect(button).toBeInTheDocument();
 
       rerender(
-        <Button variant={ButtonVariant.Tertiary} ref={React.createRef()}>
+        <Button variant={ButtonVariant.Tertiary} ref={createRef()}>
           Button
         </Button>,
       );

--- a/packages/design-system-react/src/components/Button/Button.tsx
+++ b/packages/design-system-react/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ButtonVariant } from '../../types';
 
@@ -10,7 +10,7 @@ import type { ButtonSecondaryProps } from './variants/ButtonSecondary';
 import { ButtonTertiary } from './variants/ButtonTertiary';
 import type { ButtonTertiaryProps } from './variants/ButtonTertiary';
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ variant = ButtonVariant.Primary, ...props }, ref) => {
     switch (variant) {
       case ButtonVariant.Primary:

--- a/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.tsx
@@ -1,14 +1,11 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { twMerge } from '../../../../utils/tw-merge';
 import { ButtonBase } from '../../../ButtonBase';
 
 import type { ButtonPrimaryProps } from './ButtonPrimary.types';
 
-export const ButtonPrimary = React.forwardRef<
-  HTMLButtonElement,
-  ButtonPrimaryProps
->(
+export const ButtonPrimary = forwardRef<HTMLButtonElement, ButtonPrimaryProps>(
   (
     { className, isDanger, isInverse, isDisabled, isLoading, ...props },
     ref,

--- a/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { twMerge } from '../../../../utils/tw-merge';
 import { ButtonBase } from '../../../ButtonBase';
 
 import type { ButtonSecondaryProps } from './ButtonSecondary.types';
 
-export const ButtonSecondary = React.forwardRef<
+export const ButtonSecondary = forwardRef<
   HTMLButtonElement,
   ButtonSecondaryProps
 >(

--- a/packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.test.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { ButtonTertiarySize } from '../../../../types';
 import { IconName } from '../../../Icon';
@@ -138,7 +138,7 @@ describe('ButtonTertiary', () => {
 
   describe('ref forwarding', () => {
     it('forwards ref to the button element', () => {
-      const ref = React.createRef<HTMLButtonElement>();
+      const ref = createRef<HTMLButtonElement>();
       render(<ButtonTertiary ref={ref}>Button with Ref</ButtonTertiary>);
 
       expect(ref.current).toBeInstanceOf(HTMLButtonElement);

--- a/packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { twMerge } from '../../../../utils/tw-merge';
 import { ButtonBase } from '../../../ButtonBase';
 
 import type { ButtonTertiaryProps } from './ButtonTertiary.types';
 
-export const ButtonTertiary = React.forwardRef<
+export const ButtonTertiary = forwardRef<
   HTMLButtonElement,
   ButtonTertiaryProps
 >(

--- a/packages/design-system-react/src/components/ButtonBase/ButtonBase.tsx
+++ b/packages/design-system-react/src/components/ButtonBase/ButtonBase.tsx
@@ -1,5 +1,5 @@
 import { Slot, Slottable } from '@radix-ui/react-slot';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ButtonBaseSize } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
@@ -9,7 +9,7 @@ import { Text, FontWeight, TextColor } from '../Text';
 import { BUTTON_BASE_SIZE_CLASS_MAP } from './ButtonBase.constants';
 import type { ButtonBaseProps } from './ButtonBase.types';
 
-export const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
+export const ButtonBase = forwardRef<HTMLButtonElement, ButtonBaseProps>(
   (
     {
       children,

--- a/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ButtonIconSize } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
@@ -10,7 +10,7 @@ import {
 } from './ButtonIcon.constants';
 import type { ButtonIconProps } from './ButtonIcon.types';
 
-export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
+export const ButtonIcon = forwardRef<HTMLButtonElement, ButtonIconProps>(
   (
     {
       className,

--- a/packages/design-system-react/src/components/TextButton/TextButton.tsx
+++ b/packages/design-system-react/src/components/TextButton/TextButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { TextButtonSize } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
@@ -7,7 +7,7 @@ import { ButtonBase } from '../ButtonBase';
 import { MAP_TEXTBUTTON_SIZE_TEXTVARIANT } from './TextButton.constants';
 import type { TextButtonProps } from './TextButton.types';
 
-export const TextButton = React.forwardRef<HTMLButtonElement, TextButtonProps>(
+export const TextButton = forwardRef<HTMLButtonElement, TextButtonProps>(
   (
     {
       className,


### PR DESCRIPTION
## **Description**

This PR fixes ESLint `import-x/no-named-as-default-member` linting errors throughout the design-system-react package by replacing all instances of `React.forwardRef` with proper named imports.

The changes include:
1. Adding `{ forwardRef }` to React import statements in all component files
2. Replacing `React.forwardRef` with `forwardRef` in component implementations
3. Similarly addressing `React.createRef` in test files by importing and using `{ createRef }`

These changes follow modern React best practices and improve code consistency across the codebase. The improvements make the code more maintainable and address the linting errors that were previously ignored or generating warnings.

A script was created to automate this process, ensuring consistent implementation across all affected files.

## **Related issues**

Part of: #657

## **Manual testing steps**

1. Run `yarn lint` to verify no more `import-x/no-named-as-default-member` errors for React.forwardRef
2. Run unit tests to ensure component functionality remains unchanged
3. Build the project to verify no compilation errors

## **Screenshots/Recordings**

### Before
<img width="390" alt="Screenshot 2025-05-19 at 10 10 34 AM" src="https://github.com/user-attachments/assets/5e5462eb-9797-45e8-83eb-b13d628386df" />

### After

<img width="594" alt="Screenshot 2025-05-19 at 10 09 22 AM" src="https://github.com/user-attachments/assets/3dbab472-570e-497f-a7a8-cc0e796128d6" />

<img width="651" alt="Screenshot 2025-05-19 at 10 08 24 AM" src="https://github.com/user-attachments/assets/5e88f374-5f98-4702-94b2-b20c114228ab" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md))

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
