### PR TITLE
chore: aligning badge docs

### DIFF
--- a/packages/design-system-react/src/components/BadgeCount/README.mdx
+++ b/packages/design-system-react/src/components/BadgeCount/README.mdx
@@ -4,7 +4,7 @@ import * as BadgeCountStories from './BadgeCount.stories';
 
 # BadgeCount
 
-`BadgeCount` is a numeric indicator of unread messages or notifications on an app or UI element.
+BadgeCount is a numeric indicator of unread messages or notifications on an app or UI element.
 
 ```tsx
 import { BadgeCount } from '@metamask/design-system-react';
@@ -16,46 +16,166 @@ import { BadgeCount } from '@metamask/design-system-react';
 
 ## Props
 
-### Size
+### `count`
 
-BadgeCount supports two sizes:
+Required numeric value displayed in the badge.
 
-- `BadgeCountSize.Md` (14px height) – default
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>number</code>
+      </td>
+      <td align="left">Yes</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `size`
+
+BadgeCount supports two sizes.
+
+Available sizes:
+- `BadgeCountSize.Md` (14px height)
 - `BadgeCountSize.Lg` (20px height)
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>BadgeCountSize</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>BadgeCountSize.Md</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 <Canvas of={BadgeCountStories.Size} />
 
-### Count and Max
+### `max`
 
-- **count**: Required numeric value displayed in the badge.
-- **max**: Optional upper bound. If `count > max`, it displays as `"max+"`. Default is `99`.
+Optional upper bound. If `count > max`, it displays as `"max+"`.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>number</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>99</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 <Canvas of={BadgeCountStories.Max} />
 
-### Class Name
+### `textProps`
 
-Use the `className` prop to add custom CSS classes to the component. These classes are merged with the component's default classes using `twMerge`, allowing you to:
+Optional props for the text component displaying the count.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>TextProps</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `className`
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
 
 - Add new styles that don't exist in the default component
 - Override the component's default styles when needed
 
-Example:
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-```tsx
-// Adding new styles
-<BadgeCount count={3} className="my-2 mx-1" />
-
-// Overriding default styles
-<BadgeCount
-  count={5}
-  className="bg-primary-default"
-  textProps={{ color: TextColor.PrimaryInverse }}
-/>
-```
-
-### Style
+### `style`
 
 The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with `className` alone. For static styles, prefer using `className` with Tailwind classes.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>object</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Component API
 

--- a/packages/design-system-react/src/components/BadgeIcon/README.mdx
+++ b/packages/design-system-react/src/components/BadgeIcon/README.mdx
@@ -4,10 +4,10 @@ import * as BadgeIconStories from './BadgeIcon.stories';
 
 # BadgeIcon
 
-`BadgeIcon` is a circular indicator that contains an icon, used to provide quick context or visual tagging at a glance.
+BadgeIcon is a circular indicator that contains an icon, used to provide quick context or visual tagging at a glance.
 
 ```tsx
-import { BadgeIcon } from '@metamask/design-system-react';
+import { BadgeIcon, IconName } from '@metamask/design-system-react';
 
 <BadgeIcon iconName={IconName.User} />;
 ```
@@ -16,38 +16,110 @@ import { BadgeIcon } from '@metamask/design-system-react';
 
 ## Props
 
-### Icon Name
+### `iconName`
 
-Use the `iconName` prop to define which icon should appear inside the badge. This prop is required.
+Use the `iconName` prop to define which icon should appear inside the badge.
 
-Note: The `Icon` component is a child of the `BadgeIcon` component. Use the `iconProps` prop to customize the internal `Icon` component, such as changing the icon color.
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>IconName</code>
+      </td>
+      <td align="left">Yes</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 <Canvas of={BadgeIconStories.IconNameStory} />
 
-### Class Name
+### `iconProps`
 
-Use the `className` prop to add custom CSS classes to the BadgeIcon component. These classes are merged with the component's default styles using `twMerge`, allowing you to:
+The `iconProps` prop allows you to customize the internal `Icon` component, such as changing the icon color.
 
-- Add new utility styles
-- Override default styles when needed
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>IconProps</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-Example:
+### `className`
 
-```tsx
-// Adding spacing utilities
-<BadgeIcon iconName={IconName.User} className="ml-2" />
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
 
