### PR TITLE
fix: export missing Box component color enums for React Native

### DIFF
--- a/packages/design-system-react-native/src/components/Box/index.ts
+++ b/packages/design-system-react-native/src/components/Box/index.ts
@@ -3,6 +3,8 @@ export {
   BoxFlexWrap,
   BoxAlignItems,
   BoxJustifyContent,
+  BoxBackgroundColor,
+  BoxBorderColor,
 } from '../../types';
 export type { BoxSpacing, BoxBorderWidth } from '../../types';
 export { Box } from './Box';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -58,6 +58,8 @@ export {
   BoxFlexWrap,
   BoxAlignItems,
   BoxJustifyContent,
+  BoxBackgroundColor,
+  BoxBorderColor,
 } from './Box';
 export type { BoxProps, BoxSpacing } from './Box';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes missing type exports for the Box component in React Native. This change adds `BoxBackgroundColor` and `BoxBorderColor` enum exports to ensure complete type availability for consumers of the design system package. These enums were already available internally but not exposed through the public API, which could cause TypeScript errors when trying to use strongly-typed color props with the Box component.

## **Related issues**

Fixes: <!-- No specific issue linked -->

## **Manual testing steps**

1. Import the Box component from `@metamask/design-system-react-native`
2. Verify that `BoxBackgroundColor` and `BoxBorderColor` enums are now available for import
3. Use these enums to set backgroundColor and borderColor props on Box components
4. Confirm TypeScript correctly validates the enum values without errors

## **Screenshots/Recordings**

<!-- Not applicable for type export changes -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
