### PR TITLE
feat: add background color prop for box component

### DIFF
--- a/packages/design-system-react/src/components/Box/Box.stories.tsx
+++ b/packages/design-system-react/src/components/Box/Box.stories.tsx
@@ -6,6 +6,7 @@ import {
   BoxFlexWrap,
   BoxAlignItems,
   BoxJustifyContent,
+  BoxBackgroundColor,
 } from '../../types';
 import { Text } from '../Text';
 
@@ -50,6 +51,12 @@ const meta: Meta<BoxProps> = {
       mapping: BoxJustifyContent,
       description: 'The justify-content style of the component.',
     },
+    backgroundColor: {
+      control: 'select',
+      options: Object.keys(BoxBackgroundColor),
+      mapping: BoxBackgroundColor,
+      description: 'The background color of the component using design system tokens.',
+    },
     className: {
       control: 'text',
       description:
@@ -73,6 +80,40 @@ const BoxStory: React.FC<BoxProps> = (args) => {
 
 export const Default: Story = {
   render: (args) => <BoxStory {...args} />,
+};
+
+export const BackgroundColor: Story = {
+  args: {
+    backgroundColor: BoxBackgroundColor.BackgroundAlternative,
+    gap: 2,
+    className: 'p-4',
+  },
+  render: (args) => <BoxStory {...args} />,
+};
+
+export const BackgroundColorSemantics: Story = {
+  render: () => (
+    <Box flexDirection={BoxFlexDirection.Column} gap={3}>
+      <Box backgroundColor={BoxBackgroundColor.BackgroundDefault} className="p-3 border border-border-default rounded">
+        <Text>Default Background</Text>
+      </Box>
+      <Box backgroundColor={BoxBackgroundColor.BackgroundAlternative} className="p-3 border border-border-default rounded">
+        <Text>Alternative Background</Text>
+      </Box>
+      <Box backgroundColor={BoxBackgroundColor.PrimaryMuted} className="p-3 border border-border-default rounded">
+        <Text>Primary Muted Background</Text>
+      </Box>
+      <Box backgroundColor={BoxBackgroundColor.ErrorMuted} className="p-3 border border-border-default rounded">
+        <Text>Error Muted Background</Text>
+      </Box>
+      <Box backgroundColor={BoxBackgroundColor.WarningMuted} className="p-3 border border-border-default rounded">
+        <Text>Warning Muted Background</Text>
+      </Box>
+      <Box backgroundColor={BoxBackgroundColor.SuccessMuted} className="p-3 border border-border-default rounded">
+        <Text>Success Muted Background</Text>
+      </Box>
+    </Box>
+  ),
 };
 
 export const FlexDirection: Story = {

--- a/packages/design-system-react/src/components/Box/Box.test.tsx
+++ b/packages/design-system-react/src/components/Box/Box.test.tsx
@@ -6,6 +6,7 @@ import {
   BoxFlexDirection,
   BoxFlexWrap,
   BoxJustifyContent,
+  BoxBackgroundColor,
 } from '../../types';
 
 import { Box } from './Box';
@@ -282,5 +283,93 @@ describe('Box', () => {
     expect(box).toHaveAttribute('role', 'main');
     expect(box).toHaveAttribute('aria-label', 'Test box');
     expect(box.tagName).toBe('DIV');
+  });
+
+  it('applies backgroundColor prop without flex class when no flexDirection', () => {
+    render(
+      <Box
+        data-testid="box"
+        backgroundColor={BoxBackgroundColor.BackgroundAlternative}
+      />,
+    );
+    const box = screen.getByTestId('box');
+    expect(box).not.toHaveClass('flex');
+    expect(box).toHaveClass(BoxBackgroundColor.BackgroundAlternative);
+  });
+
+  it('applies backgroundColor prop with flex class when flexDirection is provided', () => {
+    render(
+      <Box
+        data-testid="box"
+        flexDirection={BoxFlexDirection.Row}
+        backgroundColor={BoxBackgroundColor.PrimaryMuted}
+      />,
+    );
+    const box = screen.getByTestId('box');
+    expect(box).toHaveClass('flex');
+    expect(box).toHaveClass(BoxBackgroundColor.PrimaryMuted);
+  });
+
+  it('applies backgroundColor prop with semantic colors', () => {
+    render(
+      <Box
+        data-testid="error-box"
+        backgroundColor={BoxBackgroundColor.ErrorMuted}
+      />,
+    );
+    const box = screen.getByTestId('error-box');
+    expect(box).toHaveClass(BoxBackgroundColor.ErrorMuted);
+  });
+
+  it('applies backgroundColor prop with transparent background', () => {
+    render(
+      <Box
+        data-testid="transparent-box"
+        backgroundColor={BoxBackgroundColor.Transparent}
+      />,
+    );
+    const box = screen.getByTestId('transparent-box');
+    expect(box).toHaveClass(BoxBackgroundColor.Transparent);
+  });
+
+  it('applies backgroundColor prop with all other props', () => {
+    render(
+      <Box
+        data-testid="box"
+        flexDirection={BoxFlexDirection.Row}
+        flexWrap={BoxFlexWrap.Wrap}
+        gap={2}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        backgroundColor={BoxBackgroundColor.SuccessMuted}
+        className="extra-class"
+      />,
+    );
+
+    const box = screen.getByTestId('box');
+    const expectedClasses = [
+      'flex',
+      BoxFlexDirection.Row,
+      BoxFlexWrap.Wrap,
+      TWCLASSMAP_BOX_GAP[2],
+      BoxAlignItems.Center,
+      BoxJustifyContent.Between,
+      BoxBackgroundColor.SuccessMuted,
+      'extra-class',
+    ];
+
+    expectedClasses.forEach((className) => {
+      expect(box).toHaveClass(className);
+    });
+  });
+
+  it('does not apply backgroundColor class when backgroundColor is undefined', () => {
+    render(<Box data-testid="box" />);
+    const box = screen.getByTestId('box');
+    
+    // Check that no background color classes are applied
+    Object.values(BoxBackgroundColor).forEach((bgClass) => {
+      expect(box).not.toHaveClass(bgClass);
+    });
   });
 });

--- a/packages/design-system-react/src/components/Box/Box.tsx
+++ b/packages/design-system-react/src/components/Box/Box.tsx
@@ -11,6 +11,7 @@ export const Box = ({
   gap,
   alignItems,
   justifyContent,
+  backgroundColor,
   className = '',
   style,
   children,
@@ -23,6 +24,7 @@ export const Box = ({
     gap !== undefined ? TWCLASSMAP_BOX_GAP[gap] : '',
     alignItems,
     justifyContent,
+    backgroundColor,
     className,
   );
 

--- a/packages/design-system-react/src/components/Box/Box.types.ts
+++ b/packages/design-system-react/src/components/Box/Box.types.ts
@@ -6,6 +6,7 @@ import type {
   BoxSpacing,
   BoxAlignItems,
   BoxJustifyContent,
+  BoxBackgroundColor,
 } from '../../types';
 
 export type BoxProps = ComponentProps<'div'> & {
@@ -30,6 +31,11 @@ export type BoxProps = ComponentProps<'div'> & {
    * The justify-content style of the component.
    */
   justifyContent?: BoxJustifyContent;
+  /**
+   * The background color of the component.
+   * Uses design system background color tokens for consistency and backwards compatibility.
+   */
+  backgroundColor?: BoxBackgroundColor;
   /**
    * Optional prop for additional CSS classes to be applied to the Box component.
    */

--- a/packages/design-system-react/src/components/Box/README.mdx
+++ b/packages/design-system-react/src/components/Box/README.mdx
@@ -75,6 +75,62 @@ Use the `justifyContent` prop to configure the `justify-content` style of the Bo
 
 <Canvas of={BoxStories.JustifyContent} />
 
+### BackgroundColor
+
+Use the `backgroundColor` prop to apply background colors using design system tokens. This ensures consistency and themability across the design system, with backwards compatibility to the extension's box component values.
+
+<Canvas of={BoxStories.BackgroundColor} />
+
+<Canvas of={BoxStories.BackgroundColorSemantics} />
+
+```tsx
+// Background color examples
+<Box backgroundColor={BoxBackgroundColor.BackgroundDefault}>
+  Default background
+</Box>
+
+<Box backgroundColor={BoxBackgroundColor.BackgroundAlternative}>
+  Alternative background (sunken)
+</Box>
+
+<Box backgroundColor={BoxBackgroundColor.PrimaryMuted}>
+  Primary muted background
+</Box>
+
+<Box backgroundColor={BoxBackgroundColor.ErrorMuted}>
+  Error semantic background
+</Box>
+
+<Box backgroundColor={BoxBackgroundColor.SuccessMuted}>
+  Success semantic background
+</Box>
+```
+
+#### Available Background Colors
+
+The `BoxBackgroundColor` enum provides comprehensive background color options:
+
+**Background Colors:**
+- `BackgroundDefault` - Default neutral background
+- `BackgroundAlternative` - Sunken background below default
+- `BackgroundSection` - Section background over default
+- `BackgroundSubsection` - Subsection background over section
+- `BackgroundMuted` - Muted neutral background
+- `BackgroundHover` - General hover state
+- `BackgroundPressed` - General pressed state
+
+**Semantic Colors:**
+- `PrimaryDefault`, `PrimaryMuted` - Primary semantic colors
+- `ErrorDefault`, `ErrorMuted` - Error/danger semantic colors  
+- `WarningDefault`, `WarningMuted` - Warning/caution semantic colors
+- `SuccessDefault`, `SuccessMuted` - Success/positive semantic colors
+- `InfoDefault`, `InfoMuted` - Info semantic colors
+
+**Utility Colors:**
+- `Transparent` - Transparent background
+- `FlaskDefault` - Flask accent color
+- `OverlayDefault`, `OverlayAlternative` - Overlay/scrim colors
+
 ### ClassName
 
 Use `className` to apply additional Tailwind CSS classes for styling beyond the flex layout properties.

--- a/packages/design-system-react/src/components/Box/index.ts
+++ b/packages/design-system-react/src/components/Box/index.ts
@@ -3,6 +3,7 @@ export {
   BoxFlexWrap,
   BoxAlignItems,
   BoxJustifyContent,
+  BoxBackgroundColor,
 } from '../../types';
 export type { BoxSpacing } from '../../types';
 export { Box } from './Box';

--- a/packages/design-system-react/src/types/index.ts
+++ b/packages/design-system-react/src/types/index.ts
@@ -190,6 +190,108 @@ export enum BoxJustifyContent {
 }
 
 /**
+ * Box - backgroundColor
+ */
+export enum BoxBackgroundColor {
+  /** For default neutral background */
+  BackgroundDefault = 'bg-background-default',
+  /** For sunken neutral background below background/default */
+  BackgroundAlternative = 'bg-background-alternative',
+  /** For section background usually over background/default */
+  BackgroundSection = 'bg-background-section',
+  /** For subsection background usually over background/section */
+  BackgroundSubsection = 'bg-background-subsection',
+  /** For muted neutral background */
+  BackgroundMuted = 'bg-background-muted',
+  /** Hover state background for background/default */
+  BackgroundDefaultHover = 'bg-background-default-hover',
+  /** Pressed state background for background/default */
+  BackgroundDefaultPressed = 'bg-background-default-pressed',
+  /** Hover state background for background/alternative */
+  BackgroundAlternativeHover = 'bg-background-alternative-hover',
+  /** Pressed state background for background/alternative */
+  BackgroundAlternativePressed = 'bg-background-alternative-pressed',
+  /** Hover state background for background/muted */
+  BackgroundMutedHover = 'bg-background-muted-hover',
+  /** Pressed state background for background/muted */
+  BackgroundMutedPressed = 'bg-background-muted-pressed',
+  /** General purpose hover state tint */
+  BackgroundHover = 'bg-background-hover',
+  /** General purpose pressed state tint */
+  BackgroundPressed = 'bg-background-pressed',
+  /** For primary semantic elements: interactive, active, selected */
+  PrimaryDefault = 'bg-primary-default',
+  /** Stronger background for primary semantic elements */
+  PrimaryAlternative = 'bg-primary-alternative',
+  /** Muted background for primary semantic elements */
+  PrimaryMuted = 'bg-primary-muted',
+  /** Hover state background for primary/default */
+  PrimaryDefaultHover = 'bg-primary-default-hover',
+  /** Pressed state background for primary/default */
+  PrimaryDefaultPressed = 'bg-primary-default-pressed',
+  /** Hover state background for primary/muted */
+  PrimaryMutedHover = 'bg-primary-muted-hover',
+  /** Pressed state background for primary/muted */
+  PrimaryMutedPressed = 'bg-primary-muted-pressed',
+  /** For danger semantic elements: error, critical, destructive... */
+  ErrorDefault = 'bg-error-default',
+  /** Stronger background for danger semantic */
+  ErrorAlternative = 'bg-error-alternative',
+  /** Muted background for danger semantic */
+  ErrorMuted = 'bg-error-muted',
+  /** Hover state background for error/default */
+  ErrorDefaultHover = 'bg-error-default-hover',
+  /** Pressed state background for error/default */
+  ErrorDefaultPressed = 'bg-error-default-pressed',
+  /** Hover state background for error/muted */
+  ErrorMutedHover = 'bg-error-muted-hover',
+  /** Pressed state background for error/muted */
+  ErrorMutedPressed = 'bg-error-muted-pressed',
+  /** For warning semantic elements: caution, attention, precaution... */
+  WarningDefault = 'bg-warning-default',
+  /** Muted background option for warning semantic */
+  WarningMuted = 'bg-warning-muted',
+  /** Hover state background for warning/default */
+  WarningDefaultHover = 'bg-warning-default-hover',
+  /** Pressed state background for warning/default */
+  WarningDefaultPressed = 'bg-warning-default-pressed',
+  /** Hover state background for warning/muted */
+  WarningMutedHover = 'bg-warning-muted-hover',
+  /** Pressed state background for warning/muted */
+  WarningMutedPressed = 'bg-warning-muted-pressed',
+  /** For positive semantic elements: success, confirm, complete, safe... */
+  SuccessDefault = 'bg-success-default',
+  /** Muted background for positive semantic */
+  SuccessMuted = 'bg-success-muted',
+  /** Hover state background for success/default */
+  SuccessDefaultHover = 'bg-success-default-hover',
+  /** Pressed state background for success/default */
+  SuccessDefaultPressed = 'bg-success-default-pressed',
+  /** Hover state background for success/muted */
+  SuccessMutedHover = 'bg-success-muted-hover',
+  /** Pressed state background for success/muted */
+  SuccessMutedPressed = 'bg-success-muted-pressed',
+  /** For soft alert semantic elements: info, reminder, hint... */
+  InfoDefault = 'bg-info-default',
+  /** Muted background for soft alert semantic */
+  InfoMuted = 'bg-info-muted',
+  /** For overlays(scrim) */
+  OverlayDefault = 'bg-overlay-default',
+  /** Dimmer background for overlays(scrim) */
+  OverlayAlternative = 'bg-overlay-alternative',
+  /** For Flask primary accent background */
+  FlaskDefault = 'bg-flask-default',
+  /** For neutral drop shadow background */
+  ShadowDefault = 'bg-shadow-default',
+  /** For primary drop shadow background */
+  ShadowPrimary = 'bg-shadow-primary',
+  /** For critical/danger drop shadow background */
+  ShadowError = 'bg-shadow-error',
+  /** Make the background transparent */
+  Transparent = 'bg-transparent',
+}
+
+/**
  * ButtonBase - size
  */
 export enum ButtonBaseSize {


### PR DESCRIPTION
## **Description**

This PR introduces a `backgroundColor` prop to the `Box` component in `@metamask/design-system-react`.

1.  **Reason for change**: To provide a standardized way to apply background colors to the `Box` component, ensuring backwards compatibility with the `Box` component found in `metamask-extension` while adhering to the design system's token conventions.
2.  **Improvement/Solution**:
    *   A new `BoxBackgroundColor` enum has been defined, mapping various design system background color tokens (e.g., `bg-background-default`, `bg-primary-muted`, `bg-transparent`) to Tailwind CSS classes.
    *   The `backgroundColor` prop is added to `BoxProps` and integrated into the `Box` component's `twMerge` utility for dynamic class application.
    *   Storybook examples and comprehensive unit tests have been added to demonstrate and validate the new prop's functionality across different color types and scenarios.

## **Related issues**

Fixes:

## **Manual testing steps**

1.  Navigate to the Storybook for `@metamask/design-system-react`.
2.  Select the `Box` component stories.
3.  Observe the "Background Color" and "Background Color Semantics" stories to see the new prop in action.
4.  Use the `backgroundColor` control in the Storybook args table to select different background colors and verify their application.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A - New functionality.

### **After**

<!-- [screenshots/recordings] -->
See Storybook for visual examples:
*   `BackgroundColor` story
*   `BackgroundColorSemantics` story

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels 