### PR TITLE
chore: adding missing PR to design tokens changelog for icon colors

### DIFF
--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added DisplayLG typography token for larger display text ([#607](https://github.com/MetaMask/metamask-design-system/pull/607))
+- Added `icon/default-hover`, `icon/default-pressed` state colors and `icon/inverse` color tokens for monochromatic button support ([#709](https://github.com/MetaMask/metamask-design-system/pull/709))
 
 ### Changed
 
-- **BREAKING:** Updated `background.muted` from opaque colors to transparent colors and added new `background.section` and `background.subsection` tokens ([#682](https://github.com/MetaMask/metamask-design-system/pull/682)). This is a breaking change that affects components requiring opaque backgrounds like BadgeNetwork, avatar fallbacks, and non-action elements. Applications must swap `background.muted` with `background.section` for opaque backgrounds.
+- **BREAKING:** Updated `background/muted` from opaque colors to transparent colors and added new `background/section` and `background/subsection` tokens ([#682](https://github.com/MetaMask/metamask-design-system/pull/682)). This is a breaking change that affects components requiring opaque backgrounds like BadgeNetwork, avatar fallbacks, and non-action elements. Applications must swap `background/muted` with `background/section` for opaque backgrounds.
 - **BREAKING:** Removed deprecated typography tokens `sHeadingSMRegular` and `lHeadingSMRegular` ([#699](https://github.com/MetaMask/metamask-design-system/pull/699)). Choose an appropriate replacement typography token based on your design needs. See the [migration guide](./MIGRATION.md#from-version-700-to-800) for details.
 - **BREAKING:** Changed default font from CentraNo1 to Geist ([#756](https://github.com/MetaMask/metamask-design-system/pull/756)). This affects all typography tokens and requires updating font imports and references. See the [migration guide](./MIGRATION.md#from-version-700-to-800) for details.
+- Fixed `text/alternative`, `text/muted`, `icon/alternative`, and `icon/muted` colors in dark mode to match design specifications ([#709](https://github.com/MetaMask/metamask-design-system/pull/709))
 
 ## [7.1.0]
 

--- a/packages/design-tokens/MIGRATION.md
+++ b/packages/design-tokens/MIGRATION.md
@@ -17,20 +17,20 @@ In version 8.0.0, we've made significant changes to background color tokens that
 
 #### Key Changes
 
-**`background.muted` is now transparent:**
+**`background/muted` is now transparent:**
 
 - **Before**: `grey050 | grey800` (opaque colors)
 - **After**: `#3C4D9D 10% | E0E5FF 15%` (transparent colors)
 
 **New opaque tokens added:**
 
-- `background.section`: `grey050 | grey800` (replaces the old opaque `background.muted`)
-- `background.subsection`: `grey000 | grey700`
+- `background/section`: `grey050 | grey800` (replaces the old opaque `background/muted`)
+- `background/subsection`: `grey000 | grey700`
 
 **Updated transparent hover/pressed states:**
 
-- `background.muted-hover`: `#3C4D9D 15% | E0E5FF 20%`
-- `background.muted-pressed`: `#3C4D9D 20% | E0E5FF 25%`
+- `background/muted-hover`: `#3C4D9D 15% | E0E5FF 20%`
+- `background/muted-pressed`: `#3C4D9D 20% | E0E5FF 25%`
 
 #### Breaking Change Impact
 


### PR DESCRIPTION
## **Description**

This PR adds missing changelog entries for PR #709 in the design tokens package. The original PR added new design tokens for monochromatic button support and fixed dark mode color specifications, but the changelog entry was left out.

**Changes made:**
1. **Added PR #709 entry** to version 8.0.0 
2. **Improved description** to properly reflect the scope of changes:
   - Added new design tokens: `icon.default-hover`, `icon.default-pressed`, and `icon.inverse`
   - Fixed dark mode colors for `text.alternative`, `text.muted`, `icon.alternative`, and `icon.muted`
3. **Corrected token naming** throughout the changelog to use forward slashes (e.g., `background/muted` instead of `background.muted`) for consistency with Figma and not to be mistaken for code

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Review the changelog entries in `packages/design-tokens/CHANGELOG.md`
2. Verify PR #709 is correctly listed in version 8.0.0

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.