### PR TITLE
chore: remove color set from twrnc preset

### DIFF
--- a/apps/storybook-react-native/.storybook/config.js
+++ b/apps/storybook-react-native/.storybook/config.js
@@ -1,11 +1,7 @@
 import { addDecorator } from '@storybook/react-native';
 import { addons } from '@storybook/addons';
 
-import {
-  ColorSet,
-  ThemeProvider,
-  Theme,
-} from '@metamask/design-system-twrnc-preset';
+import { ThemeProvider, Theme } from '@metamask/design-system-twrnc-preset';
 
 import FontLoader from './FontLoader';
 
@@ -16,7 +12,7 @@ addons.setConfig({
 });
 
 addDecorator((Story) => (
-  <ThemeProvider colorSet={ColorSet.Brand} theme={Theme.Default}>
+  <ThemeProvider theme={Theme.Default}>
     <FontLoader>
       <Story />
     </FontLoader>

--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -47,9 +47,6 @@
   "packages/design-system-tailwind-preset/src/typography.test.ts": {
     "jest/no-conditional-in-test": 1
   },
-  "packages/design-system-twrnc-preset/src/Theme/Theme.providers.tsx": {
-    "no-empty-function": 2
-  },
   "packages/design-tokens/src/js/brandColor/brandColor.test.ts": {
     "jest/no-conditional-in-test": 2
   },

--- a/packages/design-system-twrnc-preset/src/Theme/Theme.providers.tsx
+++ b/packages/design-system-twrnc-preset/src/Theme/Theme.providers.tsx
@@ -2,19 +2,17 @@ import React, { createContext, useState, useMemo } from 'react';
 import { useColorScheme } from 'react-native';
 import { create } from 'twrnc';
 
-import { ColorSet, ColorScheme, colorSetList } from '../twrnc-settings';
+import { ColorScheme, colorSetList } from '../twrnc-settings';
 
 import type { ThemeContextProps, ThemeProviderProps } from './Theme.types';
 import { Theme } from './Theme.types';
 import { generateTailwindConfig } from './Theme.utilities';
 
 export const defaultThemeContextValue: ThemeContextProps = {
-  tw: create(generateTailwindConfig(ColorSet.Brand, ColorScheme.Light)),
-  colorSet: ColorSet.Brand,
-  colorSetList: colorSetList[ColorSet.Brand][Theme.Light],
+  tw: create(generateTailwindConfig(ColorScheme.Light)),
+  colorSetList: colorSetList[ColorScheme.Light],
   theme: Theme.Light,
-  setColorSet: () => {},
-  setTheme: () => {},
+  setTheme: () => undefined,
 };
 
 export const ThemeContext = createContext<ThemeContextProps>(
@@ -23,10 +21,8 @@ export const ThemeContext = createContext<ThemeContextProps>(
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   children,
-  colorSet = ColorSet.Brand,
   theme = Theme.Default,
 }) => {
-  const [currentColorSet, setCurrentColorSet] = useState<ColorSet>(colorSet);
   const [currentTheme, setCurrentTheme] = useState<Theme>(theme);
   const systemColorScheme = useColorScheme(); // 'light' | 'dark' | null
 
@@ -44,23 +40,17 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
     }
     throw new Error('Invalid theme value');
   }, [currentTheme, systemColorScheme]);
