### PR TITLE
fix: avatar shrinking in flex layouts

### DIFF
--- a/packages/design-system-react/src/components/AvatarBase/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/AvatarBase/AvatarBase.tsx
@@ -33,7 +33,7 @@ export const AvatarBase = forwardRef<HTMLDivElement, AvatarBaseProps>(
 
     const mergedClassName = twMerge(
       // Base styles
-      'inline-flex items-center justify-center overflow-hidden bg-section',
+      'inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section',
       shape === AvatarBaseShape.Circle
         ? 'rounded-full'
         : TWCLASSMAP_AVATARBASE_SIZE_BORDERRADIUSS_SQUARE[size],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes bug with Avatar components where they would shrink in a flex layout.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/pull/35711

## **Manual testing steps**

1. Go storybook build of this PR
2. Visit the example wallet screen
3. Use dev tools to make account name really long until it truncates
4. See that avatar remains the same size and doesn't shrink

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="607" height="137" alt="Screenshot 2025-09-05 at 7 40 25 PM" src="https://github.com/user-attachments/assets/5052889a-babf-41f4-9dc9-dc583a9b17a3" />

### **After**

<img width="629" height="220" alt="Screenshot 2025-09-05 at 7 40 10 PM" src="https://github.com/user-attachments/assets/c2e18474-6962-4516-9968-c58eb929f870" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