-// Overriding background color
-<BadgeIcon
-  iconName={IconName.User}
-  className="bg-success-default"
-  iconProps={{ color: IconColor.SuccessInverse }}
-/>
-```
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
 
-### Style
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with Tailwind or className alone. For static styles, prefer `className`.
+### `style`
+
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with `className` alone. For static styles, prefer using `className` with Tailwind classes.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>object</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Component API
 

--- a/packages/design-system-react/src/components/BadgeNetwork/README.mdx
+++ b/packages/design-system-react/src/components/BadgeNetwork/README.mdx
@@ -4,7 +4,203 @@ import * as BadgeNetworkStories from './BadgeNetwork.stories';
 
 # BadgeNetwork
 
-`BadgeNetwork` indicates the network an entity is connected to.
+BadgeNetwork indicates the network an entity is connected to.
+
+<Canvas of={BadgeNetworkStories.Default} />
+
+## Props
+
+### `name`
+
+The `name` prop is required and serves two purposes: used as alt text for the network image and first letter is used as fallback display text when `fallbackText` is not provided.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">Yes</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={BadgeNetworkStories.Name} />
+
+### `src`
+
+The `src` prop is optional and specifies the URL of the network's logo image.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={BadgeNetworkStories.Src} />
+
+### `fallbackText`
+
+The `fallbackText` prop is optional and is used for display text when no image is provided. If not provided, the first letter of `name` will be used.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={BadgeNetworkStories.FallbackText} />
+
+### `imageProps`
+
+The `imageProps` prop allows you to customize the img element when `src` is provided. All standard HTML img attributes are supported.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>object</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `fallbackTextProps`
+
+The `fallbackTextProps` prop allows you to customize the Text component used for the fallback display.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>TextProps</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `className`
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `style`
+
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with `className` alone. For static styles, prefer using `className` with Tailwind classes.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>object</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Component API
+
+<Controls of={BadgeNetworkStories.Default} />
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
 
 ```tsx
 import { BadgeNetwork } from '@metamask/design-system-react';
@@ -15,81 +211,3 @@ import { BadgeNetwork } from '@metamask/design-system-react';
   fallbackText="A"
 />;
 ```
-
-<Canvas of={BadgeNetworkStories.Default} />
-
-## Props
-
-### Name (required)
-
-The `name` prop is required and serves two purposes:
-
-- Used as alt text for the network image (unless overridden by `imageProps.alt`)
-- First letter is used as fallback display text when `fallbackText` is not provided
-
-<Canvas of={BadgeNetworkStories.Name} />
-
-### Src (image source)
-
-The `src` prop is optional and specifies the URL of the network's logo image.
-
-<Canvas of={BadgeNetworkStories.Src} />
-
-> Note: The `imageProps` prop allows you to customize the img element when `src` is provided. All standard HTML img attributes are supported and will be passed to the underlying img element when `src` is provided. This is useful for overriding the default alt text (which is the network name) when the BadgeNetwork is used as an accompaniment to an image.
-
-```tsx
-<BadgeNetwork
-  name="Ethereum"
-  src="path/to/ethereum-logo.png"
-  fallbackText="E"
-  imageProps={{ alt: 'Ethereum Logo', loading: 'lazy' }}
-/>
-```
-
-### Fallback Text
-
-The `fallbackText` prop is optional and is used for display text when no image is provided. If not provided, the first letter of `name` will be used.
-
-<Canvas of={BadgeNetworkStories.FallbackText} />
-
-> Note: The `fallbackTextProps` prop allows you to customize the Text component used for the fallback display
-
-```tsx
-<BadgeNetwork
-  name="Ethereum"
-  fallbackText="E"
-  fallbackTextProps={{ color: TextColor.PrimaryDefault }}
-/>
-```
-
-### Class Name
-
-Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default
-classes using `twMerge`, allowing you to:
-
-- Add new styles that don't exist in the default component
-- Override the component's default styles when needed
-
-Example:
-
-```tsx
-// Adding new styles
-<BadgeNetwork
-  name="Ethereum"
-  src="path/to/ethereum-logo.png"
-  fallbackText="E"
-  className="mx-2 my-4"
-/>
-```
-
-### Style
-
-The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with `className` alone. For static styles, prefer using `className` with Tailwind classes.
-
-## Component API
-
-<Controls of={BadgeNetworkStories.Default} />
-
-## References
-
-[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/src/components/BadgeStatus/README.mdx
+++ b/packages/design-system-react/src/components/BadgeStatus/README.mdx
@@ -4,10 +4,10 @@ import * as BadgeStatusStories from './BadgeStatus.stories';
 
 # BadgeStatus
 
-`BadgeStatus` indicates the state of an item through color.
+BadgeStatus indicates the state of an item through color.
 
 ```tsx
