### PR TITLE
fix: remove DOMPurify dependency from Maskicon component

### DIFF
--- a/.cursor/temp/pr-description-4a8f9c2e.md
+++ b/.cursor/temp/pr-description-4a8f9c2e.md
@@ -1,0 +1,40 @@
+## **Description**
+
+Removes the DOMPurify dependency from the Maskicon component by replacing the direct SVG injection approach with a safer data URI implementation. The component now renders an `<img>` element with an encoded SVG data URI instead of using `dangerouslySetInnerHTML`, eliminating the need for HTML sanitization while maintaining the same visual output and improving security.
+
+## **Related issues**
+
+Fixes: <!-- Add issue links if applicable -->
+
+## **Manual testing steps**
+
+1. Navigate to the Maskicon component in Storybook
+2. Verify that Maskicon renders correctly with various Ethereum addresses
+3. Test different size props to ensure proper scaling
+4. Confirm that custom props (data-testid, styles) are properly forwarded to the img element
+5. Run `yarn workspace @metamask/design-system-react test:verbose src/components/temp-components/Maskicon/Maskicon.test.tsx` to verify all tests pass
+
+## **Screenshots/Recordings**
+
+<!-- Visual changes are minimal as the component renders the same SVG content, just through an img element instead of direct injection -->
+
+### **Before**
+
+<!-- Component rendered SVG directly in a div using dangerouslySetInnerHTML with DOMPurify -->
+
+### **After**
+
+<!-- Component renders SVG via img element with data URI, maintaining identical visual appearance -->
+
+## **Pre-merge author checklist**
+
+- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
+- [x] I've completed the PR template to the best of my ability
+- [x] I've included tests if applicable
+- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
+- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
+
+## **Pre-merge reviewer checklist**
+
+- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
+- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -53,7 +53,6 @@
     "@metamask/jazzicon": "^2.0.0",
     "@radix-ui/react-slot": "^1.1.0",
     "blo": "^2.0.0",
