### PR TITLE
fix: Update border radius of AvatarBase.XS to improve visual cohesion

### DIFF
--- a/apps/storybook-react/.storybook/main.ts
+++ b/apps/storybook-react/.storybook/main.ts
@@ -1,5 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 import path, { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 /**
  * This function is used to resolve the absolute path of a package.
@@ -7,8 +8,8 @@ import path, { join, dirname } from 'path';
  *
  * @param value
  */
-function getAbsolutePath(value: string): any {
-  return dirname(require.resolve(join(value, 'package.json')));
+function getAbsolutePath(value: string): string {
+  return value;
 }
 
 // Check if we're running in test mode (Vitest)

--- a/packages/design-system-react-native/src/components/AvatarBase/AvatarBase.constants.ts
+++ b/packages/design-system-react-native/src/components/AvatarBase/AvatarBase.constants.ts
@@ -26,7 +26,7 @@ export const TWCLASSMAP_AVATARBASE_SIZE_BORDERRADIUSS_SQUARE: Record<
   AvatarBaseSize,
   string
 > = {
-  [AvatarBaseSize.Xs]: 'rounded-sm', // 4px
+  [AvatarBaseSize.Xs]: 'rounded-md', // 6px
   [AvatarBaseSize.Sm]: 'rounded-md', // 6px
   [AvatarBaseSize.Md]: 'rounded-lg', // 8px
   [AvatarBaseSize.Lg]: 'rounded-[10px]', // 10px (No tailwind class for this)

--- a/packages/design-system-react-native/src/components/AvatarBase/AvatarBase.constants.ts
+++ b/packages/design-system-react-native/src/components/AvatarBase/AvatarBase.constants.ts
@@ -26,7 +26,7 @@ export const TWCLASSMAP_AVATARBASE_SIZE_BORDERRADIUSS_SQUARE: Record<
   AvatarBaseSize,
   string
 > = {
-  [AvatarBaseSize.Xs]: 'rounded-md', // 6px
+  [AvatarBaseSize.Xs]: 'rounded-[5px]', // 5px
   [AvatarBaseSize.Sm]: 'rounded-md', // 6px
   [AvatarBaseSize.Md]: 'rounded-lg', // 8px
   [AvatarBaseSize.Lg]: 'rounded-[10px]', // 10px (No tailwind class for this)

--- a/packages/design-system-react/src/components/AvatarBase/AvatarBase.constants.ts
+++ b/packages/design-system-react/src/components/AvatarBase/AvatarBase.constants.ts
@@ -26,7 +26,7 @@ export const TWCLASSMAP_AVATARBASE_SIZE_BORDERRADIUSS_SQUARE: Record<
   AvatarBaseSize,
   string
 > = {
-  [AvatarBaseSize.Xs]: 'rounded-sm', // 4px
+  [AvatarBaseSize.Xs]: 'rounded-md', // 6px
   [AvatarBaseSize.Sm]: 'rounded-md', // 6px
   [AvatarBaseSize.Md]: 'rounded-lg', // 8px
   [AvatarBaseSize.Lg]: 'rounded-[10px]', // 10px (No tailwind class for this)

--- a/packages/design-system-react/src/components/AvatarBase/AvatarBase.constants.ts
+++ b/packages/design-system-react/src/components/AvatarBase/AvatarBase.constants.ts
@@ -26,7 +26,7 @@ export const TWCLASSMAP_AVATARBASE_SIZE_BORDERRADIUSS_SQUARE: Record<
   AvatarBaseSize,
   string
 > = {
-  [AvatarBaseSize.Xs]: 'rounded-md', // 6px
+  [AvatarBaseSize.Xs]: 'rounded-[5px]', // 5px
   [AvatarBaseSize.Sm]: 'rounded-md', // 6px
   [AvatarBaseSize.Md]: 'rounded-lg', // 8px
   [AvatarBaseSize.Lg]: 'rounded-[10px]', // 10px (No tailwind class for this)


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR refines the `borderRadius` of the `AvatarBase.XS` from `4px` to `5px` to improve visual cohesion with our typography. At `4px`, the icons looked too sharp. This change makes our icons feel like they scale more naturally.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run yarn storybook to test that the changes have been made

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="620" height="177" alt="Screenshot 2025-10-08 at 6 11 25 PM" src="https://github.com/user-attachments/assets/0295fb57-cb40-4df9-af4f-3e84e6d5aee8" />

### **After**

<img width="1081" height="729" alt="Screenshot 2025-10-08 at 10 04 43 PM" src="https://github.com/user-attachments/assets/6f81c374-86a6-4c90-8a6a-91e03e82eace" />

<!-- [screenshots/recordings] -->
<img width="996" height="584" alt="Screenshot 2025-10-08 at 9 55 30 PM" src="https://github.com/user-attachments/assets/50c7d6e1-3aec-4115-a74f-3fed73e1509c" />

Figma file has been updated [here](https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=7399-12473&t=LPuLdI1ENeGCZibl-4)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates AvatarBase XS square radius from 4px to 5px in both web and React Native; simplifies Storybook getAbsolutePath config.
> 
> - **Design System**:
>   - **AvatarBase**: Change XS square border radius from 4px (`rounded-sm`) to 5px (`rounded-[5px]`) in:
>     - `packages/design-system-react/src/components/AvatarBase/AvatarBase.constants.ts`
>     - `packages/design-system-react-native/src/components/AvatarBase/AvatarBase.constants.ts`
> - **Storybook**:
>   - `apps/storybook-react/.storybook/main.ts`: Simplify `getAbsolutePath()` to return the value (typed `string`) and add `fileURLToPath` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d29beb92051eab0ba4200ef449c35994be8b7a85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->