### PR TITLE
fix: update publish-preview workflow to use tsx instead of ts-node

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.PUBLISH_PREVIEW_NPM_TOKEN }}
       - name: Generate preview build message
-        run: yarn ts-node scripts/generate-preview-build-message.ts
+        run: yarn tsx scripts/generate-preview-build-message.ts
       - name: Post build preview in comment
         run: gh pr comment "${PR_NUMBER}" --body-file preview-build-message.txt
         env:


### PR DESCRIPTION
## **Description**

This PR fixes a missed instance in #845 where we migrated from ts-node to tsx. The publish-preview workflow was still using `yarn ts-node` to execute the `generate-preview-build-message.ts` script, which would cause the preview build process to fail.

<img width="922" height="186" alt="Screenshot 2025-12-04 at 8 14 35 PM" src="https://github.com/user-attachments/assets/dafc8a2b-097f-46ad-a2a0-2ad5548f80ce" />

The fix updates line 52 in `.github/workflows/publish-preview.yml` to use `yarn tsx` instead.

This change aligns with the same fix made in the MetaMask/core repository: https://github.com/MetaMask/core/pull/6889/files

## **Related issues**

Fixes: N/A (follow-up to #845)

## **Manual testing steps**

1. The change can be verified by reviewing the workflow file
2. The preview build workflow will be tested when the next preview build is triggered via `@metamaskbot publish-preview` comment

## **Screenshots/Recordings**

N/A - workflow configuration change only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A for workflow changes)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the publish-preview workflow to run `scripts/generate-preview-build-message.ts` with `yarn tsx` instead of `yarn ts-node`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41f1e7936484fd76febb20320eafa9f9221b5545. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->