### PR TITLE
chore: updates to box and updating example screen

### DIFF
--- a/apps/storybook-react/stories/WalletHome.stories.tsx
+++ b/apps/storybook-react/stories/WalletHome.stories.tsx
@@ -7,6 +7,11 @@ import {
   BadgeCount,
   BadgeWrapper,
   BadgeNetwork,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxFlexWrap,
+  BoxJustifyContent,
   Button,
   ButtonBase,
   ButtonIcon,
@@ -34,9 +39,9 @@ const meta: Meta = {
   // Remove default padding
   decorators: [
     (Story) => (
-      <div className="m-[-1rem]">
+      <Box className="m-[-1rem]">
         <Story />
-      </div>
+      </Box>
     ),
   ],
 };
@@ -46,27 +51,39 @@ type Story = StoryObj;
 
 const WalletHome: React.FC = () => {
   return (
-    <div className="min-h-screen md:flex md:items-center md:justify-center md:bg-alternative md:py-4">
+    <Box className="min-h-screen md:flex md:items-center md:justify-center md:bg-alternative md:py-4">
       {/* Container Expanded View */}
-      <div className="mx-auto w-full bg-default md:max-w-xl md:rounded-3xl md:py-4">
+      <Box className="mx-auto w-full bg-default md:max-w-xl md:rounded-3xl md:py-4">
         {/* Header */}
-        <div className="border-color-border-muted px-4 py-4 md:px-8">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2 overflow-hidden">
+        <Box className="border-color-border-muted px-4 py-4 md:px-8">
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Between}
+          >
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={2}
+              className="overflow-hidden"
+            >
               <AvatarAccount
                 shape={AvatarBaseShape.Square}
                 variant={AvatarAccountVariant.Maskicon}
                 address="0x1234567890123456789012345678901234567890"
               />
               <Text asChild variant={TextVariant.HeadingMd} ellipsis>
-                <div>DeFi Account</div>
+                <Box>DeFi Account</Box>
               </Text>
               <ButtonIcon
                 iconName={IconName.ArrowDown}
                 ariaLabel="Switch Account"
               />
-            </div>
-            <div className="flex items-center">
+            </Box>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+            >
               <ButtonIcon iconName={IconName.Copy} ariaLabel="Copy" />
               <ButtonIcon iconName={IconName.Global} ariaLabel="Network" />
               <BadgeWrapper
@@ -75,19 +92,27 @@ const WalletHome: React.FC = () => {
               >
                 <ButtonIcon iconName={IconName.Menu} ariaLabel="Menu" />
               </BadgeWrapper>
-            </div>
-          </div>
-        </div>
+            </Box>
+          </Box>
+        </Box>
         {/* Balance */}
-        <div className="px-4 py-4 md:px-8">
+        <Box className="px-4 py-4 md:px-8">
           <Text variant={TextVariant.DisplayMd}>$10,528.46</Text>
-          <div className="flex items-center">
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+          >
             <Icon name={IconName.Arrow2Up} color={IconColor.SuccessDefault} />
             <Text color={TextColor.TextAlternative}>$367.00 (+0.66%)</Text>
-          </div>
-        </div>
+          </Box>
+        </Box>
         {/* Actions */}
-        <div className="flex flex-wrap gap-2 px-4 py-4 md:px-8">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          flexWrap={BoxFlexWrap.Wrap}
+          gap={2}
+          className="px-4 py-4 md:px-8"
+        >
           <ButtonBase className="h-auto flex-1 flex-col justify-center rounded-lg bg-muted py-4 hover:bg-muted-hover active:bg-muted-pressed">
             <Icon name={IconName.Bank} className="mb-2" />
             Buy/Sell
@@ -104,10 +129,10 @@ const WalletHome: React.FC = () => {
             <Icon name={IconName.Send} className="mb-2" />
             Send
           </ButtonBase>
-        </div>
+        </Box>
         {/* Tabs */}
-        <div className="border-b border-border-muted px-4 md:px-8">
-          <div className="flex">
+        <Box className="border-b border-border-muted px-4 md:px-8">
+          <Box flexDirection={BoxFlexDirection.Row}>
             <Text
               asChild
               fontWeight={FontWeight.Medium}
@@ -142,12 +167,21 @@ const WalletHome: React.FC = () => {
             >
               <button>Activity</button>
             </Text>
-          </div>
-        </div>
+          </Box>
+        </Box>
         {/* Token List */}
-        <div className="">
-          <div className="flex items-center justify-between px-4 py-4 md:px-8">
-            <div className="flex items-center space-x-2">
+        <Box>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Between}
+            className="px-4 py-4 md:px-8"
+          >
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={2}
+            >
               <Button
                 size={ButtonSize.Sm}
                 variant={ButtonVariant.Secondary}
@@ -155,19 +189,27 @@ const WalletHome: React.FC = () => {
               >
                 Popular networks
               </Button>
-            </div>
-            <div className="flex space-x-2">
+            </Box>
+            <Box flexDirection={BoxFlexDirection.Row} gap={2}>
               <ButtonIcon iconName={IconName.Filter} ariaLabel="Filter" />
               <ButtonIcon iconName={IconName.MoreVertical} ariaLabel="More" />
-            </div>
-          </div>
+            </Box>
+          </Box>
 
           {/* Ethereum */}
-          <div
+          <Box
             tabIndex={0}
-            className="bg-transparent flex w-full items-center justify-between px-4 py-2 hover:bg-hover active:bg-pressed md:px-8"
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Between}
+            className="bg-transparent w-full px-4 py-2 hover:bg-hover active:bg-pressed md:px-8"
           >
-            <div className="flex items-center space-x-4 overflow-hidden">
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={4}
+              className="overflow-hidden"
+            >
               <BadgeWrapper
                 badge={
                   <BadgeNetwork
@@ -182,8 +224,15 @@ const WalletHome: React.FC = () => {
                   size={AvatarTokenSize.Md}
                 />
               </BadgeWrapper>
-              <div className="flex flex-col overflow-hidden">
-                <div className="flex flex-wrap items-center">
+              <Box
+                flexDirection={BoxFlexDirection.Column}
+                className="overflow-hidden"
+              >
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  flexWrap={BoxFlexWrap.Wrap}
+                  alignItems={BoxAlignItems.Center}
+                >
                   <Text
                     fontWeight={FontWeight.Medium}
                     ellipsis
@@ -200,7 +249,7 @@ const WalletHome: React.FC = () => {
                   >
                     Earn
                   </TextButton>
-                </div>
+                </Box>
                 <Text
                   color={TextColor.TextAlternative}
                   variant={TextVariant.BodySm}
@@ -213,9 +262,9 @@ const WalletHome: React.FC = () => {
                   />
                   <span>+85.88%</span>
                 </Text>
-              </div>
-            </div>
-            <div className="text-right">
+              </Box>
+            </Box>
+            <Box className="text-right">
               <Text>$8,509.44</Text>
               <Text
                 color={TextColor.TextAlternative}
@@ -223,15 +272,23 @@ const WalletHome: React.FC = () => {
               >
                 0.7107 ETH
               </Text>
-            </div>
-          </div>
+            </Box>
+          </Box>
 
           {/* Unibright */}
-          <div
+          <Box
             tabIndex={0}
-            className="bg-transparent flex w-full items-center justify-between px-4 py-2 hover:bg-hover active:bg-pressed md:px-8"
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Between}
+            className="bg-transparent w-full px-4 py-2 hover:bg-hover active:bg-pressed md:px-8"
           >
-            <div className="flex items-center space-x-4 overflow-hidden">
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={4}
+              className="overflow-hidden"
+            >
               <BadgeWrapper
                 badge={
                   <BadgeNetwork
@@ -246,7 +303,10 @@ const WalletHome: React.FC = () => {
                   size={AvatarTokenSize.Md}
                 />
               </BadgeWrapper>
-              <div className="flex flex-col overflow-hidden">
+              <Box
+                flexDirection={BoxFlexDirection.Column}
+                className="overflow-hidden"
+              >
                 <Text fontWeight={FontWeight.Medium} ellipsis>
                   Unibright
                 </Text>
@@ -262,9 +322,9 @@ const WalletHome: React.FC = () => {
                   />
                   <span>+85.88%</span>
                 </Text>
-              </div>
-            </div>
-            <div className="text-right">
+              </Box>
+            </Box>
+            <Box className="text-right">
               <Text>$1,293.50</Text>
               <Text
                 color={TextColor.TextAlternative}
@@ -272,15 +332,23 @@ const WalletHome: React.FC = () => {
               >
                 0.058 UBT
               </Text>
-            </div>
-          </div>
+            </Box>
+          </Box>
 
           {/* Hopr */}
-          <div
+          <Box
             tabIndex={0}
-            className="bg-transparent flex w-full items-center justify-between px-4 py-2 hover:bg-hover active:bg-pressed md:px-8"
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Between}
+            className="bg-transparent w-full px-4 py-2 hover:bg-hover active:bg-pressed md:px-8"
           >
-            <div className="flex items-center space-x-4 overflow-hidden">
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={4}
+              className="overflow-hidden"
+            >
               <BadgeWrapper
                 badge={
                   <BadgeNetwork
@@ -295,7 +363,10 @@ const WalletHome: React.FC = () => {
                   size={AvatarTokenSize.Md}
                 />
               </BadgeWrapper>
-              <div className="flex flex-col overflow-hidden">
+              <Box
+                flexDirection={BoxFlexDirection.Column}
+                className="overflow-hidden"
+              >
                 <Text fontWeight={FontWeight.Medium} ellipsis>
                   Hopr
                 </Text>
@@ -311,9 +382,9 @@ const WalletHome: React.FC = () => {
                   />
                   <span>+85.88%</span>
                 </Text>
-              </div>
-            </div>
-            <div className="text-right">
+              </Box>
+            </Box>
+            <Box className="text-right">
               <Text>$550.00</Text>
               <Text
                 color={TextColor.TextAlternative}
@@ -321,15 +392,23 @@ const WalletHome: React.FC = () => {
               >
                 12.44 HOPR
               </Text>
-            </div>
-          </div>
+            </Box>
+          </Box>
 
           {/* USDC */}
-          <div
+          <Box
             tabIndex={0}
-            className="bg-transparent flex w-full items-center justify-between px-4 py-2 hover:bg-hover active:bg-pressed md:px-8"
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Between}
+            className="bg-transparent w-full px-4 py-2 hover:bg-hover active:bg-pressed md:px-8"
           >
-            <div className="flex items-center space-x-4 overflow-hidden">
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={4}
+              className="overflow-hidden"
+            >
               <BadgeWrapper
                 badge={
                   <BadgeNetwork
@@ -344,7 +423,10 @@ const WalletHome: React.FC = () => {
                   size={AvatarTokenSize.Md}
                 />
               </BadgeWrapper>
-              <div className="flex flex-col overflow-hidden">
+              <Box
+                flexDirection={BoxFlexDirection.Column}
+                className="overflow-hidden"
+              >
                 <Text fontWeight={FontWeight.Medium} ellipsis>
                   USDC Coin
                 </Text>
@@ -360,9 +442,9 @@ const WalletHome: React.FC = () => {
                   />
                   <span>-7.80%</span>
                 </Text>
-              </div>
-            </div>
-            <div className="text-right">
+              </Box>
+            </Box>
+            <Box className="text-right">
               <Text>$110.20</Text>
               <Text
                 color={TextColor.TextAlternative}
@@ -370,11 +452,11 @@ const WalletHome: React.FC = () => {
               >
                 0.7107 USDC
               </Text>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
   );
 };
 

--- a/packages/design-system-react/src/components/Box/Box.test.tsx
+++ b/packages/design-system-react/src/components/Box/Box.test.tsx
@@ -22,51 +22,115 @@ describe('Box', () => {
     expect(screen.getByTestId('box')).toHaveStyle({ margin: '4px' });
   });
 
-  it('applies default flex class', () => {
+  it('does not apply flex class by default', () => {
     render(<Box data-testid="box" />);
     const box = screen.getByTestId('box');
-    expect(box).toHaveClass('flex');
+    expect(box).not.toHaveClass('flex');
   });
 
-  it('applies flexDirection prop', () => {
+  it('applies flex class and flexDirection prop when flexDirection is provided', () => {
     render(<Box data-testid="box" flexDirection={BoxFlexDirection.Column} />);
     const box = screen.getByTestId('box');
     expect(box).toHaveClass('flex');
     expect(box).toHaveClass(BoxFlexDirection.Column);
   });
 
-  it('applies flexWrap prop', () => {
+  it('applies flexWrap prop without flex class when no flexDirection', () => {
     render(<Box data-testid="box" flexWrap={BoxFlexWrap.Wrap} />);
     const box = screen.getByTestId('box');
-    expect(box).toHaveClass('flex');
+    expect(box).not.toHaveClass('flex');
     expect(box).toHaveClass(BoxFlexWrap.Wrap);
   });
 
-  it('applies gap prop using spacing scale', () => {
+  it('applies flex class when flexWrap and flexDirection are both provided', () => {
+    render(
+      <Box
+        data-testid="box"
+        flexDirection={BoxFlexDirection.Row}
+        flexWrap={BoxFlexWrap.Wrap}
+      />,
+    );
+    const box = screen.getByTestId('box');
+    expect(box).toHaveClass('flex');
+    expect(box).toHaveClass(BoxFlexWrap.Wrap);
+    expect(box).toHaveClass(BoxFlexDirection.Row);
+  });
+
+  it('applies gap prop using spacing scale without flex class when no flexDirection', () => {
     render(<Box data-testid="box" gap={4} />);
+    const box = screen.getByTestId('box');
+    expect(box).not.toHaveClass('flex');
+    expect(box).toHaveClass(TWCLASSMAP_BOX_GAP[4]);
+  });
+
+  it('applies gap prop using spacing scale with flex class when flexDirection is provided', () => {
+    render(
+      <Box data-testid="box" flexDirection={BoxFlexDirection.Row} gap={4} />,
+    );
     const box = screen.getByTestId('box');
     expect(box).toHaveClass('flex');
     expect(box).toHaveClass(TWCLASSMAP_BOX_GAP[4]);
   });
 
-  it('applies alignItems prop', () => {
+  it('applies alignItems prop without flex class when no flexDirection', () => {
     render(<Box data-testid="box" alignItems={BoxAlignItems.Center} />);
+    const box = screen.getByTestId('box');
+    expect(box).not.toHaveClass('flex');
+    expect(box).toHaveClass(BoxAlignItems.Center);
+  });
+
+  it('applies alignItems prop with flex class when flexDirection is provided', () => {
+    render(
+      <Box
+        data-testid="box"
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+      />,
+    );
     const box = screen.getByTestId('box');
     expect(box).toHaveClass('flex');
     expect(box).toHaveClass(BoxAlignItems.Center);
   });
 
-  it('applies justifyContent prop', () => {
+  it('applies justifyContent prop without flex class when no flexDirection', () => {
     render(
       <Box data-testid="box" justifyContent={BoxJustifyContent.Between} />,
+    );
+    const box = screen.getByTestId('box');
+    expect(box).not.toHaveClass('flex');
+    expect(box).toHaveClass(BoxJustifyContent.Between);
+  });
+
+  it('applies justifyContent prop with flex class when flexDirection is provided', () => {
+    render(
+      <Box
+        data-testid="box"
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.Between}
+      />,
     );
     const box = screen.getByTestId('box');
     expect(box).toHaveClass('flex');
     expect(box).toHaveClass(BoxJustifyContent.Between);
   });
 
-  it('applies className prop', () => {
+  it('applies className prop without flex class when no flexDirection', () => {
     render(<Box data-testid="box" className="custom-class bg-red-500 p-4" />);
+    const box = screen.getByTestId('box');
+    expect(box).not.toHaveClass('flex');
+    expect(box).toHaveClass('custom-class');
+    expect(box).toHaveClass('p-4');
+    expect(box).toHaveClass('bg-red-500');
+  });
+
+  it('applies className prop with flex class when flexDirection is provided', () => {
+    render(
+      <Box
+        data-testid="box"
+        flexDirection={BoxFlexDirection.Row}
+        className="custom-class bg-red-500 p-4"
+      />,
+    );
     const box = screen.getByTestId('box');
     expect(box).toHaveClass('flex');
     expect(box).toHaveClass('custom-class');
@@ -74,7 +138,7 @@ describe('Box', () => {
     expect(box).toHaveClass('bg-red-500');
   });
 
-  it('applies all flex props together', () => {
+  it('applies all flex props together with flex class', () => {
     render(
       <Box
         data-testid="box"
@@ -103,15 +167,61 @@ describe('Box', () => {
     });
   });
 
-  it('handles gap prop with value 0', () => {
+  it('applies all props together without flex class when no flexDirection', () => {
+    render(
+      <Box
+        data-testid="box"
+        flexWrap={BoxFlexWrap.Wrap}
+        gap={2}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        className="extra-class"
+      />,
+    );
+
+    const box = screen.getByTestId('box');
+    const expectedClasses = [
+      BoxFlexWrap.Wrap,
+      TWCLASSMAP_BOX_GAP[2],
+      BoxAlignItems.Center,
+      BoxJustifyContent.Between,
+      'extra-class',
+    ];
+
+    expectedClasses.forEach((className) => {
+      expect(box).toHaveClass(className);
+    });
+
+    expect(box).not.toHaveClass('flex');
+  });
+
+  it('handles gap prop with value 0 without flex class when no flexDirection', () => {
     render(<Box data-testid="box" gap={0} />);
+    const box = screen.getByTestId('box');
+    expect(box).not.toHaveClass('flex');
+    expect(box).toHaveClass(TWCLASSMAP_BOX_GAP[0]);
+  });
+
+  it('handles gap prop with value 0 with flex class when flexDirection is provided', () => {
+    render(
+      <Box data-testid="box" flexDirection={BoxFlexDirection.Row} gap={0} />,
+    );
     const box = screen.getByTestId('box');
     expect(box).toHaveClass('flex');
     expect(box).toHaveClass(TWCLASSMAP_BOX_GAP[0]);
   });
 
-  it('handles gap prop with maximum value', () => {
+  it('handles gap prop with maximum value without flex class when no flexDirection', () => {
     render(<Box data-testid="box" gap={12} />);
+    const box = screen.getByTestId('box');
+    expect(box).not.toHaveClass('flex');
+    expect(box).toHaveClass(TWCLASSMAP_BOX_GAP[12]);
+  });
+
+  it('handles gap prop with maximum value with flex class when flexDirection is provided', () => {
+    render(
+      <Box data-testid="box" flexDirection={BoxFlexDirection.Row} gap={12} />,
+    );
     const box = screen.getByTestId('box');
     expect(box).toHaveClass('flex');
     expect(box).toHaveClass(TWCLASSMAP_BOX_GAP[12]);
@@ -119,6 +229,17 @@ describe('Box', () => {
 
   it('does not apply gap class when gap is undefined', () => {
     render(<Box data-testid="box" />);
+    const box = screen.getByTestId('box');
+    expect(box).not.toHaveClass('flex');
+
+    // Check that no gap classes are applied
+    Object.values(TWCLASSMAP_BOX_GAP).forEach((gapClass) => {
+      expect(box).not.toHaveClass(gapClass);
+    });
+  });
+
+  it('does not apply gap class when gap is undefined but flexDirection is provided', () => {
+    render(<Box data-testid="box" flexDirection={BoxFlexDirection.Row} />);
     const box = screen.getByTestId('box');
     expect(box).toHaveClass('flex');
 
@@ -128,7 +249,7 @@ describe('Box', () => {
     });
   });
 
-  it('forwards other props to the div element', () => {
+  it('forwards other props to the div element without flex class when no flexDirection', () => {
     const mockClick = jest.fn();
     render(
       <Box
@@ -139,6 +260,25 @@ describe('Box', () => {
       />,
     );
     const box = screen.getByTestId('box');
+    expect(box).not.toHaveClass('flex');
+    expect(box).toHaveAttribute('role', 'main');
+    expect(box).toHaveAttribute('aria-label', 'Test box');
+    expect(box.tagName).toBe('DIV');
+  });
+
+  it('forwards other props to the div element with flex class when flexDirection is provided', () => {
+    const mockClick = jest.fn();
+    render(
+      <Box
+        data-testid="box"
+        flexDirection={BoxFlexDirection.Row}
+        role="main"
+        aria-label="Test box"
+        onClick={mockClick}
+      />,
+    );
+    const box = screen.getByTestId('box');
+    expect(box).toHaveClass('flex');
     expect(box).toHaveAttribute('role', 'main');
     expect(box).toHaveAttribute('aria-label', 'Test box');
     expect(box.tagName).toBe('DIV');

--- a/packages/design-system-react/src/components/Box/Box.tsx
+++ b/packages/design-system-react/src/components/Box/Box.tsx
@@ -17,7 +17,7 @@ export const Box = ({
   ...props
 }: BoxProps) => {
   const mergedClassName = twMerge(
-    'flex',
+    flexDirection ? 'flex' : '',
     flexDirection,
     flexWrap,
     gap !== undefined ? TWCLASSMAP_BOX_GAP[gap] : '',

--- a/packages/design-system-react/src/components/Box/index.ts
+++ b/packages/design-system-react/src/components/Box/index.ts
@@ -1,9 +1,9 @@
-export type {
+export {
   BoxFlexDirection,
   BoxFlexWrap,
-  BoxSpacing,
   BoxAlignItems,
   BoxJustifyContent,
 } from '../../types';
+export type { BoxSpacing } from '../../types';
 export { Box } from './Box';
 export type { BoxProps } from './Box.types';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -52,15 +52,14 @@ export type { BadgeWrapperCustomPosition } from './BadgeWrapper';
 export { Blockies } from './temp-components/Blockies';
 export type { BlockiesProps } from './temp-components/Blockies';
 
-export type {
+export {
   BoxFlexDirection,
   BoxFlexWrap,
-  BoxSpacing,
   BoxAlignItems,
   BoxJustifyContent,
-  BoxProps,
+  Box,
 } from './Box';
-export { Box } from './Box';
+export type { BoxSpacing, BoxProps } from './Box';
 
 export { Button, ButtonSize, ButtonVariant } from './Button';
 export type { ButtonProps } from './Button';


### PR DESCRIPTION
## **Description**

This PR fixes the Box component's layout behavior and updates the WalletHome story to use Box components instead of HTML divs.

**What is the reason for the change?**
1. The Box component was always applying a `flex` class even when flex behavior wasn't needed, causing layout issues
2. Box enum types (BoxFlexDirection, BoxFlexWrap, etc.) were being exported as type-only exports, preventing their use as runtime values
3. The WalletHome story was using HTML divs instead of the design system's Box component

**What is the improvement/solution?**
1. Modified Box component to conditionally apply `flex` class only when `flexDirection` prop is provided
2. Fixed exports to properly export Box enums as values while keeping BoxSpacing and BoxProps as type exports
3. Converted all HTML divs in WalletHome.stories.tsx to use Box components with appropriate flexbox props

## **Related issues**

Fixes: N/A Layout issues with Box component applying unnecessary flex styling

## **Manual testing steps**

1. Go to Storybook and navigate to the WalletHome story
2. Verify that the layout renders correctly without flex-related issues
3. Test Box component usage both with and without flexDirection prop
4. Ensure all Box enum imports work correctly (BoxFlexDirection.Row, etc.)

## **Screenshots/Recordings**

### **Before**
- Box component always had `flex` class applied, causing unwanted flex behavior
- HTML divs used instead of design system components
- Box enums couldn't be imported as values

### **After**
- Box component only applies `flex` class when flexDirection is specified
- Consistent use of Box components throughout WalletHome story
- Box enums properly exported and usable as runtime values

https://github.com/user-attachments/assets/0e126caa-f0b5-4d53-bd7f-3385b5de17cf

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.