-    "dompurify": "^3.2.5",
     "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.test.tsx
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.test.tsx
@@ -190,7 +190,7 @@ describe('Maskicon Utilities', () => {
 describe('Maskicon', () => {
   afterEach(cleanup);
 
-  it('renders a placeholder div initially, then updates when SVG is ready', async () => {
+  it('renders a placeholder div initially, then updates to an <img> with data URI when SVG is ready', async () => {
     // Spy on getMaskiconSVG to resolve immediately.
     const resolvedSvg = '<svg><rect width="100" height="100"/></svg>';
     const getSvgSpy = jest
@@ -209,16 +209,17 @@ describe('Maskicon', () => {
     expect(initialDiv).toBeInTheDocument();
     expect(initialDiv.innerHTML).toBe('');
 
-    // Wait for the async effect to update the div.
+    // Wait for the async effect to render an <img> with a data URI
     await waitFor(() => {
-      expect((container.firstChild as HTMLElement).innerHTML).toContain('<svg');
+      const img = container.querySelector('img') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      expect(img.getAttribute('src')).toContain('data:image/svg+xml,');
     });
-    // Now that the SVG is rendered, the div should have the test id.
-    const updatedDiv = container.querySelector(
-      '[data-testid="maskicon"]',
-    ) as HTMLElement;
-    expect(updatedDiv).toBeInTheDocument();
-    expect(updatedDiv).toHaveStyle({ width: '32px', height: '32px' });
+    const updatedImg = container.querySelector(
+      'img[data-testid="maskicon"]',
+    ) as HTMLImageElement;
+    expect(updatedImg).toBeInTheDocument();
+    expect(updatedImg).toHaveStyle({ width: '32px', height: '32px' });
 
     getSvgSpy.mockRestore();
   });
@@ -237,15 +238,16 @@ describe('Maskicon', () => {
     );
 
     await waitFor(() => {
-      expect((container.firstChild as HTMLElement).innerHTML).toStrictEqual(
-        expect.stringContaining('<svg'),
-      );
+      const img = container.querySelector('img') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      expect(img.getAttribute('src')).toContain('data:image/svg+xml,');
     });
-    expect(container.firstChild).toHaveStyle({ width: '32px', height: '32px' });
+    const imgEl = container.querySelector('img') as HTMLImageElement;
+    expect(imgEl).toHaveStyle({ width: '32px', height: '32px' });
     getSvgSpy.mockRestore();
   });
 
-  it('forwards additional props to the div container', async () => {
+  it('forwards additional props to the <img> element', async () => {
     const resolvedSvg = '<svg><rect width="100" height="100"/></svg>';
     const getSvgSpy = jest
       .spyOn(MaskiconUtilities, 'getMaskiconSVG')
@@ -260,15 +262,14 @@ describe('Maskicon', () => {
     );
 
     await waitFor(() => {
-      expect((container.firstChild as HTMLElement).innerHTML).toStrictEqual(
-        expect.stringContaining('<svg'),
-      );
+      const img = container.querySelector('img') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
     });
-    const updatedDiv = container.querySelector(
-      '[data-testid="maskicon-forward"]',
-    ) as HTMLElement;
-    expect(updatedDiv).toBeInTheDocument();
-    expect(updatedDiv.getAttribute('data-custom')).toBe('hello');
+    const updatedImg = container.querySelector(
+      'img[data-testid="maskicon-forward"]',
+    ) as HTMLImageElement;
+    expect(updatedImg).toBeInTheDocument();
+    expect(updatedImg.getAttribute('data-custom')).toBe('hello');
     getSvgSpy.mockRestore();
   });
 

--- a/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.tsx
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.tsx
@@ -31,8 +31,8 @@ export const Maskicon = ({
     }
     // Encode the SVG for safe data URI usage
     const encoded = encodeURIComponent(svgString)
-      .replace(/%0A/g, '')
-      .replace(/%20/g, ' ');
+      .replace(/%0A/gu, '')
+      .replace(/%20/gu, ' ');
     return `data:image/svg+xml,${encoded}`;
   }, [svgString]);
 

--- a/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.tsx
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.tsx
@@ -1,10 +1,7 @@
-import * as dompurify from 'dompurify';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import type { MaskiconProps } from './Maskicon.types';
 import { getMaskiconSVG } from './Maskicon.utilities';
-
-const DOMPurify = dompurify.default;
 
 export const Maskicon = ({
   address,
@@ -28,14 +25,28 @@ export const Maskicon = ({
     };
   }, [address, size]);
 
-  if (!svgString) {
+  const dataUri = useMemo(() => {
+    if (!svgString) {
+      return '';
+    }
+    // Encode the SVG for safe data URI usage
+    const encoded = encodeURIComponent(svgString)
+      .replace(/%0A/g, '')
+      .replace(/%20/g, ' ');
+    return `data:image/svg+xml,${encoded}`;
+  }, [svgString]);
+
+  if (!dataUri) {
     return <div style={{ width: size, height: size, ...style }} {...props} />;
   }
 
   return (
-    <div
+    <img
+      alt="maskicon"
+      width={size}
+      height={size}
       style={{ width: size, height: size, ...style }}
-      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(svgString) }}
+      src={dataUri}
       {...props}
     />
   );

--- a/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.types.ts
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.types.ts
@@ -3,7 +3,7 @@ import type { ComponentProps } from 'react';
 /**
  * Maskicon component props.
  */
-export type MaskiconProps = ComponentProps<'div'> & {
+export type MaskiconProps = ComponentProps<'img'> & {
   /**
    * Required address used as a unique identifier to generate the Maskicon.
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3399,7 +3399,6 @@ __metadata:
     bitcoin-address-validation: "npm:>=2.0.0"
     blo: "npm:^2.0.0"
     deepmerge: "npm:^4.2.2"
-    dompurify: "npm:^3.2.5"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
     rimraf: "npm:^5.0.5"
@@ -6025,13 +6024,6 @@ __metadata:
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10/01fd82efc8202670865928629697b62fe9bf0c0dcbc5b1c115831caeb073a2c0abb871ff393d7df1ae94ea41e256cb87d2a5a91fd03cdb1b0b4384e08d4ee482
-  languageName: node
-  linkType: hard
-
-"@types/trusted-types@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@types/trusted-types@npm:2.0.7"
-  checksum: 10/8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
   languageName: node
   linkType: hard
 
@@ -9932,18 +9924,6 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: 10/809b805a50a9c6884a29f38aec0a4e1b4537f40e1c861950ed47d10b049febe6b79ab72adaeeebb3cc8fc1cd33f34e97048a72a9265103426d93efafa78d3e96
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.2.5":
-  version: 3.2.5
-  resolution: "dompurify@npm:3.2.5"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10/03974f18851fb4e447d26adc0ebf7a64b6c5b4a11caebebec3e04de8fcaa19cdb67bf3575a2335727123d0fc1c2febc1bc992a84f327a8ce65a0bfd11e3afc50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Removes the DOMPurify dependency from the Maskicon component by replacing the direct SVG injection approach with a safer data URI implementation. The component now renders an `<img>` element with an encoded SVG data URI instead of using `dangerouslySetInnerHTML`, eliminating the need for HTML sanitization while maintaining the same visual output and improving security.

## **Related issues**

Fixes: <!-- Add issue links if applicable -->

## **Manual testing steps**

1. Navigate to the Maskicon component in Storybook
2. Verify that Maskicon renders correctly with various Ethereum addresses
3. Test different size props to ensure proper scaling
4. Confirm that custom props (data-testid, styles) are properly forwarded to the img element
5. Run `yarn workspace @metamask/design-system-react test:verbose src/components/temp-components/Maskicon/Maskicon.test.tsx` to verify all tests pass

## **Screenshots/Recordings**

<!-- Visual changes are minimal as the component renders the same SVG content, just through an img element instead of direct injection -->

### **Before**

<!-- Component rendered SVG directly in a div using dangerouslySetInnerHTML with DOMPurify -->

### **After**

<!-- Component renders SVG via img element with data URI, maintaining identical visual appearance -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
