### PR TITLE
feat: add CAIP-10 address utilities to design-system-shared

### DIFF
--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
   "version": "0.0.0",
-  "private": true,
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",
@@ -43,7 +42,11 @@
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "since-latest-release": "../../scripts/since-latest-release.sh",
+    "publish:preview": "yarn npm publish --tag preview"
+  },
+  "dependencies": {
+    "@metamask/utils": "^11.7.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^5.0.2",
@@ -56,5 +59,9 @@
   },
   "engines": {
     "node": "^18.18 || >=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/design-system-shared/src/index.test.ts
+++ b/packages/design-system-shared/src/index.test.ts
@@ -1,9 +1,0 @@
-import greeter from '.';
-
-describe('Test', () => {
-  it('greets', () => {
-    const name = 'Huey';
-    const result = greeter(name);
-    expect(result).toBe('Hello, Huey!');
-  });
-});

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -1,9 +1,7 @@
-/**
- * Example function that returns a greeting for the given name.
- *
- * @param name - The name to greet.
- * @returns The greeting.
- */
-export default function greeter(name: string): string {
-  return `Hello, ${name}!`;
-}
+export {
+  extractAccountAddress,
+  generateSeedEthereum,
+  generateSeedNonEthereum,
+  isEthereumAddress,
+  generateIconSeed,
+} from './utils/caip-address';

--- a/packages/design-system-shared/src/utils/caip-address.test.ts
+++ b/packages/design-system-shared/src/utils/caip-address.test.ts
@@ -1,0 +1,280 @@
+import {
+  extractAccountAddress,
+  generateSeedEthereum,
+  generateSeedNonEthereum,
+  isEthereumAddress,
+  generateIconSeed,
+} from './caip-address';
+
+describe('extractAccountAddress', () => {
+  describe('Legacy addresses', () => {
+    it('should return Ethereum addresses unchanged', () => {
+      const address = '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+      const result = extractAccountAddress(address);
+      expect(result).toBe(address);
+    });
+
+    it('should return Solana addresses unchanged', () => {
+      const address = '4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7';
+      const result = extractAccountAddress(address);
+      expect(result).toBe(address);
+    });
+
+    it('should return Bitcoin addresses unchanged', () => {
+      const address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+      const result = extractAccountAddress(address);
+      expect(result).toBe(address);
+    });
+  });
+
+  describe('CAIP-10 formatted addresses', () => {
+    it('should extract Ethereum address from eip155 CAIP-10 format', () => {
+      const caipAddress = 'eip155:1:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+      const expectedAddress = '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+      const result = extractAccountAddress(caipAddress);
+      expect(result).toBe(expectedAddress);
+    });
+
+    it('should extract Solana address from solana CAIP-10 format', () => {
+      const caipAddress =
+        'solana:mainnet:4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7';
+      const expectedAddress = '4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7';
+      const result = extractAccountAddress(caipAddress);
+      expect(result).toBe(expectedAddress);
+    });
+
+    it('should extract Bitcoin address from bip122 CAIP-10 format', () => {
+      const caipAddress =
+        'bip122:000000000019d6689c085ae165831e93:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+      const expectedAddress = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+      const result = extractAccountAddress(caipAddress);
+      expect(result).toBe(expectedAddress);
+    });
+  });
+
+  describe('Network consistency', () => {
+    const expectedAddress = '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+
+    it('should extract same address from different Ethereum networks', () => {
+      const mainnet = 'eip155:1:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+      const base = 'eip155:8453:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+      const linea = 'eip155:59144:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+      const polygon = 'eip155:137:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+
+      expect(extractAccountAddress(mainnet)).toBe(expectedAddress);
+      expect(extractAccountAddress(base)).toBe(expectedAddress);
+      expect(extractAccountAddress(linea)).toBe(expectedAddress);
+      expect(extractAccountAddress(polygon)).toBe(expectedAddress);
+    });
+
+    it('should match legacy and CAIP-10 addresses', () => {
+      const legacyAddress = '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+      const caipAddress = 'eip155:1:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+
+      const legacyResult = extractAccountAddress(legacyAddress);
+      const caipResult = extractAccountAddress(caipAddress);
+
+      expect(legacyResult).toBe(caipResult);
+      expect(legacyResult).toBe(expectedAddress);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should return original address for invalid CAIP-10 format', () => {
+      const invalidAddress = 'invalid:format';
+      const result = extractAccountAddress(invalidAddress);
+      expect(result).toBe(invalidAddress);
+    });
+
+    it('should return original address for malformed CAIP-10', () => {
+      const malformedAddress = 'eip155:invalid';
+      const result = extractAccountAddress(malformedAddress);
+      expect(result).toBe(malformedAddress);
+    });
+
+    it('should handle empty string', () => {
+      const emptyAddress = '';
+      const result = extractAccountAddress(emptyAddress);
+      expect(result).toBe(emptyAddress);
+    });
+
+    it('should handle addresses with colons but not CAIP-10 format', () => {
+      const nonCaipAddress = 'some:random:string:with:colons';
+      const result = extractAccountAddress(nonCaipAddress);
+      expect(result).toBe(nonCaipAddress);
+    });
+  });
+
+  describe('Icon generation consistency (integration)', () => {
+    it('should ensure CAIP-10 and legacy addresses produce same seeds', () => {
+      // This test verifies the core issue reported:
+      // identical icons should be generated for these addresses
+      const testCases = [
+        {
+          legacy: '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8',
+          caip10: [
+            'eip155:1:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8',
+            'eip155:8453:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8',
+            'eip155:59144:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8',
+          ],
+        },
+      ];
+
+      testCases.forEach(({ legacy, caip10 }) => {
+        const legacyResult = extractAccountAddress(legacy);
+
+        caip10.forEach((caipAddress) => {
+          const caipResult = extractAccountAddress(caipAddress);
+          expect(caipResult).toBe(legacyResult);
+        });
+      });
+    });
+  });
+});
+
+describe('generateSeedEthereum', () => {
+  it('should generate consistent numeric seeds for Ethereum addresses', () => {
+    const address = '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+    const seed = generateSeedEthereum(address);
+
+    expect(typeof seed).toBe('number');
+    expect(seed).toBe(0x9cbf7c41);
+  });
+
+  it('should handle addresses with different cases', () => {
+    const lowerAddress = '0xabcdef123456789a';
+    const upperAddress = '0xABCDEF123456789A';
+
+    const lowerSeed = generateSeedEthereum(lowerAddress);
+    const upperSeed = generateSeedEthereum(upperAddress);
+
+    expect(lowerSeed).toBe(0xabcdef12);
+    expect(upperSeed).toBe(0xabcdef12);
+  });
+
+  it('should handle short addresses correctly', () => {
+    const shortAddress = '0x1234';
+    const seed = generateSeedEthereum(shortAddress);
+
+    expect(typeof seed).toBe('number');
+    expect(seed).toBe(0x1234);
+  });
+});
+
+describe('generateSeedNonEthereum', () => {
+  it('should generate byte array for Solana addresses', () => {
+    const address = '4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7';
+    const seed = generateSeedNonEthereum(address);
+
+    expect(Array.isArray(seed)).toBe(true);
+    expect(seed.length).toBeGreaterThan(0);
+    expect(seed.every((byte) => typeof byte === 'number')).toBe(true);
+  });
+
+  it('should generate byte array for Bitcoin addresses', () => {
+    const address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+    const seed = generateSeedNonEthereum(address);
+
+    expect(Array.isArray(seed)).toBe(true);
+    expect(seed.length).toBeGreaterThan(0);
+    expect(seed.every((byte) => typeof byte === 'number')).toBe(true);
+  });
+
+  it('should handle Unicode normalization', () => {
+    const unicodeAddress = 'tëst';
+    const seed = generateSeedNonEthereum(unicodeAddress);
+
+    expect(Array.isArray(seed)).toBe(true);
+    expect(seed.length).toBeGreaterThan(0);
+  });
+
+  it('should normalize case to lowercase', () => {
+    const upperAddress = 'TESTADDRESS';
+    const lowerAddress = 'testaddress';
+
+    const upperSeed = generateSeedNonEthereum(upperAddress);
+    const lowerSeed = generateSeedNonEthereum(lowerAddress);
+
+    expect(upperSeed).toStrictEqual(lowerSeed);
+  });
+});
+
+describe('isEthereumAddress', () => {
+  it('should return true for valid Ethereum addresses', () => {
+    const ethereumAddresses = [
+      '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8',
+      '0x0000000000000000000000000000000000000000',
+      '0x1234567890abcdef',
+      '0xABCDEF123456789a',
+    ];
+
+    ethereumAddresses.forEach((address) => {
+      expect(isEthereumAddress(address)).toBe(true);
+    });
+  });
+
+  it('should return false for non-Ethereum addresses', () => {
+    const nonEthereumAddresses = [
+      '4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7', // Solana
+      '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', // Bitcoin
+      'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', // Bitcoin bech32
+      '', // Empty string
+      '0X9Cbf7c41B7787F6c621115010D3B044029FE2Ce8', // Wrong case prefix
+      'x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8', // Missing 0
+    ];
+
+    nonEthereumAddresses.forEach((address) => {
+      expect(isEthereumAddress(address)).toBe(false);
+    });
+  });
+});
+
+describe('generateIconSeed', () => {
+  it('should return numeric seed for Ethereum addresses', () => {
+    const ethereumAddress = '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8';
+    const seed = generateIconSeed(ethereumAddress);
+
+    expect(typeof seed).toBe('number');
+    expect(seed).toBe(generateSeedEthereum(ethereumAddress));
+  });
+
+  it('should return byte array for Solana addresses', () => {
+    const solanaAddress = '4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7';
+    const seed = generateIconSeed(solanaAddress);
+
+    expect(Array.isArray(seed)).toBe(true);
+    expect(seed).toStrictEqual(generateSeedNonEthereum(solanaAddress));
+  });
+
+  it('should return byte array for Bitcoin addresses', () => {
+    const bitcoinAddress = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+    const seed = generateIconSeed(bitcoinAddress);
+
+    expect(Array.isArray(seed)).toBe(true);
+    expect(seed).toStrictEqual(generateSeedNonEthereum(bitcoinAddress));
+  });
+
+  it('should handle Ethereum addresses returning numeric seeds', () => {
+    const address = '0x1234567890abcdef';
+    const seed = generateIconSeed(address);
+
+    expect(typeof seed).toBe('number');
+    expect(seed).toBe(generateSeedEthereum(address));
+  });
+
+  it('should handle Solana addresses returning byte array seeds', () => {
+    const address = '4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7';
+    const seed = generateIconSeed(address);
+
+    expect(typeof seed).toBe('object');
+    expect(seed).toStrictEqual(generateSeedNonEthereum(address));
+  });
+
+  it('should handle Bitcoin bech32 addresses returning byte array seeds', () => {
+    const address = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+    const seed = generateIconSeed(address);
+
+    expect(typeof seed).toBe('object');
+    expect(seed).toStrictEqual(generateSeedNonEthereum(address));
+  });
+});

--- a/packages/design-system-shared/src/utils/caip-address.ts
+++ b/packages/design-system-shared/src/utils/caip-address.ts
@@ -1,0 +1,89 @@
+import {
+  parseCaipAccountId,
+  isCaipAccountId,
+  stringToBytes,
+} from '@metamask/utils';
+
+/**
+ * Extracts the account address from a CAIP-10 formatted address string.
+ *
+ * For CAIP-10 addresses like "eip155:1:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8",
+ * this returns just the address part: "0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8".
+ *
+ * This ensures that both legacy addresses and CAIP-10 addresses generate
+ * the same icon, regardless of network specification.
+ *
+ * @param address - The address string (either legacy format or CAIP-10)
+ * @returns The extracted account address
+ *
+ * @example
+ * extractAccountAddress('0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8')
+ * Returns: '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8'
+ *
+ * @example
+ * extractAccountAddress('eip155:1:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8')
+ * Returns: '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8'
+ *
+ * @example
+ * extractAccountAddress('solana:mainnet:4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7')
+ * Returns: '4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7'
+ */
+export function extractAccountAddress(address: string): string {
+  try {
+    // Try to parse as CAIP-10 first
+    if (isCaipAccountId(address)) {
+      const parsed = parseCaipAccountId(address);
+      return parsed.address;
+    }
+  } catch {
+    // If parsing fails, fall through to return original address
+  }
+
+  // Return the address as-is if it's not CAIP-10 format
+  return address;
+}
+
+/**
+ * Generates a numeric seed for Ethereum (eip155) addresses.
+ *
+ * @param address - The Ethereum address to generate a seed from
+ * @returns A numeric seed for icon generation
+ */
+export function generateSeedEthereum(address: string): number {
+  // Parse the first 8 chars of the address after '0x'
+  const addr = address.slice(2, 10);
+  return parseInt(addr, 16);
+}
+
+/**
+ * Generates a byte-array seed for non-Ethereum addresses (Solana, Bitcoin, etc.).
+ *
+ * @param address - The address to generate a byte array seed from
+ * @returns An array of numbers representing the bytes of the address
+ */
+export function generateSeedNonEthereum(address: string): number[] {
+  return Array.from(stringToBytes(address.normalize('NFKC').toLowerCase()));
+}
+
+/**
+ * Determines if an address is Ethereum format (starts with 0x).
+ *
+ * @param address - The address to check
+ * @returns True if Ethereum format, false otherwise
+ */
+export function isEthereumAddress(address: string): boolean {
+  return address.startsWith('0x');
+}
+
+/**
+ * Generates an appropriate seed for icon generation based on address format.
+ * Ethereum addresses (0x prefix) use hex parsing, others use byte array.
+ *
+ * @param address - The address to generate a seed from (should be extracted first)
+ * @returns A seed for icon generation (number for Ethereum, number[] for others)
+ */
+export function generateIconSeed(address: string): number | number[] {
+  return isEthereumAddress(address)
+    ? generateSeedEthereum(address)
+    : generateSeedNonEthereum(address);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3423,6 +3423,7 @@ __metadata:
   resolution: "@metamask/design-system-shared@workspace:packages/design-system-shared"
   dependencies:
     "@metamask/auto-changelog": "npm:^5.0.2"
+    "@metamask/utils": "npm:^11.7.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"


### PR DESCRIPTION
## **Description**

Adds CAIP-10 address utilities to the design-system-shared package to enable consistent icon generation across different blockchain address formats. This foundational change provides utilities for extracting account addresses from CAIP-10 formatted strings and generating appropriate seeds for icon generation based on address type (Ethereum vs non-Ethereum).

The utilities support seamless handling of both legacy addresses (e.g., `0x...`) and CAIP-10 formatted addresses (e.g., `eip155:1:0x...`), ensuring the same address generates identical icons regardless of format.

## **Related issues**

Fixes: <!-- Add issue links -->

## **Manual testing steps**

1. Install dependencies: `yarn install`
2. Build the shared package: `yarn workspace @metamask/design-system-shared build`
3. Run tests to verify functionality: `yarn workspace @metamask/design-system-shared test`
4. Import and test utilities in a test file:
   ```typescript
   import { extractAccountAddress, generateIconSeed, isEthereumAddress } from '@metamask/design-system-shared';
   
   // Test CAIP-10 address extraction
   console.log(extractAccountAddress('eip155:1:0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8')); // Should return '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8'
   
   // Test legacy address passthrough
   console.log(extractAccountAddress('0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8')); // Should return same address
   
   // Test seed generation
   console.log(generateIconSeed('0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8')); // Should return numeric seed
   console.log(generateIconSeed('4Nd1m3NnENa8h8Xte1Xr7s9jcvKqqm21z3FvY9hKg4s7')); // Should return byte array
   ```

## **Screenshots/Recordings**

Not applicable - this change adds utility functions without visual components.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.