### PR TITLE
chore: updating can i use

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8406,9 +8406,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001669":
-  version: 1.0.30001687
-  resolution: "caniuse-lite@npm:1.0.30001687"
-  checksum: 10/0b6a064d5df185ec60b842dba5a27d2c54a66967b7f89571bfd0a8256f0863b1f2a910da6a19ed1b8f534bedf0663cae90309a4a6899bba2286205d459b32f95
+  version: 1.0.30001718
+  resolution: "caniuse-lite@npm:1.0.30001718"
+  checksum: 10/e172a4c156f743cc947e659f353ad9edb045725cc109a02cc792dcbf98569356ebfa4bb4356e3febf87427aab0951c34c1ee5630629334f25ae6f76de7d86fd0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

This PR updates the `caniuse-lite` package from version 1.0.30001687 to 1.0.30001718.

`caniuse-lite` provides browser support data for CSS features and is a critical dependency for tools like Autoprefixer and Browserslist. Keeping this package updated ensures we have the latest browser compatibility data, which helps our design system maintain optimal cross-browser compatibility and reduces potential styling issues.

Regular updates to this package are important as they include the latest browser feature support information, ensuring our CSS transforms and prefixing remain accurate for current browser versions.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Pull this branch
2. Run `yarn install` to update dependencies
3. Build the design system to verify no compatibility issues
4. Run existing tests to ensure no regressions

## **Screenshots/Recordings**

Not applicable for this dependency update.
