### PR TITLE
[TWRNC] Updated Pressed class naming to -pressed

### DIFF
--- a/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
@@ -97,7 +97,7 @@ describe('ButtonPrimary', () => {
     const btn = getByTestId('button-primary');
 
     fireEvent(btn, 'pressIn');
-    expectBackground(btn.props.style, 'bg-primary-defaultPressed');
+    expectBackground(btn.props.style, 'bg-primary-default-pressed');
 
     fireEvent(btn, 'pressOut');
     expectBackground(btn.props.style, 'bg-primary-default');
@@ -112,7 +112,7 @@ describe('ButtonPrimary', () => {
     const btn = getByTestId('button-primary');
 
     fireEvent(btn, 'pressIn');
-    expectBackground(btn.props.style, 'bg-error-defaultPressed');
+    expectBackground(btn.props.style, 'bg-error-default-pressed');
 
     fireEvent(btn, 'pressOut');
     expectBackground(btn.props.style, 'bg-error-default');
@@ -127,7 +127,7 @@ describe('ButtonPrimary', () => {
     const btn = getByTestId('button-primary');
 
     fireEvent(btn, 'pressIn');
-    expectBackground(btn.props.style, 'bg-background-defaultPressed');
+    expectBackground(btn.props.style, 'bg-background-default-pressed');
 
     fireEvent(btn, 'pressOut');
     expectBackground(btn.props.style, 'bg-background-default');
@@ -172,7 +172,7 @@ describe('ButtonPrimary', () => {
       </ButtonPrimary>,
     );
     const btn = getByTestId('button-primary');
-    expectBackground(btn.props.style, 'bg-error-defaultPressed');
+    expectBackground(btn.props.style, 'bg-error-default-pressed');
   });
 
   it('renders inverse+loading background', () => {
@@ -182,7 +182,7 @@ describe('ButtonPrimary', () => {
       </ButtonPrimary>,
     );
     const btn = getByTestId('button-primary');
-    expectBackground(btn.props.style, 'bg-background-defaultPressed');
+    expectBackground(btn.props.style, 'bg-background-default-pressed');
   });
 
   it('renders inverse+danger+loading background', () => {
@@ -192,6 +192,6 @@ describe('ButtonPrimary', () => {
       </ButtonPrimary>,
     );
     const btn = getByTestId('button-primary');
-    expectBackground(btn.props.style, 'bg-background-defaultPressed');
+    expectBackground(btn.props.style, 'bg-background-default-pressed');
   });
 });

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.tsx
@@ -34,18 +34,18 @@ const ButtonPrimaryBase = ({
     ${
       isInverse && isDanger
         ? isPressed || isLoading
-          ? 'bg-background-defaultPressed'
+          ? 'bg-background-default-pressed'
           : 'bg-background-default'
         : isDanger
           ? isPressed || isLoading
-            ? 'bg-error-defaultPressed'
+            ? 'bg-error-default-pressed'
             : 'bg-error-default'
           : isInverse
             ? isPressed || isLoading
-              ? 'bg-background-defaultPressed'
+              ? 'bg-background-default-pressed'
               : 'bg-background-default'
             : isPressed || isLoading
-              ? 'bg-primary-defaultPressed'
+              ? 'bg-primary-default-pressed'
               : 'bg-primary-default'
     }
     ${twClassName}
@@ -54,7 +54,7 @@ const ButtonPrimaryBase = ({
   const twTextClassNames =
     isInverse && isDanger
       ? isPressed || isLoading
-        ? 'text-error-defaultPressed'
+        ? 'text-error-default-pressed'
         : 'text-error-default'
       : isDanger
         ? 'text-primary-inverse'

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
@@ -135,8 +135,8 @@ describe('ButtonSecondary', () => {
     const btn = getByTestId('button-secondary');
 
     fireEvent(btn, 'pressIn');
-    expectBackground(btn.props.style, 'bg-error-mutedPressed');
-    expectBorder(btn.props.style, 'border-error-defaultPressed');
+    expectBackground(btn.props.style, 'bg-error-muted-pressed');
+    expectBorder(btn.props.style, 'border-error-default-pressed');
 
     fireEvent(btn, 'pressOut');
     expectBackground(btn.props.style, 'bg-transparent');
@@ -199,8 +199,8 @@ describe('ButtonSecondary', () => {
       </ButtonSecondary>,
     );
     const btn = getByTestId('button-secondary');
-    expectBackground(btn.props.style, 'bg-error-mutedPressed');
-    expectBorder(btn.props.style, 'border-error-defaultPressed');
+    expectBackground(btn.props.style, 'bg-error-muted-pressed');
+    expectBorder(btn.props.style, 'border-error-default-pressed');
   });
 
   it('renders inverse+loading background & border', () => {
@@ -221,7 +221,7 @@ describe('ButtonSecondary', () => {
       </ButtonSecondary>,
     );
     const btn = getByTestId('button-secondary');
-    expectBackground(btn.props.style, 'bg-background-defaultPressed');
-    expectBorder(btn.props.style, 'border-background-defaultPressed');
+    expectBackground(btn.props.style, 'bg-background-default-pressed');
+    expectBorder(btn.props.style, 'border-background-default-pressed');
   });
 });

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.tsx
@@ -30,11 +30,11 @@ export const ButtonSecondary = ({
     ${
       isInverse && isDanger
         ? isPressed || isLoading
-          ? 'bg-background-defaultPressed'
+          ? 'bg-background-default-pressed'
           : 'bg-background-default'
         : isDanger
           ? isPressed || isLoading
-            ? 'bg-error-mutedPressed'
+            ? 'bg-error-muted-pressed'
             : 'bg-transparent'
           : isPressed || isLoading
             ? 'bg-background-pressed'
@@ -44,11 +44,11 @@ export const ButtonSecondary = ({
     ${
       isInverse && isDanger
         ? isPressed || isLoading
-          ? 'border-background-defaultPressed'
+          ? 'border-background-default-pressed'
           : 'border-background-default'
         : isDanger
           ? isPressed || isLoading
-            ? 'border-error-defaultPressed'
+            ? 'border-error-default-pressed'
             : 'border-error-default'
           : isInverse
             ? 'border-primary-inverse'
@@ -59,7 +59,7 @@ export const ButtonSecondary = ({
 
   const twTextClassNames = isDanger
     ? isPressed || isLoading
-      ? 'text-error-defaultPressed'
+      ? 'text-error-default-pressed'
       : 'text-error-default'
     : isInverse
       ? 'text-primary-inverse'

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.test.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.test.tsx
@@ -130,8 +130,8 @@ describe('ButtonTertiary', () => {
     const btn = getByTestId('button-tertiary');
 
     fireEvent(btn, 'pressIn');
-    expectBackground(btn.props.style, 'bg-error-mutedPressed');
-    expectBorder(btn.props.style, 'border-error-mutedPressed');
+    expectBackground(btn.props.style, 'bg-error-muted-pressed');
+    expectBorder(btn.props.style, 'border-error-muted-pressed');
 
     fireEvent(btn, 'pressOut');
     expectBackground(btn.props.style, 'bg-transparent');
@@ -194,8 +194,8 @@ describe('ButtonTertiary', () => {
       </ButtonTertiary>,
     );
     const btn = getByTestId('button-tertiary');
-    expectBackground(btn.props.style, 'bg-error-mutedPressed');
-    expectBorder(btn.props.style, 'border-error-mutedPressed');
+    expectBackground(btn.props.style, 'bg-error-muted-pressed');
+    expectBorder(btn.props.style, 'border-error-muted-pressed');
   });
 
   it('renders inverse+loading', () => {
@@ -216,7 +216,7 @@ describe('ButtonTertiary', () => {
       </ButtonTertiary>,
     );
     const btn = getByTestId('button-tertiary');
-    expectBackground(btn.props.style, 'bg-background-defaultPressed');
-    expectBorder(btn.props.style, 'border-background-defaultPressed');
+    expectBackground(btn.props.style, 'bg-background-default-pressed');
+    expectBorder(btn.props.style, 'border-background-default-pressed');
   });
 });

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.tsx
@@ -30,11 +30,11 @@ export const ButtonTertiary = ({
     ${
       isInverse && isDanger
         ? isPressed || isLoading
-          ? 'bg-background-defaultPressed'
+          ? 'bg-background-default-pressed'
           : 'bg-background-default'
         : isDanger
           ? isPressed || isLoading
-            ? 'bg-error-mutedPressed'
+            ? 'bg-error-muted-pressed'
             : 'bg-transparent'
           : isInverse
             ? isPressed || isLoading
@@ -48,11 +48,11 @@ export const ButtonTertiary = ({
     ${
       isInverse && isDanger
         ? isPressed || isLoading
-          ? 'border-background-defaultPressed'
+          ? 'border-background-default-pressed'
           : 'border-background-default'
         : isDanger
           ? isPressed || isLoading
-            ? 'border-error-mutedPressed'
+            ? 'border-error-muted-pressed'
             : 'border-transparent'
           : isInverse
             ? 'border-primary-inverse'
@@ -64,12 +64,12 @@ export const ButtonTertiary = ({
 
   const twTextClassNames = isDanger
     ? isPressed || isLoading
-      ? 'text-error-defaultPressed'
+      ? 'text-error-default-pressed'
       : 'text-error-default'
     : isInverse
       ? 'text-primary-inverse'
       : isPressed || isLoading
-        ? 'text-primary-defaultPressed'
+        ? 'text-primary-default-pressed'
         : 'text-primary-default';
 
   const onPressInHandler = (event: GestureResponderEvent) => {

--- a/packages/design-system-react-native/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/design-system-react-native/src/components/Checkbox/Checkbox.test.tsx
@@ -200,7 +200,7 @@ describe('Checkbox', () => {
     expect(styles).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining(
-          tw`bg-background-defaultPressed border-border-default flex h-[22px] w-[22px] items-center justify-center rounded border-2`,
+          tw`bg-background-default-pressed border-border-default flex h-[22px] w-[22px] items-center justify-center rounded border-2`,
         ),
       ]),
     );

--- a/packages/design-system-react-native/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system-react-native/src/components/Checkbox/Checkbox.tsx
@@ -93,11 +93,11 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
           baseBorder = 'border-error-default';
         }
         const pressedBg = isSelected
-          ? 'bg-primary-defaultPressed'
-          : 'bg-background-defaultPressed';
+          ? 'bg-primary-default-pressed'
+          : 'bg-background-default-pressed';
         let pressedBorder = 'border-border-default';
         if (isSelected) {
-          pressedBorder = 'border-primary-defaultPressed';
+          pressedBorder = 'border-primary-default-pressed';
         } else if (isInvalid) {
           pressedBorder = 'border-error-default';
         }

--- a/packages/design-system-react-native/src/components/TextButton/TextButton.test.tsx
+++ b/packages/design-system-react-native/src/components/TextButton/TextButton.test.tsx
@@ -208,7 +208,7 @@ describe('TextButton', () => {
     expect(txtPrStyles).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          color: tw`text-primary-defaultPressed`.color,
+          color: tw`text-primary-default-pressed`.color,
         }),
         expect.objectContaining({ textDecorationLine: 'underline' }),
       ]),
@@ -216,7 +216,7 @@ describe('TextButton', () => {
 
     const iconPressed = renderedPressed.findByProps({ testID: 'start-icon' });
     expect(iconPressed.props.twClassName).toContain(
-      'text-primary-defaultPressed',
+      'text-primary-default-pressed',
     );
   });
 });

--- a/packages/design-system-react-native/src/components/TextButton/TextButton.tsx
+++ b/packages/design-system-react-native/src/components/TextButton/TextButton.tsx
@@ -45,7 +45,7 @@ export const TextButton: React.FC<TextButtonProps> = ({
       if (isInverse) {
         return 'text-primary-inverse';
       }
-      return pressed ? 'text-primary-defaultPressed' : 'text-primary-default';
+      return pressed ? 'text-primary-default-pressed' : 'text-primary-default';
     },
     [isInverse],
   );

--- a/packages/design-system-react-native/src/types/index.ts
+++ b/packages/design-system-react-native/src/types/index.ts
@@ -230,7 +230,7 @@ export enum TextColor {
   /** For elements used on top of primary/default. */
   PrimaryInverse = 'text-primary-inverse',
   /** For primary text in a pressed state. */
-  PrimaryDefaultPressed = 'text-primary-defaultPressed',
+  PrimaryDefaultPressed = 'text-primary-default-pressed',
   /** For critical alert text. */
   ErrorDefault = 'text-error-default',
   /** For stronger contrast error text. */
@@ -238,19 +238,19 @@ export enum TextColor {
   /** For elements used on top of error/default. */
   ErrorInverse = 'text-error-inverse',
   /** For critical alert text in a pressed state. */
-  ErrorDefaultPressed = 'text-error-defaultPressed',
+  ErrorDefaultPressed = 'text-error-default-pressed',
   /** For caution alert text. */
   WarningDefault = 'text-warning-default',
   /** For elements used on top of warning/default. */
   WarningInverse = 'text-warning-inverse',
   /** For caution text in a pressed state. */
-  WarningDefaultPressed = 'text-warning-defaultPressed',
+  WarningDefaultPressed = 'text-warning-default-pressed',
   /** For positive semantic text. */
   SuccessDefault = 'text-success-default',
   /** For elements used on top of success/default. */
   SuccessInverse = 'text-success-inverse',
   /** For positive text in a pressed state. */
-  SuccessDefaultPressed = 'text-success-defaultPressed',
+  SuccessDefaultPressed = 'text-success-default-pressed',
   /** For informational read-only text. */
   InfoDefault = 'text-info-default',
   /** For elements used on top of info/default. */
@@ -323,7 +323,7 @@ export enum IconColor {
   /** For elements used on top of primary/default. Used for text, icon, or border */
   PrimaryInverse = 'text-primary-inverse',
   /** For primary interactive elements in a pressed state */
-  PrimaryDefaultPressed = 'text-primary-defaultPressed',
+  PrimaryDefaultPressed = 'text-primary-default-pressed',
   /** For critical alert semantic elements. Used for text, background, icon, or border */
   ErrorDefault = 'text-error-default',
   /** For softer variants of error elements */
@@ -331,19 +331,19 @@ export enum IconColor {
   /** For elements used on top of error/default. Used for text, icon, or border */
   ErrorInverse = 'text-error-inverse',
   /** For critical alert semantic elements in a pressed state */
-  ErrorDefaultPressed = 'text-error-defaultPressed',
+  ErrorDefaultPressed = 'text-error-default-pressed',
   /** For caution alert semantic elements. Used for text, background, icon, or border */
   WarningDefault = 'text-warning-default',
   /** For elements used on top of warning/default. Used for text, icon, or border */
   WarningInverse = 'text-warning-inverse',
   /** For caution alert semantic elements in a pressed state */
-  WarningDefaultPressed = 'text-warning-defaultPressed',
+  WarningDefaultPressed = 'text-warning-default-pressed',
   /** For positive semantic elements. Used for text, background, icon, or border */
   SuccessDefault = 'text-success-default',
   /** For elements used on top of success/default. Used for text, icon, or border */
   SuccessInverse = 'text-success-inverse',
   /** For positive semantic elements in a pressed state */
-  SuccessDefaultPressed = 'text-success-defaultPressed',
+  SuccessDefaultPressed = 'text-success-default-pressed',
   /** For informational read-only elements. Used for text, background, icon, or border */
   InfoDefault = 'text-info-default',
   /** For elements used on top of info/default. Used for text, icon, or border */

--- a/packages/design-system-twrnc-preset/src/twrnc-settings/colors.utilities.ts
+++ b/packages/design-system-twrnc-preset/src/twrnc-settings/colors.utilities.ts
@@ -1,38 +1,78 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
- * Helper function to flatten a nested color object into a single-level object
- * with keys as kebab-case strings and values as strings.
+ * Helper function to convert a camelCase / PascalCase string to kebab-case.
  *
- * @param colors - A nested object representing color values.
- * @param prefix - A string prefix used for constructing flattened keys.
- * @returns A single-level object with flattened keys and their corresponding color values.
+ * It inserts a hyphen (“-”) before every capital letter (while also handling
+ * consecutive capitals), then lower-cases the entire result.
+ *
+ * @param str - The original camelCase or PascalCase string.
+ * @returns The kebab-case representation of the input.
+ *
  * @example
- * const colors = {
+ * toKebab('defaultHover');  // → 'default-hover'
+ * toKebab('RGBValue');      // → 'r-g-b-value'
+ */
+const toKebab = (str: string): string =>
+  str
+    // place a dash between lower/number → upper transitions
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    // place a dash between upper → upper+lower transitions (e.g. "RGBValue")
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+
+/**
+ * Recursively flattens a nested colour definition object into a single-level map
+ * whose keys are fully kebab-cased, dash-delimited paths.
+ *
+ * Each segment of the path (including camelCase properties) is converted to
+ * kebab-case. The resulting keys are built by concatenating the segments with
+ * “-” and prepending any parent prefix supplied during recursion.
+ *
+ * @param colors - A nested object representing colour values.
+ * @param prefix - (For internal use) The current path prefix accumulated during
+ *                 recursion. Leave blank when calling directly.
+ * @returns A flat object whose keys are kebab-cased paths and whose values are
+ *          the corresponding colour strings.
+ *
+ * @example
+ * const palette = {
  *   primary: {
- *     default: '#abc',
- *     alternative: '#123',
+ *     default: '#4459ff',
+ *     defaultHover: '#384df5',
+ *     muted: '#4459ff1a',
  *   },
- *   secondary: '#456',
+ *   secondary: '#2c3dc5',
  * };
  *
- * flattenColors(colors);
- * // Returns:
- * // {
- * //   'primary-default': '#abc',
- * //   'primary-alternative': '#123',
- * //   'secondary': '#456'
+ * flattenColors(palette);
+ * // ⇒ {
+ * //   'primary-default': '#4459ff',
+ * //   'primary-default-hover': '#384df5',
+ * //   'primary-muted': '#4459ff1a',
+ * //   'secondary': '#2c3dc5'
  * // }
  */
-export const flattenColors = (colors: Record<string, any>, prefix = '') => {
+export const flattenColors = (
+  colors: Record<string, any>,
+  prefix = '',
+): Record<string, string> => {
   let result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(colors)) {
+
+  for (const [rawKey, value] of Object.entries(colors)) {
+    const key = toKebab(rawKey);
+
     if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      // Recurse into nested objects and merge their flattened results
       result = { ...result, ...flattenColors(value, `${prefix}${key}-`) };
     } else if (typeof value === 'string') {
+      // Leaf node: add the fully-qualified kebab-case key
       result[`${prefix}${key}`] = value;
     } else {
-      console.warn(`Invalid color value for ${prefix}${key}:`, value);
+      /* eslint-disable-next-line no-console */
+      console.warn(`Invalid colour value for ${prefix}${key}:`, value);
     }
   }
+
   return result;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates the `Pressed` class naming in twrnc to `-pressed` aligning with Tailwind configs

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #670 

## **Manual testing steps**

1. Run `yarn build`
2. Run `yarn storybook:ios`
3. Check all relevant stories (Buttons, Checkbox, TextButton, Icon, Text)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
