### PR TITLE
fix: ensure peer dependencies reflect latest breaking changes for pre-1.0 packages

### DIFF
--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -613,10 +613,23 @@ function expectUpToDateWorkspacePeerDependencies(Yarn, workspace) {
           dependency.range,
         )
       ) {
+        // Ensure peer dependency includes latest breaking changes.
+        //
+        // Technically pre-1.0 versions can make breaking changes in patch releases, but
+        // conventionally we always bump the most significant digit for breaking changes.
+        let peerDependencyRange;
+        if (dependencyWorkspaceVersion.major > 0) {
+          peerDependencyRange = `^${dependencyWorkspaceVersion.major}.0.0`;
+        } else if (dependencyWorkspaceVersion.minor > 0) {
+          peerDependencyRange = `^0.${dependencyWorkspaceVersion.minor}.0`;
+        } else {
+          peerDependencyRange = `^0.0.${dependencyWorkspaceVersion.patch}`;
+        }
+
         expectWorkspaceField(
           workspace,
           `peerDependencies["${dependency.ident}"]`,
-          `^${dependencyWorkspaceVersion.major}.0.0`,
+          peerDependencyRange,
         );
       }
     }


### PR DESCRIPTION
## **Description**

Fixes peer dependency constraints for pre-1.0 packages in the monorepo. The previous implementation only used major version ranges (`^0.0.0` for all pre-1.0 packages), which was too permissive and could allow incompatible older versions. This update ensures peer dependencies correctly reflect the most significant version digit for breaking changes, following semantic versioning best practices for pre-1.0 packages.

[Same PR in core](https://github.com/MetaMask/core/pull/6652/files#diff-594447fef9feecf11f1839e337c464b7b857fdb73fde7e18940eaa9cdf5b819d)

## **Related issues**

Fixes: <!-- Based on MetaMask/core#6652 pattern -->

## **Manual testing steps**

1. Run `yarn constraints` to verify no constraint violations
2. Check that the updated logic handles various version scenarios:
   - `0.4.1` → generates `^0.4.0` peer dependency range
   - `0.2.1` → generates `^0.2.0` peer dependency range
   - `8.1.1` → generates `^8.0.0` peer dependency range (unchanged)
   - `0.0.5` → generates `^0.0.5` peer dependency range
3. Verify existing peer dependencies in package.json files remain valid
4. Test that the constraint logic properly prevents version mismatches

## **Screenshots/Recordings**

Not applicable - this is a build configuration improvement with no visual changes.

### **Before**

Pre-1.0 packages generated overly permissive `^0.0.0` peer dependency ranges.

### **After**

Pre-1.0 packages generate appropriate ranges: `^0.minor.0` for minor-based versions, `^0.0.patch` for patch-only versions.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.