### PR TITLE
[Design Token] Semantic color updates for trade-app alignment

### DIFF
--- a/packages/design-tokens/src/css/dark-theme-colors.css
+++ b/packages/design-tokens/src/css/dark-theme-colors.css
@@ -91,32 +91,32 @@
   --color-error-muted-pressed: #ff758440;
   /* For warning semantic elements: caution, attention, precaution (#f0b034) */
   --color-warning-default: var(--brand-colors-yellow-yellow200);
-  /* Muted color option for warning semantic (#F0B03426) */
-  --color-warning-muted: #F0B03426;
+  /* Muted color option for warning semantic (#f0b03426) */
+  --color-warning-muted: #f0b03426;
   /* For elements placed on top of warning/default (#121314) */
   --color-warning-inverse: var(--brand-colors-grey-grey900);
-  /* Hover state surface for warning/default (#F3BE59) */
-  --color-warning-default-hover: #F3BE59;
-  /* Pressed state surface for warning/default (#F6CD7F) */
-  --color-warning-default-pressed: #F6CD7F;
-  /* Hover state surface for warning/muted (#F0B03433) */
-  --color-warning-muted-hover: #F0B03433;
-  /* Pressed state surface for warning/muted (#F0B03440) */
-  --color-warning-muted-pressed: #F0B03440;
+  /* Hover state surface for warning/default (#f3be59) */
+  --color-warning-default-hover: #f3be59;
+  /* Pressed state surface for warning/default (#f6cd7f) */
+  --color-warning-default-pressed: #f6cd7f;
+  /* Hover state surface for warning/muted (#f0b03433) */
+  --color-warning-muted-hover: #f0b03433;
+  /* Pressed state surface for warning/muted (#f0b03440) */
+  --color-warning-muted-pressed: #f0b03440;
   /* For positive semantic elements: success, confirm, complete, safe (#baf24a) */
   --color-success-default: var(--brand-colors-lime-lime100);
-  /* Muted color for positive semantic (#BAF24A26) */
-  --color-success-muted: #BAF24A26;
+  /* Muted color for positive semantic (#baf24a26) */
+  --color-success-muted: #baf24a26;
   /* For elements placed on top of success/default (#121314) */
   --color-success-inverse: var(--brand-colors-grey-grey900);
-  /* Hover state surface for success/default (#C9F570) */
-  --color-success-default-hover: #C9F570;
-  /* Pressed state surface for success/default (#D7F796) */
-  --color-success-default-pressed: #D7F796;
-  /* Hover state surface for success/muted (#BAF24A33) */
-  --color-success-muted-hover: #BAF24A33;
-  /* Pressed state surface for success/muted (#BAF24A40) */
-  --color-success-muted-pressed: #BAF24A40;
+  /* Hover state surface for success/default (#c9f570) */
+  --color-success-default-hover: #c9f570;
+  /* Pressed state surface for success/default (#d7f796) */
+  --color-success-default-pressed: #d7f796;
+  /* Hover state surface for success/muted (#baf24a33) */
+  --color-success-muted-hover: #baf24a33;
+  /* Pressed state surface for success/muted (#baf24a40) */
+  --color-success-muted-pressed: #baf24a40;
   /* For informational read-only elements: info, reminder, hint (#8b99ff) */
   --color-info-default: var(--brand-colors-blue-blue300);
   /* Muted color for informational semantic (#8b99ff26) */

--- a/packages/design-tokens/src/css/dark-theme-colors.css
+++ b/packages/design-tokens/src/css/dark-theme-colors.css
@@ -89,34 +89,34 @@
   --color-error-muted-hover: #ff758433;
   /* Pressed state surface for error/muted (#ff758440) */
   --color-error-muted-pressed: #ff758440;
-  /* For warning semantic elements: caution, attention, precaution (#ffd957) */
-  --color-warning-default: var(--brand-colors-yellow-yellow100);
-  /* Muted color option for warning semantic (#ffd95726) */
-  --color-warning-muted: #ffd95726;
+  /* For warning semantic elements: caution, attention, precaution (#f0b034) */
+  --color-warning-default: var(--brand-colors-yellow-yellow200);
+  /* Muted color option for warning semantic (#F0B03426) */
+  --color-warning-muted: #F0B03426;
   /* For elements placed on top of warning/default (#121314) */
   --color-warning-inverse: var(--brand-colors-grey-grey900);