-import { BadgeStatus } from '@metamask/design-system-react';
+import { BadgeStatus, BadgeStatusStatus } from '@metamask/design-system-react';
 
 <BadgeStatus status={BadgeStatusStatus.Active} />;
 ```
@@ -16,51 +16,150 @@ import { BadgeStatus } from '@metamask/design-system-react';
 
 ## Props
 
-### Status
+### `status`
 
-Use the `status` prop to indicate the visual state of the badge. Supported values:
+Use the `status` prop to indicate the visual state of the badge.
 
-- `BadgeStatusStatus.Active` (Connected)
-- `BadgeStatusStatus.Inactive` (Connected)
+Available statuses:
+- `BadgeStatusStatus.Active` - Connected
+- `BadgeStatusStatus.Inactive` - Connected
 - `BadgeStatusStatus.Disconnected`
 - `BadgeStatusStatus.New`
 - `BadgeStatusStatus.Attention`
 
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>BadgeStatusStatus</code>
+      </td>
+      <td align="left">Yes</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <Canvas of={BadgeStatusStories.Status} />
 
-### Size
+### `size`
 
-BadgeStatus supports two size options:
+BadgeStatus supports two size options.
 
-- `BadgeStatusSize.Md` (8px) – default
+Available sizes:
+- `BadgeStatusSize.Md` (8px)
 - `BadgeStatusSize.Lg` (10px)
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>BadgeStatusSize</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>BadgeStatusSize.Md</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 <Canvas of={BadgeStatusStories.Size} />
 
-### Has Border
+### `hasBorder`
 
-The `hasBorder` prop adds an outer border to the badge, often used to separate the status from surrounding backgrounds. Default is `true`.
+The `hasBorder` prop adds an outer border to the badge, often used to separate the status from surrounding backgrounds.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>boolean</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>true</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 <Canvas of={BadgeStatusStories.HasBorder} />
 
-### Class Name
+### `className`
 
-Use the `className` prop to add custom CSS classes to the BadgeStatus component. These classes are merged with the component's default styles using `twMerge`, allowing you to:
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
 
-- Add new utility styles
-- Override default styles when needed
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
 
-```tsx
-// Custom border and spacing
-<BadgeStatus
-  status={BadgeStatusStatus.Active}
-  className="ml-2 border-warning-default"
-/>
-```
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-### Style
+### `style`
 
-The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with Tailwind or className alone. For static styles, prefer `className`.
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with `className` alone. For static styles, prefer using `className` with Tailwind classes.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>object</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Component API
 

--- a/packages/design-system-react/src/components/BadgeWrapper/README.mdx
+++ b/packages/design-system-react/src/components/BadgeWrapper/README.mdx
@@ -1,9 +1,20 @@
 import { Controls, Canvas } from '@storybook/blocks';
+
 import * as BadgeWrapperStories from './BadgeWrapper.stories';
 
 # BadgeWrapper
 
-The `BadgeWrapper` positions a badge on top of another element.
+BadgeWrapper positions a badge on top of another element.
+
+```tsx
+import { BadgeWrapper, BadgeStatus, BadgeStatusStatus } from '@metamask/design-system-react';
+
+<BadgeWrapper
+  badge={<BadgeStatus status={BadgeStatusStatus.Active} />}
+>
+  <div>Content with badge</div>
+</BadgeWrapper>;
+```
 
 <Canvas of={BadgeWrapperStories.Default} />
 
@@ -11,11 +22,9 @@ The `BadgeWrapper` positions a badge on top of another element.
 
 ### `position`
 
-Optional prop to control the preset position of the badge.  
-This prop gets used along with `positionAnchorShape`, `positionXOffset`, and `positionYOffset` to determine the final position.
+Optional prop to control the preset position of the badge. This prop gets used along with `positionAnchorShape`, `positionXOffset`, and `positionYOffset` to determine the final position.
 
 Available positions:
-
 - `BadgeWrapperPosition.TopRight`
 - `BadgeWrapperPosition.TopLeft`
 - `BadgeWrapperPosition.BottomLeft`
@@ -31,11 +40,11 @@ Available positions:
   </thead>
   <tbody>
     <tr>
-      <td>
+      <td align="left">
         <code>BadgeWrapperPosition</code>
       </td>
-      <td>No</td>
-      <td>
+      <td align="left">No</td>
+      <td align="left">
         <code>BadgeWrapperPosition.BottomRight</code>
       </td>
     </tr>
@@ -44,14 +53,11 @@ Available positions:
 
 <Canvas of={BadgeWrapperStories.Position} />
 
----
-
 ### `positionAnchorShape`
 
-Optional prop to determine the shape of the anchoring element.  
-This prop gets used along with `position`, `positionXOffset`, and `positionYOffset` to determine the final position.  
-Possible values:
+Optional prop to determine the shape of the anchoring element. This prop gets used along with `position`, `positionXOffset`, and `positionYOffset` to determine the final position.
 
+Available shapes:
 - `BadgeWrapperPositionAnchorShape.Circular`
 - `BadgeWrapperPositionAnchorShape.Rectangular`
 
@@ -65,11 +71,11 @@ Possible values:
   </thead>
   <tbody>
     <tr>
-      <td>
+      <td align="left">
         <code>BadgeWrapperPositionAnchorShape</code>
       </td>
-      <td>No</td>
-      <td>
+      <td align="left">No</td>
+      <td align="left">
         <code>BadgeWrapperPositionAnchorShape.Circular</code>
       </td>
     </tr>
@@ -78,12 +84,9 @@ Possible values:
 
 <Canvas of={BadgeWrapperStories.PositionAnchorShape} />
 
----
-
 ### `positionXOffset`
 
-Optional prop to move the preset position horizontally.  
-This prop gets used along with `position`, `positionAnchorShape`, and `positionYOffset` to determine the final position.
+Optional prop to move the preset position horizontally. This prop gets used along with `position`, `positionAnchorShape`, and `positionYOffset` to determine the final position.
 
 <table>
   <thead>
@@ -95,11 +98,11 @@ This prop gets used along with `position`, `positionAnchorShape`, and `positionY
   </thead>
   <tbody>
     <tr>