-
   const tw = useMemo(() => {
-    const tailwindConfig = generateTailwindConfig(
-      currentColorSet,
-      activeColorScheme,
-    );
+    const tailwindConfig = generateTailwindConfig(activeColorScheme);
     return create(tailwindConfig);
-  }, [currentColorSet, activeColorScheme]);
+  }, [activeColorScheme]);
 
   return (
     <ThemeContext.Provider
       value={{
         tw,
-        colorSet: currentColorSet,
-        colorSetList: colorSetList[colorSet][activeColorScheme],
+        colorSetList: colorSetList[activeColorScheme],
         theme: currentTheme,
-        setColorSet: setCurrentColorSet,
         setTheme: setCurrentTheme,
       }}
     >

--- a/packages/design-system-twrnc-preset/src/Theme/Theme.types.ts
+++ b/packages/design-system-twrnc-preset/src/Theme/Theme.types.ts
@@ -1,7 +1,6 @@
 import type { create } from 'twrnc';
 
 import { ColorScheme } from '../twrnc-settings';
-import type { ColorSet } from '../twrnc-settings';
 
 export enum Theme {
   Default = 'default',
@@ -11,15 +10,12 @@ export enum Theme {
 
 export type ThemeContextProps = {
   tw: ReturnType<typeof create>;
-  colorSet: ColorSet;
   colorSetList: Record<string, string>;
   theme: Theme;
-  setColorSet: (theme: ColorSet) => void;
-  setTheme: (scheme: Theme) => void;
+  setTheme: (theme: Theme) => void;
 };
 
 export type ThemeProviderProps = {
   children: React.ReactNode;
-  colorSet?: ColorSet;
   theme?: Theme;
 };

--- a/packages/design-system-twrnc-preset/src/Theme/Theme.utilities.ts
+++ b/packages/design-system-twrnc-preset/src/Theme/Theme.utilities.ts
@@ -1,30 +1,18 @@
-import type { ColorSet, ColorScheme } from '../twrnc-settings';
+import type { TwConfig } from 'twrnc';
+
+import type { ColorScheme } from '../twrnc-settings';
 import { colorSetList, typographyTailwindConfig } from '../twrnc-settings';
 
-// Inline base Tailwind config to avoid relative import issues when package is consumed
-const baseConfig = {
-  content: ['./src/**/*.{js,jsx,ts,tsx}'],
-  theme: {
-    extend: {
-      colors: {},
-    },
-  },
-  plugins: [],
-};
-
 /**
- * Generates a Tailwind CSS configuration object based on the specified color set and color scheme.
+ * Generates a Tailwind CSS configuration object based on the specified color scheme.
  * This configuration extends the base Tailwind settings with custom theme colors, typography settings,
  * and other style properties for use in React Native with `twrnc`.
  *
- * @param colorSet - The color set to use (e.g., 'Brand', 'Neutral'). Determines the base palette for the theme.
- * @param colorScheme - The current color scheme ('light' or 'dark'). Specifies whether to use light or dark mode styles.
+ * @param colorScheme - The color scheme ('light' or 'dark'). Specifies whether to use light or dark mode styles.
  * @returns A Tailwind CSS configuration object with extended theme properties and plugins.
  * @example
- * const colorSet = 'Brand';
  * const colorScheme = 'dark';
- *
- * const tailwindConfig = generateTailwindConfig(colorSet, colorScheme);
+ * const tailwindConfig = generateTailwindConfig(colorScheme);
  * console.log(tailwindConfig);
  *
  * Output:
@@ -58,11 +46,8 @@ const baseConfig = {
  * }
  * @throws Will log an error and return an empty object if theme colors are not found for the specified color set and color scheme.
  */
-export const generateTailwindConfig = (
-  colorSet: ColorSet,
-  colorScheme: ColorScheme,
-) => {
-  const themeColors = colorSetList[colorSet][colorScheme];
+export const generateTailwindConfig = (colorScheme: ColorScheme): TwConfig => {
+  const themeColors = colorSetList[colorScheme];
 
   if (!themeColors) {
     console.error('Theme colors not found.');
@@ -70,13 +55,9 @@ export const generateTailwindConfig = (
   }
 
   return {
-    ...baseConfig,
     theme: {
-      ...baseConfig.theme,
       extend: {
-        ...baseConfig.theme?.extend,
         colors: {
-          ...baseConfig.theme?.extend?.colors,
           ...themeColors,
         },
         fontSize: {
@@ -93,6 +74,5 @@ export const generateTailwindConfig = (
         },
       },
     },
-    plugins: baseConfig.plugins || [],
   };
 };

--- a/packages/design-system-twrnc-preset/src/index.ts
+++ b/packages/design-system-twrnc-preset/src/index.ts
@@ -1,4 +1,4 @@
 export type { ThemeContextProps, ThemeProviderProps } from './Theme';
 export { useTailwind, ThemeContext, ThemeProvider, Theme } from './Theme';
 
-export { ColorSet } from './twrnc-settings';
+export { ColorScheme } from './twrnc-settings';

--- a/packages/design-system-twrnc-preset/src/twrnc-settings/colors.ts
+++ b/packages/design-system-twrnc-preset/src/twrnc-settings/colors.ts
@@ -1,12 +1,10 @@
 import { lightTheme, darkTheme } from '@metamask/design-tokens';
 
 import type { ColorSetListProps } from './colors.types';
-import { ColorSet, ColorScheme } from './colors.types';
+import { ColorScheme } from './colors.types';
 import { flattenColors } from './colors.utilities';
 
 export const colorSetList: ColorSetListProps = {
-  [ColorSet.Brand]: {
-    [ColorScheme.Light]: flattenColors(lightTheme.colors),
-    [ColorScheme.Dark]: flattenColors(darkTheme.colors),
-  },
+  [ColorScheme.Light]: flattenColors(lightTheme.colors),
+  [ColorScheme.Dark]: flattenColors(darkTheme.colors),
 };

--- a/packages/design-system-twrnc-preset/src/twrnc-settings/colors.types.ts
+++ b/packages/design-system-twrnc-preset/src/twrnc-settings/colors.types.ts
@@ -1,11 +1,4 @@
 /**
- * Enum for different color set options.
- */
-export enum ColorSet {
-  Brand = 'brand',
-}
-
-/**
  * Enum for different color scheme options.
  */
 export enum ColorScheme {
@@ -14,7 +7,7 @@ export enum ColorScheme {
 }
 
 /**
- * Props for ColorSet. Each color set - color scheme should contain
+ * Props for colorSetList. Each color scheme should contain
  * an object with twrnc-className string as key and color string as value.
  *
  * @example
@@ -25,8 +18,6 @@ export enum ColorScheme {
  * // }
  */
 export type ColorSetListProps = {
-  brand: {
-    [ColorScheme.Light]: Record<string, string>;
-    [ColorScheme.Dark]: Record<string, string>;
-  };
+  [ColorScheme.Light]: Record<string, string>;
+  [ColorScheme.Dark]: Record<string, string>;
 };

--- a/packages/design-system-twrnc-preset/src/twrnc-settings/index.ts
+++ b/packages/design-system-twrnc-preset/src/twrnc-settings/index.ts
@@ -1,4 +1,4 @@
 export { colorSetList } from './colors';
-export { ColorSet, ColorScheme } from './colors.types';
+export { ColorScheme } from './colors.types';
 
 export { typographyTailwindConfig } from './typography';

--- a/packages/design-system-twrnc-preset/src/twrnc-settings/typography.ts
+++ b/packages/design-system-twrnc-preset/src/twrnc-settings/typography.ts
@@ -5,7 +5,7 @@ import type { TypographyTailwindConfigProps } from './typography.types';
 export const typographyTailwindConfig: TypographyTailwindConfigProps = {
   fontSize: {
     'display-lg': [
-      typography.sDisplayLG.fontSize,
+      typography.sDisplayLG.fontSize.toString(),
       {
         lineHeight: `${typography.sDisplayLG.lineHeight as number}px`,
         letterSpacing: `${typography.sDisplayLG.letterSpacing as number}`,
@@ -13,7 +13,7 @@ export const typographyTailwindConfig: TypographyTailwindConfigProps = {
       },
     ],
     'display-md': [
-      typography.sDisplayMD.fontSize,
+      typography.sDisplayMD.fontSize.toString(),
       {
         lineHeight: `${typography.sDisplayMD.lineHeight as number}px`,
         letterSpacing: `${typography.sDisplayMD.letterSpacing as number}`,
@@ -21,7 +21,7 @@ export const typographyTailwindConfig: TypographyTailwindConfigProps = {
       },
     ],
     'heading-lg': [
-      typography.sHeadingLG.fontSize,
+      typography.sHeadingLG.fontSize.toString(),
       {
         lineHeight: `${typography.sHeadingLG.lineHeight as number}px`,
         letterSpacing: `${typography.sHeadingLG.letterSpacing as number}`,
@@ -29,7 +29,7 @@ export const typographyTailwindConfig: TypographyTailwindConfigProps = {
       },
     ],
     'heading-md': [
-      typography.sHeadingMD.fontSize,
+      typography.sHeadingMD.fontSize.toString(),
       {
         lineHeight: `${typography.sHeadingMD.lineHeight as number}px`,
         letterSpacing: `${typography.sHeadingMD.letterSpacing as number}`,
@@ -37,7 +37,7 @@ export const typographyTailwindConfig: TypographyTailwindConfigProps = {
       },
     ],
     'heading-sm': [
-      typography.sHeadingSM.fontSize,
+      typography.sHeadingSM.fontSize.toString(),
       {
         lineHeight: `${typography.sHeadingSM.lineHeight as number}px`,
         letterSpacing: `${typography.sHeadingSM.letterSpacing as number}`,
@@ -45,7 +45,7 @@ export const typographyTailwindConfig: TypographyTailwindConfigProps = {
       },
     ],
     'body-lg': [
-      typography.sBodyLGMedium.fontSize,
+      typography.sBodyLGMedium.fontSize.toString(),
       {
         lineHeight: `${typography.sBodyLGMedium.lineHeight as number}px`,
         letterSpacing: `${typography.sBodyLGMedium.letterSpacing as number}`,
@@ -53,7 +53,7 @@ export const typographyTailwindConfig: TypographyTailwindConfigProps = {
       },
     ],
     'body-md': [
-      typography.sBodyMD.fontSize,
+      typography.sBodyMD.fontSize.toString(),
       {
         lineHeight: `${typography.sBodyMD.lineHeight as number}px`,
         letterSpacing: `${typography.sBodyMD.letterSpacing as number}`,
@@ -61,7 +61,7 @@ export const typographyTailwindConfig: TypographyTailwindConfigProps = {
       },
     ],
     'body-sm': [
-      typography.sBodySM.fontSize,
+      typography.sBodySM.fontSize.toString(),
       {
         lineHeight: `${typography.sBodySM.lineHeight as number}px`,
         letterSpacing: `${typography.sBodySM.letterSpacing as number}`,
@@ -69,7 +69,7 @@ export const typographyTailwindConfig: TypographyTailwindConfigProps = {
       },
     ],
     'body-xs': [
-      typography.sBodyXS.fontSize,
+      typography.sBodyXS.fontSize.toString(),
       {
         lineHeight: `${typography.sBodyXS.lineHeight as number}px`,
         letterSpacing: `${typography.sBodyXS.letterSpacing as number}`,

--- a/packages/design-system-twrnc-preset/src/twrnc-settings/typography.types.ts
+++ b/packages/design-system-twrnc-preset/src/twrnc-settings/typography.types.ts
@@ -69,7 +69,7 @@ export type TypographyTailwindConfigProps = {
   fontSize: Record<
     TypographyVariant,
     [
-      number,
+      string,
       {
         lineHeight: string; // Make sure to include units - "40px" instead of "40"
         letterSpacing: string;


### PR DESCRIPTION
## **Description**

This PR simplifies the theme handling in the `design-system-twrnc-preset` by removing the unused `ColorSet` enum and its associated complexity. The changes streamline the color management by directly mapping color schemes to colors without the unnecessary `brand` object nesting.

Key improvements:
1. Removes unused `ColorSet` enum and related types
2. Simplifies color set list structure by removing unnecessary nesting
3. Updates theme configuration to work directly with color schemes
4. Maintains backward compatibility with existing theme functionality
5. Converts font sizes to strings to match twrnc library requirements

These changes reduce complexity in the codebase while maintaining all existing functionality. The removal of `ColorSet` was possible because we only ever used the `Brand` value, making the additional abstraction unnecessary.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/issues/719 https://github.com/MetaMask/metamask-design-system/issues/720

## **Manual testing steps**

1. Run `yarn build && yarn && yarn storybook:ios`
2. Verify light/dark theme switching works correctly
3. Verify all components render with correct colors
4. Check that font sizes render correctly in all components

## **Screenshots/Recordings**

N/A - No visual changes, this is an internal refactor

### **Before**

Color configuration had unnecessary nesting:
```typescript
export const colorSetList: ColorSetListProps = {
  [ColorSet.Brand]: {
    [ColorScheme.Light]: flattenColors(lightTheme.colors),
    [ColorScheme.Dark]: flattenColors(darkTheme.colors),
  },
};
```

### **After**

Simplified color configuration:
```typescript
export const colorSetList: ColorSetListProps = {
  [ColorScheme.Light]: flattenColors(lightTheme.colors),
  [ColorScheme.Dark]: flattenColors(darkTheme.colors),
};
```

Theming works as expected

https://github.com/user-attachments/assets/a7084178-cb3f-4201-9457-55b5cd9e577f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.