-  /* Hover state surface for warning/default (#ffde6b) */
-  --color-warning-default-hover: #ffde6b;
-  /* Pressed state surface for warning/default (#ffe794) */
-  --color-warning-default-pressed: #ffe794;
-  /* Hover state surface for warning/muted (#ffd95733) */
-  --color-warning-muted-hover: #ffd95733;
-  /* Pressed state surface for warning/muted (#ffd95740) */
-  --color-warning-muted-pressed: #ffd95740;
-  /* For positive semantic elements: success, confirm, complete, safe (#4cb564) */
-  --color-success-default: var(--brand-colors-green-green300);
-  /* Muted color for positive semantic (#4cb56426) */
-  --color-success-muted: #4cb56426;
+  /* Hover state surface for warning/default (#F3BE59) */
+  --color-warning-default-hover: #F3BE59;
+  /* Pressed state surface for warning/default (#F6CD7F) */
+  --color-warning-default-pressed: #F6CD7F;
+  /* Hover state surface for warning/muted (#F0B03433) */
+  --color-warning-muted-hover: #F0B03433;
+  /* Pressed state surface for warning/muted (#F0B03440) */
+  --color-warning-muted-pressed: #F0B03440;
+  /* For positive semantic elements: success, confirm, complete, safe (#baf24a) */
+  --color-success-default: var(--brand-colors-lime-lime100);
+  /* Muted color for positive semantic (#BAF24A26) */
+  --color-success-muted: #BAF24A26;
   /* For elements placed on top of success/default (#121314) */
   --color-success-inverse: var(--brand-colors-grey-grey900);
-  /* Hover state surface for success/default (#59ba6f) */
-  --color-success-default-hover: #59ba6f;
-  /* Pressed state surface for success/default (#76c688) */
-  --color-success-default-pressed: #76c688;
-  /* Hover state surface for success/muted (#4cb56433) */
-  --color-success-muted-hover: #4cb56433;
-  /* Pressed state surface for success/muted (#4cb56440) */
-  --color-success-muted-pressed: #4cb56440;
+  /* Hover state surface for success/default (#C9F570) */
+  --color-success-default-hover: #C9F570;
+  /* Pressed state surface for success/default (#D7F796) */
+  --color-success-default-pressed: #D7F796;
+  /* Hover state surface for success/muted (#BAF24A33) */
+  --color-success-muted-hover: #BAF24A33;
+  /* Pressed state surface for success/muted (#BAF24A40) */
+  --color-success-muted-pressed: #BAF24A40;
   /* For informational read-only elements: info, reminder, hint (#8b99ff) */
   --color-info-default: var(--brand-colors-blue-blue300);
   /* Muted color for informational semantic (#8b99ff26) */

--- a/packages/design-tokens/src/css/light-theme-colors.css
+++ b/packages/design-tokens/src/css/light-theme-colors.css
@@ -104,20 +104,20 @@
   --color-warning-muted-hover: #9a630026;
   /* Pressed state surface for warning/muted (#9a630033) */
   --color-warning-muted-pressed: #9a630033;
-  /* For positive semantic elements: success, confirm, complete, safe (#1c7e33) */
-  --color-success-default: var(--brand-colors-green-green500);
-  /* Muted color for positive semantic (#1c7e331a) */
-  --color-success-muted: #1c7e331a;
+  /* For positive semantic elements: success, confirm, complete, safe (#457A39) */
+  --color-success-default: var(--brand-colors-lime-lime500);
+  /* Muted color for positive semantic (#457A391A) */
+  --color-success-muted: #457A391A;
   /* For elements placed on top of success/default (#ffffff) */
   --color-success-inverse: var(--brand-colors-grey-grey000);
-  /* Hover state surface for success/default (#186c2c) */
-  --color-success-default-hover: #186c2c;
-  /* Pressed state surface for success/default (#114b1e) */
-  --color-success-default-pressed: #114b1e;
-  /* Hover state surface for success/muted (#1c7e3326) */
-  --color-success-muted-hover: #1c7e3326;
-  /* Pressed state surface for success/muted (#1c7e3333) */
-  --color-success-muted-pressed: #1c7e3333;
+  /* Hover state surface for success/default (#3D6C32) */
+  --color-success-default-hover: #3D6C32;
+  /* Pressed state surface for success/default (#2D5025) */
+  --color-success-default-pressed: #2D5025;
+  /* Hover state surface for success/muted (#457A3926) */
+  --color-success-muted-hover: #457A3926;
+  /* Pressed state surface for success/muted (#457A3933) */
+  --color-success-muted-pressed: #457A3933;
   /* For informational read-only elements: info, reminder, hint (#4459ff) */
   --color-info-default: var(--brand-colors-blue-blue500);
   /* Muted color for informational semantic (#4459ff1a) */