-      <td>
+      <td align="left">
         <code>number</code>
       </td>
-      <td>No</td>
-      <td>
+      <td align="left">No</td>
+      <td align="left">
         <code>0</code>
       </td>
     </tr>
@@ -108,12 +111,9 @@ This prop gets used along with `position`, `positionAnchorShape`, and `positionY
 
 <Canvas of={BadgeWrapperStories.PositionXOffset} />
 
----
-
 ### `positionYOffset`
 
-Optional prop to move the preset position vertically.  
-This prop gets used along with `position`, `positionAnchorShape`, and `positionXOffset` to determine the final position.
+Optional prop to move the preset position vertically. This prop gets used along with `position`, `positionAnchorShape`, and `positionXOffset` to determine the final position.
 
 <table>
   <thead>
@@ -125,11 +125,11 @@ This prop gets used along with `position`, `positionAnchorShape`, and `positionX
   </thead>
   <tbody>
     <tr>
-      <td>
+      <td align="left">
         <code>number</code>
       </td>
-      <td>No</td>
-      <td>
+      <td align="left">No</td>
+      <td align="left">
         <code>0</code>
       </td>
     </tr>
@@ -138,13 +138,9 @@ This prop gets used along with `position`, `positionAnchorShape`, and `positionX
 
 <Canvas of={BadgeWrapperStories.PositionYOffset} />
 
----
-
 ### `customPosition`
 
-Optional prop to customize the position through a position object.  
-Shape of the object: `{ top?: number\|string; right?: number\|string; bottom?: number\|string; left?: number\|string }`.  
-If provided, this overrides the preset `position` + offsets.
+Optional prop to customize the position through a position object. Shape of the object: `{ top?: number|string; right?: number|string; bottom?: number|string; left?: number|string }`. If provided, this overrides the preset `position` + offsets.
 
 <table>
   <thead>
@@ -156,11 +152,11 @@ If provided, this overrides the preset `position` + offsets.
   </thead>
   <tbody>
     <tr>
-      <td>
+      <td align="left">
         <code>BadgeWrapperCustomPosition</code>
       </td>
-      <td>No</td>
-      <td>
+      <td align="left">No</td>
+      <td align="left">
         <code>undefined</code>
       </td>
     </tr>
@@ -168,8 +164,6 @@ If provided, this overrides the preset `position` + offsets.
 </table>
 
 <Canvas of={BadgeWrapperStories.CustomPosition} />
-
----
 
 ### `children`
 
@@ -185,18 +179,16 @@ The element that the badge will attach itself to. Additional props can be passed
   </thead>
   <tbody>
     <tr>
-      <td>
+      <td align="left">
         <code>ReactNode</code>
       </td>
-      <td>Yes</td>
-      <td>
-        <code>—</code>
+      <td align="left">Yes</td>
+      <td align="left">
+        <code>undefined</code>
       </td>
     </tr>
   </tbody>
 </table>
-
----
 
 ### `badge`
 
@@ -212,12 +204,12 @@ Any element that will be placed in the position of the badge. Additional props c
   </thead>
   <tbody>
     <tr>
-      <td>
+      <td align="left">
         <code>ReactNode</code>
       </td>
-      <td>Yes</td>
-      <td>
-        <code>—</code>
+      <td align="left">Yes</td>
+      <td align="left">
+        <code>undefined</code>
       </td>
     </tr>
   </tbody>
@@ -225,12 +217,62 @@ Any element that will be placed in the position of the badge. Additional props c
 
 <Canvas of={BadgeWrapperStories.Badge} />
 
----
+### `childrenContainerProps`
+
+Additional props can be passed to the children container.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>object</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `badgeContainerProps`
+
+Additional props can be passed to the badge container.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>object</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### `className`
 
-Optional prop for additional CSS classes to be applied to the BadgeWrapper component.  
-These classes will be merged with the component’s default classes using `twMerge`.
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
 
 <table>
   <thead>
@@ -242,22 +284,20 @@ These classes will be merged with the component’s default classes using `twMer
   </thead>
   <tbody>
     <tr>
