### PR TITLE
fix: export TextButtonSize enum from design-system-react-native

### DIFF
--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -87,7 +87,7 @@ export type { JazziconProps } from './temp-components/Jazzicon';
 export { Maskicon } from './temp-components/Maskicon';
 export type { MaskiconProps } from './temp-components/Maskicon';
 
-export { TextButton } from './TextButton';
+export { TextButton, TextButtonSize } from './TextButton';
 export type { TextButtonProps } from './TextButton';
 
 export {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

1.  **Reason for the change:** The `TextButtonSize` enum was not being exported from the root `design-system-react-native` package, making it inaccessible to consumers. This was reported by a user (Elliot in Slack).
2.  **Improvement/Solution:** This PR updates `packages/design-system-react-native/src/components/index.ts` to export `TextButtonSize`, ensuring it is available when importing from the package's root.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1.  In a React Native project consuming `@metamask/design-system-react-native`, attempt to import `TextButtonSize`:
    ```typescript
    import { TextButtonSize } from '@metamask/design-system-react-native';
    ```
2.  Verify that `TextButtonSize` is successfully imported and can be used (e.g., `TextButtonSize.Lg`).

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---
[Slack Thread](https://consensys.slack.com/archives/C0354T27M5M/p1761343338972079?thread_ts=1761343338.972079&cid=C0354T27M5M)

<a href="https://cursor.com/background-agent?bcId=bc-eaea0367-8563-4944-95af-c46cb6b570a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eaea0367-8563-4944-95af-c46cb6b570a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose `TextButtonSize` by exporting it from `packages/design-system-react-native/src/components/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59e8d5b04ed322df7864957cc1a9681b6b2c5471. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->