--- a/packages/design-tokens/src/css/light-theme-colors.css
+++ b/packages/design-tokens/src/css/light-theme-colors.css
@@ -106,18 +106,18 @@
   --color-warning-muted-pressed: #9a630033;
   /* For positive semantic elements: success, confirm, complete, safe (#457A39) */
   --color-success-default: var(--brand-colors-lime-lime500);
-  /* Muted color for positive semantic (#457A391A) */
-  --color-success-muted: #457A391A;
+  /* Muted color for positive semantic (#457a391a) */
+  --color-success-muted: #457a391a;
   /* For elements placed on top of success/default (#ffffff) */
   --color-success-inverse: var(--brand-colors-grey-grey000);
-  /* Hover state surface for success/default (#3D6C32) */
-  --color-success-default-hover: #3D6C32;
-  /* Pressed state surface for success/default (#2D5025) */
-  --color-success-default-pressed: #2D5025;
-  /* Hover state surface for success/muted (#457A3926) */
-  --color-success-muted-hover: #457A3926;
-  /* Pressed state surface for success/muted (#457A3933) */
-  --color-success-muted-pressed: #457A3933;
+  /* Hover state surface for success/default (#3d6c32) */
+  --color-success-default-hover: #3d6c32;
+  /* Pressed state surface for success/default (#2d5025) */
+  --color-success-default-pressed: #2d5025;
+  /* Hover state surface for success/muted (#457a3926) */
+  --color-success-muted-hover: #457a3926;
+  /* Pressed state surface for success/muted (#457a3933) */
+  --color-success-muted-pressed: #457a3933;
   /* For informational read-only elements: info, reminder, hint (#4459ff) */
   --color-info-default: var(--brand-colors-blue-blue500);
   /* Muted color for informational semantic (#4459ff1a) */

