### PR TITLE
chore: update brand color tokens for dark theme consistency

### DIFF
--- a/packages/design-tokens/src/css/brand-colors.css
+++ b/packages/design-tokens/src/css/brand-colors.css
@@ -9,13 +9,13 @@
   /* Grey */
   --brand-colors-grey-grey100: #dadce5;
   --brand-colors-grey-grey200: #b7bbc8;
-  --brand-colors-grey-grey300: #9ca1af;
+  --brand-colors-grey-grey300: #9b9b9b;
   --brand-colors-grey-grey400: #858b9a;
   --brand-colors-grey-grey500: #686e7d;
-  --brand-colors-grey-grey600: #4b505c;
-  --brand-colors-grey-grey700: #2a2c32;
-  --brand-colors-grey-grey800: #232426;
-  --brand-colors-grey-grey900: #121314;
+  --brand-colors-grey-grey600: #48484e;
+  --brand-colors-grey-grey700: #252628;
+  --brand-colors-grey-grey800: #1c1d1f;
+  --brand-colors-grey-grey900: #131416;
   --brand-colors-grey-grey1000: #000000;
   --brand-colors-grey-grey050: #f3f5f9;
   --brand-colors-grey-grey000: #ffffff;

--- a/packages/design-tokens/src/figma/brandColors.json
+++ b/packages/design-tokens/src/figma/brandColors.json
@@ -13,7 +13,7 @@
       "description": ""
     },
     "300": {
-      "value": "#9ca1af",
+      "value": "#9b9b9b",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
@@ -31,25 +31,25 @@
       "description": ""
     },
     "600": {
-      "value": "#4b505c",
+      "value": "#48484e",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
     },
     "700": {
-      "value": "#2a2c32",
+      "value": "#252628",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
     },
     "800": {
-      "value": "#232426",
+      "value": "#1c1d1f",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""
     },
     "900": {
-      "value": "#121314",
+      "value": "#131416",
       "type": "color",
       "parent": "Brand Colors/v2- brand evo (preview)",
       "description": ""

--- a/packages/design-tokens/src/js/brandColor/brandColor.ts
+++ b/packages/design-tokens/src/js/brandColor/brandColor.ts
@@ -6,19 +6,19 @@ export const brandColor: BrandColor = {
   // Grey
   grey200: '#b7bbc8',
   // Grey
-  grey300: '#9ca1af',
+  grey300: '#9b9b9b',
   // Grey
   grey400: '#858b9a',
   // Grey
   grey500: '#686e7d',
   // Grey
-  grey600: '#4b505c',
+  grey600: '#48484e',
   // Grey
-  grey700: '#2a2c32',
+  grey700: '#252628',
   // Grey
-  grey800: '#232426',
+  grey800: '#1c1d1f',
   // Grey
-  grey900: '#121314',
+  grey900: '#131416',
   // Grey
   grey1000: '#000000',
   // Grey


### PR DESCRIPTION
## **Description**

Updates brand color tokens to align with the latest Figma dark theme specifications. This change ensures design system consistency across CSS, JavaScript, and Figma token formats by updating five grey scale values (grey300, grey600, grey700, grey800, grey900) to match the updated dark mode color palette.

**Note**: This update also affects light theme default text and icon colors, which now use a slightly darker shade (#131416 instead of #121314) to maintain brand color consistency across themes.

## **Related issues**

Fixes: <!-- Add issue links -->

## **Manual testing steps**

1. Build the design tokens package: `yarn workspace @metamask/design-tokens test`
2. Verify dark theme colors are updated:
   - Background default: #131416 (was #121314)
   - Text/icon alternative: #9b9b9b (was #9ca1af)
   - Text/icon muted: #48484e (was #4b505c)
   - Background section: #1c1d1f (was #232426)
   - Background subsection: #252628 (was #2a2c32)
3. Check light theme still renders correctly with updated text/icon default color
4. Test Storybook to ensure visual consistency across components

## **Screenshots/Recordings**

<!-- Before/after screenshots would be helpful to show the subtle color differences -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.