### PR TITLE
fix: correct changelog entries and avatar flex layout shrinking

### DIFF
--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed Avatar components shrinking in flex layouts ([#825](https://github.com/MetaMask/metamask-design-system/pull/825))
 - Removed unnecessary peer dependencies ([#828](https://github.com/MetaMask/metamask-design-system/pull/828))
 - Bump @metamask/utils from 11.7.0 to 11.8.0 ([#827](https://github.com/MetaMask/metamask-design-system/pull/827))
+- Bump npm and yarn dependencies ([#829](https://github.com/MetaMask/metamask-design-system/pull/829))
+- Bump vite from 5.4.19 to 5.4.20 ([#826](https://github.com/MetaMask/metamask-design-system/pull/826))
 
 ## [0.4.0]
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Avatar components shrinking in flex layouts ([#825](https://github.com/MetaMask/metamask-design-system/pull/825))
 - Jazzicon, Blockies and Maskicon icon generation for CAIP-10 addresses ([#816](https://github.com/MetaMask/metamask-design-system/pull/816))
 
 ## [0.3.1]

--- a/packages/design-system-react/src/components/AvatarBase/AvatarBase.tsx
+++ b/packages/design-system-react/src/components/AvatarBase/AvatarBase.tsx
@@ -33,7 +33,7 @@ export const AvatarBase = forwardRef<HTMLDivElement, AvatarBaseProps>(
 
     const mergedClassName = twMerge(
       // Base styles
-      'inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section',
+      'inline-flex shrink-0 items-center justify-center overflow-hidden bg-section',
       shape === AvatarBaseShape.Circle
         ? 'rounded-full'
         : TWCLASSMAP_AVATARBASE_SIZE_BORDERRADIUSS_SQUARE[size],


### PR DESCRIPTION
## **Description**

This PR corrects the changelog entries to accurately reflect what was shipped in each release and includes a fix for Avatar components shrinking in flex layouts. The avatar flex layout issue was merged into release/14 (v0.4.0) when main was merged but the changelogs were not updated, so the changelog has been updated to reflect the actual shipping timeline. Additionally, this includes the technical fix that changes the CSS class from `flex-shrink-0` to `shrink-0` in the AvatarBase component. Both classnames work but `shrink-0` is more accurate and aligns with [tailwind docs](https://tailwindcss.com/docs/flex-shrink)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Pull and build the branch locally
2. Verify the changelog entries now accurately reflect release contents:
   - v0.4.0 should include the avatar flex layout fix (#825)
   - v0.4.1 should only include dependency updates and peer dependency cleanup
3. Test Avatar components in various flex layouts to ensure they no longer shrink
4. Run `yarn build` to ensure all packages build successfully
5. Verify that all avatar components (AvatarAccount, AvatarIcon, AvatarNetwork, etc.) maintain their intended size in flex containers

## **Screenshots/Recordings**

Not applicable - this is primarily a changelog correction with a minor CSS class fix.

### **Before**

- Changelog incorrectly listed avatar fix in v0.4.1 instead of v0.4.0
- Avatar components could shrink unexpectedly in flex layouts

### **After**

- Changelog accurately reflects release contents
- Avatar components maintain consistent sizing in flex layouts

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.