### PR TITLE
fix: align React peer dependencies with MetaMask extension React 17

### DIFF
--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -87,8 +87,8 @@
     "@metamask/utils": "^11.4.2",
     "@solana/addresses": "^2.0.0",
     "bitcoin-address-validation": ">=2.0.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "tailwindcss": "^3.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3413,8 +3413,8 @@ __metadata:
     "@metamask/utils": ^11.4.2
     "@solana/addresses": ^2.0.0
     bitcoin-address-validation: ">=2.0.0"
-    react: ^16.0.0
-    react-dom: ^16.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
     tailwindcss: ^3.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates React and React-DOM peer dependencies in the design system React package to support both React 17 and React 18. This change aligns with the MetaMask extension's current use of React 17.0.2 while maintaining forward compatibility with React 18 for development environments and future upgrades.

## **Related issues**

Fixes: <!-- No specific issue linked -->

## **Manual testing steps**

1. Install the updated package in a React 17 project (like MetaMask extension)
2. Verify no peer dependency warnings are shown during installation
3. Import and use any design system component (e.g., Button, Checkbox)
4. Confirm components render and function correctly
5. Repeat steps 1-4 with a React 18 project to ensure forward compatibility

## **Screenshots/Recordings**

<!-- Not applicable for dependency updates -->

### **Before**

Peer dependencies only supported React ^16.0.0, causing compatibility issues with both the extension (React 17) and development environment (React 18).

### **After**

Peer dependencies now support React ^17.0.0 || ^18.0.0, ensuring compatibility with current and future React versions.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
