### PR TITLE
fix: make Button variant prop optional with Primary as default

### DIFF
--- a/packages/design-system-react-native/src/components/Button/Button.test.tsx
+++ b/packages/design-system-react-native/src/components/Button/Button.test.tsx
@@ -6,6 +6,13 @@ import { ButtonVariant } from '../../types';
 import { Button } from './Button';
 
 describe('Button', () => {
+  it('renders primary variant by default when no variant is provided', () => {
+    const { getByTestId } = render(
+      <Button testID="button-default">Default Button</Button>,
+    );
+    expect(getByTestId('button-default')).not.toBeNull();
+  });
+
   it('renders the correct primary variant', () => {
     const { getByTestId } = render(
       <Button variant={ButtonVariant.Primary} testID="button-primary">

--- a/packages/design-system-react-native/src/components/Button/Button.tsx
+++ b/packages/design-system-react-native/src/components/Button/Button.tsx
@@ -8,7 +8,7 @@ import { ButtonSecondary } from './variants/ButtonSecondary';
 import { ButtonTertiary } from './variants/ButtonTertiary';
 
 export const Button = (buttonProps: ButtonProps) => {
-  const { variant, ...restProps } = buttonProps;
+  const { variant = ButtonVariant.Primary, ...restProps } = buttonProps;
 
   switch (variant) {
     case ButtonVariant.Tertiary:

--- a/packages/design-system-react-native/src/components/Button/Button.types.ts
+++ b/packages/design-system-react-native/src/components/Button/Button.types.ts
@@ -15,5 +15,5 @@ export type ButtonProps = (
   /**
    * Variant of Button.
    */
-  variant: ButtonVariant;
+  variant?: ButtonVariant;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Makes the `variant` prop optional for the Button component in React Native, defaulting to `ButtonVariant.Primary` when not specified. This change improves developer experience by allowing simpler Button usage without explicitly defining the variant for primary buttons, which is the most common use case.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Navigate to the React Native Button component in Storybook
2. Test that Button renders with primary variant when no variant prop is provided
3. Verify that explicitly setting variant prop still works for all variants (Primary, Secondary, Tertiary)
4. Run the Button component tests to ensure all test cases pass

## **Screenshots/Recordings**

<!-- Not applicable for this change as it's a TypeScript/prop change with no visual impact -->

### **Before**

Button component required explicit variant prop:

```tsx
<Button variant={ButtonVariant.Primary}>Click me</Button>
```

### **After**

Button component now works without variant prop (defaults to Primary):

```tsx
<Button>Click me</Button>
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