-      <td>
+      <td align="left">
         <code>string</code>
       </td>
-      <td>No</td>
-      <td>
+      <td align="left">No</td>
+      <td align="left">
         <code>undefined</code>
       </td>
     </tr>
   </tbody>
 </table>
-
----
 
 ### `style`
 
-Optional prop to control the style of the outer wrapper.
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with `className` alone. For static styles, prefer using `className` with Tailwind classes.
 
 <table>
   <thead>
@@ -269,22 +309,20 @@ Optional prop to control the style of the outer wrapper.
   </thead>
   <tbody>
     <tr>
-      <td>
-        <code>React.CSSProperties</code>
+      <td align="left">
+        <code>object</code>
       </td>
-      <td>No</td>
-      <td>
+      <td align="left">No</td>
+      <td align="left">
         <code>undefined</code>
       </td>
     </tr>
   </tbody>
 </table>
-
----
 
 ### `data-testid`
 
-Optional prop to add a test id to the outermost `<div>` for testing.
+Optional prop to add a test id to the outermost element for testing.
 
 <table>
   <thead>
@@ -296,18 +334,16 @@ Optional prop to add a test id to the outermost `<div>` for testing.
   </thead>
   <tbody>
     <tr>
-      <td>
+      <td align="left">
         <code>string</code>
       </td>
-      <td>No</td>
-      <td>
+      <td align="left">No</td>
+      <td align="left">
         <code>undefined</code>
       </td>
     </tr>
   </tbody>
 </table>
-
----
 
 ## Component API
 


### PR DESCRIPTION
### **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change%3F
2. What is the improvement/solution%3F
-->

This PR was initiated to isolate documentation updates for badge components. However, it also includes broader changes to the design system's Tailwind CSS integration and significant enhancements to the `Box` component.

1.  **Badge Component Documentation:** Updated `README.mdx` files for `BadgeCount`, `BadgeIcon`, `BadgeNetwork`, `BadgeStatus`, and `BadgeWrapper`.
2.  **Tailwind CSS Tooling Migration:** Switched from `prettier-plugin-tailwindcss` to `eslint-plugin-tailwindcss` for class sorting and validation, affecting configuration files and best practices documentation.
3.  **`Box` Component Expansion:** Added new props to the `Box` component for direct control over `margin`, `padding`, `borderWidth`, `borderColor`, and `backgroundColor`, complete with updated types, constants, stories, and tests.
4.  **Tailwind Class Optimizations:** Refactored various components and stories to use more concise Tailwind utility classes (e.g., `p-4` instead of `px-4 py-4`, `size-full` instead of `h-full w-full`).
5.  **Test 


Partially fixes: https://github.com/MetaMask/metamask-design-system/issues/488

### Before

https://github.com/user-attachments/assets/7512223d-b24e-4947-a299-408bd9e694e6

### After

https://github.com/user-attachments/assets/253926f3-4ff2-4a20-91a4-08548280fe6f