### PR TITLE
fix: broken build of DSRN

### DIFF
--- a/packages/design-system-react-native/scripts/build.js
+++ b/packages/design-system-react-native/scripts/build.js
@@ -10,6 +10,32 @@ try {
   console.log('Step 3: Building the project...');
   execSync('tsc --project tsconfig.build.json', { stdio: 'inherit' });
 
+  console.log('Step 4: Copying non-TypeScript files...');
+
+  // Copy Blockies utilities
+  // TODO: Remove this step when blockies is converted to typescript
+  execSync('mkdir -p dist/components/temp-components/Blockies', {
+    stdio: 'inherit',
+  });
+  execSync(
+    'cp src/components/temp-components/Blockies/Blockies.utilities.js dist/components/temp-components/Blockies/',
+    { stdio: 'inherit' },
+  );
+
+  // Copy SVG files
+  console.log('Step 5: Copying SVG assets...');
+
+  // Copy Icon assets
+  execSync('mkdir -p dist/components/Icon/assets', {
+    stdio: 'inherit',
+  });
+  execSync(
+    'cp -R src/components/Icon/assets/*.svg dist/components/Icon/assets/',
+    {
+      stdio: 'inherit',
+    },
+  );
+
   console.log('Build completed successfully!');
 } catch (error) {
   console.error('Build process failed:', error.message);


### PR DESCRIPTION
# Description

This PR fixes the React Native build script to properly include non-TypeScript files in the distribution package. The changes add two additional steps to the build process:

1. Copy Blockies utilities JavaScript files that haven't been converted to TypeScript yet
2. Copy SVG assets required by the Icon component

These additions ensure that all necessary assets are included in the final build package, preventing missing file errors when consuming the library.

# Related issues

Fixes: https://github.com/MetaMask/metamask-design-system/issues/652

# Manual testing steps

1. Run the build script using `yarn workspace @metamask/design-system-react-native build` in root
2. Verify that the Blockies utilities are copied to `dist/components/temp-components/Blockies/`
3. Verify that SVG assets are copied to `dist/components/Icon/assets/`

# Screenshots/Recordings

### Before

https://github.com/user-attachments/assets/2b464c29-bd40-483c-ac7b-6e2f3de704bd

### After

https://github.com/user-attachments/assets/09d951be-4737-4321-a769-e783f088642c

# Pre-merge author checklist

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR

# Pre-merge reviewer checklist

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