--- a/packages/design-tokens/src/figma/darkTheme.json
+++ b/packages/design-tokens/src/figma/darkTheme.json
@@ -317,13 +317,13 @@
   },
   "success": {
     "default": {
-      "value": "{green.300}",
+      "value": "{lime.100}",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For positive semantic elements: success, confirm, complete, safe..."
     },
     "muted": {
-      "value": "#4cb56426",
+      "value": "#BAF24A26",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Muted color for positive semantic."
@@ -335,25 +335,25 @@
       "description": "For elements placed on top of success/default fill."
     },
     "default-hover": {
-      "value": "#59ba6f",
+      "value": "#C9F570",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Hover state surface for success/default."
     },
     "default-pressed": {
-      "value": "#76c688",
+      "value": "#D7F796",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Pressed state surface for success/default."
     },
     "muted-hover": {
-      "value": "#4cb56433",
+      "value": "#BAF24A33",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Hover state surface for success/muted."
     },
     "muted-pressed": {
-      "value": "#4cb56440",
+      "value": "#BAF24A40",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Pressed state surface for success/muted."

--- a/packages/design-tokens/src/figma/darkTheme.json
+++ b/packages/design-tokens/src/figma/darkTheme.json
@@ -273,13 +273,13 @@
   },
   "warning": {
     "default": {
-      "value": "{yellow.100}",
+      "value": "{yellow.200}",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For warning semantic elements: caution, attention, precaution..."
     },
     "muted": {
-      "value": "#ffd95726",
+      "value": "#F0B03426",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Muted color option for warning semantic."
@@ -291,25 +291,25 @@
       "description": "For elements placed on top of warning/default fill."
     },
     "default-hover": {
-      "value": "#ffde6b",
+      "value": "#F3BE59",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Hover state surface for warning/default."
     },
     "default-pressed": {
-      "value": "#ffe794",
+      "value": "#F6CD7F",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Pressed state surface for warning/default."
     },
     "muted-hover": {
-      "value": "#ffd95733",
+      "value": "#F0B03433",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Hover state surface for warning/muted."
     },
     "muted-pressed": {
-      "value": "#ffd95740",
+      "value": "#F0B03440",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Pressed state surface for warning/muted."

--- a/packages/design-tokens/src/figma/lightTheme.json
+++ b/packages/design-tokens/src/figma/lightTheme.json
@@ -317,13 +317,13 @@
   },
   "success": {
     "default": {
-      "value": "{green.500}",
+      "value": "{lime.500}",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "For positive semantic elements: success, confirm, complete, safe..."
     },
     "muted": {
-      "value": "#1c7e331a",
+      "value": "#457A391A",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Muted color for positive semantic."
@@ -335,25 +335,25 @@
       "description": "For elements placed on top of success/default fill."
     },
     "default-hover": {
-      "value": "#186c2c",
+      "value": "#3D6C32",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Hover state surface for success/default."
     },
     "default-pressed": {
-      "value": "#114b1e",
+      "value": "#2D5025",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Pressed state surface for success/default."
     },
     "muted-hover": {
-      "value": "#1c7e3326",
+      "value": "#457A3926",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Hover state surface for success/muted."
     },
     "muted-pressed": {
-      "value": "#1c7e3333",
+      "value": "#457A3933",
       "type": "color",
       "parent": "Theme Colors/Light mode",
       "description": "Pressed state surface for success/muted."

--- a/packages/design-tokens/src/js/themes/darkTheme/colors.ts
+++ b/packages/design-tokens/src/js/themes/darkTheme/colors.ts
@@ -107,36 +107,36 @@ export const colors: ThemeColors = {
   warning: {
     /** For warning semantic elements: caution, attention, precaution (#F0B034) */
     default: brandColor.yellow200,
-    /** Muted color option for warning semantic (#F0B03426) */
-    muted: '#F0B03426',
+    /** Muted color option for warning semantic (#f0b03426) */
+    muted: '#f0b03426',
     /** For elements placed on top of warning/default fill (#121314) */
     inverse: brandColor.grey900,
-    /** Hover state surface for warning/default (#F3BE59) */
-    defaultHover: '#F3BE59',
-    /** Pressed state surface for warning/default (#F6CD7F) */
-    defaultPressed: '#F6CD7F',
+    /** Hover state surface for warning/default (#f3be59) */
+    defaultHover: '#f3be59',
+    /** Pressed state surface for warning/default (#f6cd7f) */
+    defaultPressed: '#f6cd7f',
 
-    /** Hover state surface for warning/muted (#F0B03433) */
-    mutedHover: '#F0B03433',
-    /** Pressed state surface for warning/muted (#F0B03440) */
-    mutedPressed: '#F0B03440',
+    /** Hover state surface for warning/muted (#f0b03433) */
+    mutedHover: '#f0b03433',
+    /** Pressed state surface for warning/muted (#f0b03440) */
+    mutedPressed: '#f0b03440',
   },
   success: {
     /** For positive semantic elements: success, confirm, complete, safe (#BAF24A) */
     default: brandColor.lime100,
-    /** Muted color for positive semantic (#BAF24A26) */
-    muted: '#BAF24A26',
+    /** Muted color for positive semantic (#baf24a26) */
+    muted: '#baf24a26',
     /** For elements placed on top of success/default fill (#121314) */
     inverse: brandColor.grey900,
-    /** Hover state surface for success/default (#C9F570) */
-    defaultHover: '#C9F570',
-    /** Pressed state surface for success/default (#D7F796) */
-    defaultPressed: '#D7F796',
+    /** Hover state surface for success/default (#c9f570) */
+    defaultHover: '#c9f570',
+    /** Pressed state surface for success/default (#d7f796) */
+    defaultPressed: '#d7f796',
 
-    /** Hover state surface for success/muted (#BAF24A33) */
-    mutedHover: '#BAF24A33',
-    /** Pressed state surface for success/muted (#BAF24A40) */
-    mutedPressed: '#BAF24A40',
+    /** Hover state surface for success/muted (#baf24a33) */
+    mutedHover: '#baf24a33',
+    /** Pressed state surface for success/muted (#baf24a40) */
+    mutedPressed: '#baf24a40',
   },
   info: {
     /** For informational read-only elements: info, reminder, hint (#8b99ff) */

--- a/packages/design-tokens/src/js/themes/darkTheme/colors.ts
+++ b/packages/design-tokens/src/js/themes/darkTheme/colors.ts
@@ -105,38 +105,38 @@ export const colors: ThemeColors = {
     mutedPressed: '#ff758440',
   },
   warning: {
-    /** For warning semantic elements: caution, attention, precaution (#FFD957) */
-    default: brandColor.yellow100,
-    /** Muted color option for warning semantic (#FFD95726) */
-    muted: '#ffd95726',
+    /** For warning semantic elements: caution, attention, precaution (#F0B034) */
+    default: brandColor.yellow200,
+    /** Muted color option for warning semantic (#F0B03426) */
+    muted: '#F0B03426',
     /** For elements placed on top of warning/default fill (#121314) */
     inverse: brandColor.grey900,
-    /** Hover state surface for warning/default (#ffde6b) */
-    defaultHover: '#ffde6b',
-    /** Pressed state surface for warning/default (#ffe794) */
-    defaultPressed: '#ffe794',
+    /** Hover state surface for warning/default (#F3BE59) */
+    defaultHover: '#F3BE59',
+    /** Pressed state surface for warning/default (#F6CD7F) */
+    defaultPressed: '#F6CD7F',
 
-    /** Hover state surface for warning/muted (#FFD95733) */
-    mutedHover: '#ffd95733',
-    /** Pressed state surface for warning/muted (#FFD95740) */
-    mutedPressed: '#ffd95740',
+    /** Hover state surface for warning/muted (#F0B03433) */
+    mutedHover: '#F0B03433',
+    /** Pressed state surface for warning/muted (#F0B03440) */
+    mutedPressed: '#F0B03440',
   },
   success: {
-    /** For positive semantic elements: success, confirm, complete, safe (#4CB564) */
-    default: brandColor.green300,
-    /** Muted color for positive semantic (#4CB56426) */
-    muted: '#4cb56426',
+    /** For positive semantic elements: success, confirm, complete, safe (#BAF24A) */
+    default: brandColor.lime100,
+    /** Muted color for positive semantic (#BAF24A26) */
+    muted: '#BAF24A26',
     /** For elements placed on top of success/default fill (#121314) */
     inverse: brandColor.grey900,
-    /** Hover state surface for success/default (#59ba6f) */
-    defaultHover: '#59ba6f',
-    /** Pressed state surface for success/default (#76C688) */
-    defaultPressed: '#76c688',
+    /** Hover state surface for success/default (#C9F570) */
+    defaultHover: '#C9F570',
+    /** Pressed state surface for success/default (#D7F796) */
+    defaultPressed: '#D7F796',
 
-    /** Hover state surface for success/muted (#4CB56433) */
-    mutedHover: '#4cb56433',
-    /** Pressed state surface for success/muted (#4CB56440) */
-    mutedPressed: '#4cb56440',
+    /** Hover state surface for success/muted (#BAF24A33) */
+    mutedHover: '#BAF24A33',
+    /** Pressed state surface for success/muted (#BAF24A40) */
+    mutedPressed: '#BAF24A40',
   },
   info: {
     /** For informational read-only elements: info, reminder, hint (#8b99ff) */

--- a/packages/design-tokens/src/js/themes/lightTheme/colors.ts
+++ b/packages/design-tokens/src/js/themes/lightTheme/colors.ts
@@ -121,18 +121,18 @@ export const colors: ThemeColors = {
   success: {
     /** For positive semantic elements: success, confirm, complete, safe (#457A39) */
     default: brandColor.lime500,
-    /** Muted color for positive semantic (#457A391A) */
-    muted: '#457A391A',
+    /** Muted color for positive semantic (#457a391a) */
+    muted: '#457a391a',
     /** For elements placed on top of success/default fill (#FFFFFF) */
     inverse: brandColor.grey000,
-    /** Hover state surface for success/default (#3D6C32) */
-    defaultHover: '#3D6C32',
-    /** Pressed state surface for success/default (#2D5025) */
-    defaultPressed: '#2D5025',
-    /** Hover state surface for success/muted (#457A3926) */
-    mutedHover: '#457A3926',
-    /** Pressed state surface for success/muted (#457A3933) */
-    mutedPressed: '#457A3933',
+    /** Hover state surface for success/default (#3d6c32) */
+    defaultHover: '#3d6c32',
+    /** Pressed state surface for success/default (#2d5025) */
+    defaultPressed: '#2d5025',
+    /** Hover state surface for success/muted (#457a3926) */
+    mutedHover: '#457a3926',
+    /** Pressed state surface for success/muted (#457a3933) */
+    mutedPressed: '#457a3933',
   },
   info: {
     /** For informational read-only elements: info, reminder, hint (#4459ff) */

--- a/packages/design-tokens/src/js/themes/lightTheme/colors.ts
+++ b/packages/design-tokens/src/js/themes/lightTheme/colors.ts
@@ -119,20 +119,20 @@ export const colors: ThemeColors = {
     mutedPressed: '#9a630033',
   },
   success: {
-    /** For positive semantic elements: success, confirm, complete, safe (#1C7E33) */
-    default: brandColor.green500,
-    /** Muted color for positive semantic (#1C7E331A) */
-    muted: '#1c7e331a',
+    /** For positive semantic elements: success, confirm, complete, safe (#457A39) */
+    default: brandColor.lime500,
+    /** Muted color for positive semantic (#457A391A) */
+    muted: '#457A391A',
     /** For elements placed on top of success/default fill (#FFFFFF) */
     inverse: brandColor.grey000,
-    /** Hover state surface for success/default (#186c2c) */
-    defaultHover: '#186c2c',
-    /** Pressed state surface for success/default (#114B1E) */
-    defaultPressed: '#114b1e',
-    /** Hover state surface for success/muted (#1C7E3326) */
-    mutedHover: '#1c7e3326',
-    /** Pressed state surface for success/muted (#1C7E3333) */
-    mutedPressed: '#1c7e3333',
+    /** Hover state surface for success/default (#3D6C32) */
+    defaultHover: '#3D6C32',
+    /** Pressed state surface for success/default (#2D5025) */
+    defaultPressed: '#2D5025',
+    /** Hover state surface for success/muted (#457A3926) */
+    mutedHover: '#457A3926',
+    /** Pressed state surface for success/muted (#457A3933) */
+    mutedPressed: '#457A3933',
   },
   info: {
     /** For informational read-only elements: info, reminder, hint (#4459ff) */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This update aligns the semantic success and warning color tokens with the latest Trade app design direction. Changes focus on shifting success colors from green to lime for clearer visual branding and refining warning colors in dark mode to ensure distinction from lime hues.

This is part 2 of 2 for trade-app-alignment. See [part 1 of 2](https://github.com/MetaMask/metamask-design-system/pull/774) for the other ticket.

🟢 Success Color Updates (Light & Dark Themes)

Purpose: Shift success tokens from green to lime for improved visual identity and consistency.

![image](https://github.com/user-attachments/assets/43e061fa-9082-4bcf-8e95-9ebbec931367)

	•	success-default
	 •	Light: green500 → lime500
	 •	Dark: green300 → lime100
	
	•	success-default-hover
	 •	Light: #186C2C → #3D6C32
	 •	Dark: #59BA6F → #C9F570
	
	•	success-default-pressed
	 •	Light: #114B1E → #2D5025
	 •	Dark: #76C688 → #D7F796
	
	•	success-muted
	 •	Light: green500 @ 10% (#1C7E331A) → lime500 @ 10% (#457A391A)
	 •	Dark: green300 @ 15% (#4CB56426) → lime100 @ 15% (#BAF24A26)
	
	•	success-muted-hover
	 •	Light: green500 @ 15% (#1C7E3326) → lime500 @ 15% (#457A3926)
	 •	Dark: green300 @ 20% (#4CB56433) → lime100 @ 20% (#BAF24A33)
	
	•	success-muted-pressed
	 •	Light: green500 @ 20% (#1C7E3333) → lime500 @ 20% (#457A3933)
	 •	Dark: green300 @ 25% (#4CB56440) → lime100 @ 25% (#BAF24A40)

⸻

🟠 Warning Color Updates (Dark Theme Only)

Purpose: Refine orange tone in dark mode to improve contrast and avoid overlap with lime hues.
![image](https://github.com/user-attachments/assets/f3cb7ffb-1614-4923-bc8d-f1a2b1a232e9)


	•	warning-default
	 •	Light: No change
	 •	Dark: yellow100 → yellow200
	
	•	warning-default-hover
	 •	Light: No change
	 •	Dark: #FFDE6B → #F3BE59
	
	•	warning-default-pressed
 	 •	Light: No change
 	 •	Dark: #FFE794 → #F6CD7F
	
	•	warning-muted
	 •	Light: No change
	 •	Dark: yellow100 @ 15% (#FFD95726) → yellow200 @ 15% (#F0B03426)
	
	•	warning-muted-hover
	 •	Light: No change
	 •	Dark: yellow100 @ 20% (#FFD95733) → yellow200 @ 20% (#F0B03433)
	
	•	warning-muted-pressed
	 •	Light: No change
	 •	Dark: yellow100 @ 25% (#FFD95740) → yellow200 @ 25% (#F0B03440)
	 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
