### PR TITLE
Remove dompurify and simplify maskicon

### DIFF
--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -53,7 +53,6 @@
     "@metamask/jazzicon": "^2.0.0",
     "@radix-ui/react-slot": "^1.1.0",
     "blo": "^2.0.0",
-    "dompurify": "^3.2.5",
     "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.test.tsx
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.test.tsx
@@ -190,7 +190,7 @@ describe('Maskicon Utilities', () => {
 describe('Maskicon', () => {
   afterEach(cleanup);
 
-  it('renders a placeholder div initially, then updates when SVG is ready', async () => {
+  it('renders a placeholder div initially, then updates to an <img> with data URI when SVG is ready', async () => {
     // Spy on getMaskiconSVG to resolve immediately.
     const resolvedSvg = '<svg><rect width="100" height="100"/></svg>';
     const getSvgSpy = jest
@@ -209,16 +209,17 @@ describe('Maskicon', () => {
     expect(initialDiv).toBeInTheDocument();
     expect(initialDiv.innerHTML).toBe('');
 
-    // Wait for the async effect to update the div.
+    // Wait for the async effect to render an <img> with a data URI
     await waitFor(() => {
-      expect((container.firstChild as HTMLElement).innerHTML).toContain('<svg');
+      const img = container.querySelector('img') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      expect(img.getAttribute('src')).toContain('data:image/svg+xml,');
     });
-    // Now that the SVG is rendered, the div should have the test id.
-    const updatedDiv = container.querySelector(
-      '[data-testid="maskicon"]',
-    ) as HTMLElement;
-    expect(updatedDiv).toBeInTheDocument();
-    expect(updatedDiv).toHaveStyle({ width: '32px', height: '32px' });
+    const updatedImg = container.querySelector(
+      'img[data-testid="maskicon"]',
+    ) as HTMLImageElement;
+    expect(updatedImg).toBeInTheDocument();
+    expect(updatedImg).toHaveStyle({ width: '32px', height: '32px' });
 
     getSvgSpy.mockRestore();
   });
@@ -237,15 +238,16 @@ describe('Maskicon', () => {
     );
 
     await waitFor(() => {
-      expect((container.firstChild as HTMLElement).innerHTML).toStrictEqual(
-        expect.stringContaining('<svg'),
-      );
+      const img = container.querySelector('img') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      expect(img.getAttribute('src')).toContain('data:image/svg+xml,');
     });
-    expect(container.firstChild).toHaveStyle({ width: '32px', height: '32px' });
+    const imgEl = container.querySelector('img') as HTMLImageElement;
+    expect(imgEl).toHaveStyle({ width: '32px', height: '32px' });
     getSvgSpy.mockRestore();
   });
 
-  it('forwards additional props to the div container', async () => {
+  it('forwards additional props to the <img> element', async () => {
     const resolvedSvg = '<svg><rect width="100" height="100"/></svg>';
     const getSvgSpy = jest
       .spyOn(MaskiconUtilities, 'getMaskiconSVG')
@@ -260,15 +262,14 @@ describe('Maskicon', () => {
     );
 
     await waitFor(() => {
-      expect((container.firstChild as HTMLElement).innerHTML).toStrictEqual(
-        expect.stringContaining('<svg'),
-      );
+      const img = container.querySelector('img') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
     });
-    const updatedDiv = container.querySelector(
-      '[data-testid="maskicon-forward"]',
-    ) as HTMLElement;
-    expect(updatedDiv).toBeInTheDocument();
-    expect(updatedDiv.getAttribute('data-custom')).toBe('hello');
+    const updatedImg = container.querySelector(
+      'img[data-testid="maskicon-forward"]',
+    ) as HTMLImageElement;
+    expect(updatedImg).toBeInTheDocument();
+    expect(updatedImg.getAttribute('data-custom')).toBe('hello');
     getSvgSpy.mockRestore();
   });
 

--- a/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.tsx
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.tsx
@@ -1,10 +1,7 @@
-import * as dompurify from 'dompurify';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import type { MaskiconProps } from './Maskicon.types';
 import { getMaskiconSVG } from './Maskicon.utilities';
-
-const DOMPurify = dompurify.default;
 
 export const Maskicon = ({
   address,
@@ -28,14 +25,28 @@ export const Maskicon = ({
     };
   }, [address, size]);
 
-  if (!svgString) {
+  const dataUri = useMemo(() => {
+    if (!svgString) {
+      return '';
+    }
+    // Encode the SVG for safe data URI usage
+    const encoded = encodeURIComponent(svgString)
+      .replace(/%0A/g, '')
+      .replace(/%20/g, ' ');
+    return `data:image/svg+xml,${encoded}`;
+  }, [svgString]);
+
+  if (!dataUri) {
     return <div style={{ width: size, height: size, ...style }} {...props} />;
   }
 
   return (
-    <div
+    <img
+      alt="maskicon"
+      width={size}
+      height={size}
       style={{ width: size, height: size, ...style }}
-      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(svgString) }}
+      src={dataUri}
       {...props}
     />
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

1.  **Reason for the change**: The `Maskicon` component currently uses `DOMPurify` and `dangerouslySetInnerHTML` to render SVGs, which adds an unnecessary dependency, increases bundle size, and is inconsistent with safer patterns used in the MetaMask extension.
2.  **Improvement/Solution**: This PR removes the `DOMPurify` dependency and refactors the `Maskicon` component to render SVGs as an `<img>` element using a `data:image/svg+xml` URI. This approach is inherently safer (as SVG scripts are not executed when used as an image source), reduces bundle size, and aligns with best practices.

## **Related issues**

Fixes:

## **Manual testing steps**

1.  Navigate to a page where `Maskicon` components are rendered (e.g., a storybook story or a relevant UI page).
2.  Verify that Maskicons render correctly for various addresses.
3.  Test with different `size` props to ensure proper scaling.
4.  Inspect the rendered HTML to confirm that the `Maskicon` is now an `<img>` element with a `src` attribute starting with `data:image/svg+xml,`.
5.  Ensure no visual regressions or console errors are introduced.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable (updated existing tests)
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable (No new complex functions, refactor of existing)
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---
<a href="https://cursor.com/background-agent?bcId=bc-b23caf0e-2dc0-4c98-bcb4-9367a1714e27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b23caf0e-2dc0-4c98-bcb4-9367a1714e27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

