### PR TITLE
chore: update AvatarAccount shape from circle to square

### DIFF
--- a/packages/design-system-react-native/src/components/AvatarAccount/AvatarAccount.tsx
+++ b/packages/design-system-react-native/src/components/AvatarAccount/AvatarAccount.tsx
@@ -45,7 +45,7 @@ export const AvatarAccount = ({
   return (
     <AvatarBase
       size={size}
-      shape={AvatarBaseShape.Circle}
+      shape={AvatarBaseShape.Square}
       accessibilityRole="image"
       {...props}
     >

--- a/packages/design-system-react-native/src/components/temp-components/Jazzicon/Jazzicon.test.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/Jazzicon/Jazzicon.test.tsx
@@ -44,7 +44,14 @@ describe('Jazzicon Component', () => {
     render(<Jazzicon {...testProps} testID="jazzicon-container" />);
 
     expect(RNJazzicon).toHaveBeenCalledWith(
-      expect.objectContaining(testProps),
+      expect.objectContaining({
+        ...testProps,
+        containerStyle: {
+          borderRadius: 0, // Component adds this by default
+          backgroundColor: 'red',
+          padding: 5,
+        },
+      }),
       expect.any(Object),
     );
   });

--- a/packages/design-system-react-native/src/components/temp-components/Jazzicon/Jazzicon.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/Jazzicon/Jazzicon.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { View } from 'react-native';
+import { View, type ViewStyle } from 'react-native';
 import RNJazzicon from 'react-native-jazzicon';
 
 import type { JazziconProps } from './Jazzicon.types';
 
 export const Jazzicon = ({ testID, ...props }: JazziconProps) => (
   <View testID={testID}>
-    <RNJazzicon {...props} />
+    <RNJazzicon
+      {...props}
+      containerStyle={{
+        borderRadius: 0, // Override circular border radius to make it square
+        ...(props.containerStyle as ViewStyle),
+      }}
+    />
   </View>
 );

--- a/packages/design-system-react/src/components/AvatarAccount/AvatarAccount.tsx
+++ b/packages/design-system-react/src/components/AvatarAccount/AvatarAccount.tsx
@@ -62,7 +62,7 @@ export const AvatarAccount = forwardRef<HTMLDivElement, AvatarAccountProps>(
     return (
       <AvatarBase
         ref={ref}
-        shape={AvatarBaseShape.Circle}
+        shape={AvatarBaseShape.Square}
         size={size}
         className={className}
         {...props}

--- a/packages/design-system-react/src/components/temp-components/Jazzicon/Jazzicon.tsx
+++ b/packages/design-system-react/src/components/temp-components/Jazzicon/Jazzicon.tsx
@@ -90,7 +90,11 @@ export const Jazzicon = ({
   }, [address, size]);
 
   return (
-    <div ref={containerRef} className={twMerge('flex', className)} {...props} />
+    <div
+      ref={containerRef}
+      className={twMerge('flex [&>div]:!rounded-none', className)}
+      {...props}
+    />
   );
 };
 


### PR DESCRIPTION
## **Description**

Updates the AvatarAccount component shape from circular to square across both React and React Native implementations. This change ensures visual consistency in the avatar display pattern and aligns with updated design system requirements for account avatars.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to Storybook for AvatarAccount component in both React and React Native apps
2. Verify that all AvatarAccount instances now render with square shape instead of circular
3. Test different sizes (xs, sm, md, lg, xl) to ensure square shape is applied consistently
4. Verify that the component maintains proper accessibility attributes
5. Check that existing props and functionality remain unchanged (only shape has changed)

## **Screenshots/Recordings**

Screenshots would be helpful to visualize the shape change from circular to square avatars.

### **Before**

<img width="1440" height="824" alt="Screenshot 2025-07-31 at 11 46 11 AM" src="https://github.com/user-attachments/assets/47bec392-0499-4e19-899e-eb950d9cd611" />
<img width="1279" height="835" alt="Screenshot 2025-07-31 at 11 46 25 AM" src="https://github.com/user-attachments/assets/2715762b-5704-4c56-8ed2-63f9c5363d57" />


### **After**

<img width="895" height="668" alt="Screenshot 2025-07-31 at 10 15 41 AM" src="https://github.com/user-attachments/assets/9a758bcd-79ba-4fbf-95d2-7f7f50e9133d" />
<img width="1261" height="740" alt="Screenshot 2025-07-31 at 10 16 17 AM" src="https://github.com/user-attachments/assets/d2830e91-e69c-4a66-b0f6-e48e67abccc6" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.