### PR TITLE
fix: update ButtonPrimary background color and increase button padding (TEST DO NOT MERGE)

### DIFF
--- a/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.tsx
@@ -16,9 +16,9 @@ export const ButtonPrimary = forwardRef<HTMLButtonElement, ButtonPrimaryProps>(
       // Default primary styles
       !isDanger &&
         !isInverse && [
-          'bg-icon-default text-primary-inverse',
+          'bg-primary-default text-primary-inverse',
           // Loading state uses pressed color
-          isLoading && 'bg-icon-default-pressed',
+          isLoading && 'bg-primary-default-pressed',
         ],
       // Danger styles
       isDanger &&
@@ -45,8 +45,8 @@ export const ButtonPrimary = forwardRef<HTMLButtonElement, ButtonPrimaryProps>(
       isInteractive && [
         !isDanger &&
           !isInverse && [
-            'hover:bg-icon-default-hover',
-            'active:bg-icon-default-pressed',
+            'hover:bg-primary-default-hover',
+            'active:bg-primary-default-pressed',
           ],
         isDanger &&
           !isInverse && [

--- a/packages/design-system-react/src/components/ButtonBase/ButtonBase.tsx
+++ b/packages/design-system-react/src/components/ButtonBase/ButtonBase.tsx
@@ -150,7 +150,7 @@ export const ButtonBase = forwardRef<HTMLButtonElement, ButtonBaseProps>(
     const mergedClassName = twMerge(
       // Base styles
       'inline-flex items-center justify-center',
-      'rounded-xl px-4',
+      'rounded-xl px-6',
       'font-medium text-default',
       'bg-muted',
       'min-w-20 overflow-hidden',


### PR DESCRIPTION
## **Description**

Updates the ButtonPrimary component to use the correct semantic color tokens and increases the horizontal padding for all buttons:

1. **Background color fix**: Changed ButtonPrimary from `bg-icon-default` to `bg-primary-default` to use the correct semantic primary color token. This also updates the corresponding hover (`bg-primary-default-hover`), active (`bg-primary-default-pressed`), and loading states.

2. **Padding increase**: Increased horizontal padding in ButtonBase from `px-4` (16px) to `px-6` (24px) for improved button appearance.

## **Related issues**

Fixes: N/A - Style refinement

## **Manual testing steps**

1. Go to Storybook
2. Navigate to Button > ButtonPrimary story
3. Verify the button has correct background color and increased horizontal padding
4. Test hover, active, and loading states

## **Screenshots/Recordings**

### **Before**

- Background: `bg-icon-default` (dark gray)
- Padding: 16px horizontal

### **After**

- Background: `bg-primary-default` (primary blue)
- Padding: 24px horizontal

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only changes to button classes; main risk is visual regressions (spacing/color) across consumers of `ButtonPrimary`/`ButtonBase`. No behavioral or data/security logic is modified.
> 
> **Overview**
> Updates `ButtonPrimary` to use the semantic `bg-primary-default` token instead of `bg-icon-default`, including matching hover/active and loading/pressed background classes.
> 
> Increases default horizontal padding in `ButtonBase` from `px-4` to `px-6`, widening all buttons that rely on the base component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5094036a159a6a2e2614917691b609c63f9ea156. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->