### PR TITLE
fix: align ButtonIcon icon sizes and border radius with Figma design

### DIFF
--- a/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.constants.ts
+++ b/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.constants.ts
@@ -9,7 +9,7 @@ export const TWCLASSMAP_BUTTONICON_SIZE_DIMENSION = {
 };
 
 export const MAP_BUTTONICON_SIZE_ICONSIZE: Record<ButtonIconSize, IconSize> = {
-  [ButtonIconSize.Sm]: IconSize.Sm,
-  [ButtonIconSize.Md]: IconSize.Md,
-  [ButtonIconSize.Lg]: IconSize.Lg,
+  [ButtonIconSize.Sm]: IconSize.Md,
+  [ButtonIconSize.Md]: IconSize.Lg,
+  [ButtonIconSize.Lg]: IconSize.Xl,
 };

--- a/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.test.tsx
@@ -13,7 +13,7 @@ describe('ButtonIcon', () => {
   it('renders default state correctly', () => {
     const { result } = renderHook(() => useTailwind());
     const tw = result.current;
-    const expected = tw`items-center justify-center ${TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[ButtonIconSize.Md]} rounded-sm bg-transparent opacity-100`;
+    const expected = tw`items-center justify-center ${TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[ButtonIconSize.Md]} rounded-lg bg-transparent opacity-100`;
 
     const { getByTestId } = render(
       <ButtonIcon
@@ -32,7 +32,7 @@ describe('ButtonIcon', () => {
   it('applies isDisabled state', () => {
     const { result } = renderHook(() => useTailwind());
     const tw = result.current;
-    const expected = tw`items-center justify-center ${TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[ButtonIconSize.Md]} rounded-sm bg-transparent opacity-50`;
+    const expected = tw`items-center justify-center ${TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[ButtonIconSize.Md]} rounded-lg bg-transparent opacity-50`;
 
     const { getByTestId } = render(
       <ButtonIcon
@@ -63,7 +63,7 @@ describe('ButtonIcon', () => {
     const { result } = renderHook(() => useTailwind());
     const tw = result.current;
     // isInverse does not change container styling beyond default
-    const expected = tw`items-center justify-center ${TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[ButtonIconSize.Md]} rounded-sm bg-transparent opacity-100`;
+    const expected = tw`items-center justify-center ${TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[ButtonIconSize.Md]} rounded-lg bg-transparent opacity-100`;
 
     const { getByTestId } = render(
       <ButtonIcon
@@ -80,7 +80,7 @@ describe('ButtonIcon', () => {
   it('forwards style and twClassName', () => {
     const { result } = renderHook(() => useTailwind());
     const tw = result.current;
-    const expected = tw`items-center justify-center ${TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[ButtonIconSize.Md]} rounded-sm bg-transparent text-primary-default opacity-100`;
+    const expected = tw`items-center justify-center ${TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[ButtonIconSize.Md]} rounded-lg bg-transparent text-primary-default opacity-100`;
 
     const { getByTestId } = render(
       <ButtonIcon

--- a/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.tsx
@@ -40,7 +40,7 @@ export const ButtonIcon = ({
   const twContainerClassNames = `
     items-center justify-center
     ${TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[size]}
-    ${isFloating ? 'rounded-full' : 'rounded-sm'}
+    ${isFloating ? 'rounded-full' : 'rounded-lg'}
     ${backgroundColor}
     ${isDisabled ? 'opacity-50' : 'opacity-100'}
     ${twClassName}`;

--- a/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.constants.ts
+++ b/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.constants.ts
@@ -8,7 +8,7 @@ export const TWCLASSMAP_BUTTONICON_SIZE_DIMENSION = {
 } as const;
 
 export const MAP_BUTTONICON_SIZE_ICONSIZE = {
-  [ButtonIconSize.Sm]: IconSize.Sm,
-  [ButtonIconSize.Md]: IconSize.Md,
-  [ButtonIconSize.Lg]: IconSize.Lg,
+  [ButtonIconSize.Sm]: IconSize.Md,
+  [ButtonIconSize.Md]: IconSize.Lg,
+  [ButtonIconSize.Lg]: IconSize.Xl,
 } as const;

--- a/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.test.tsx
+++ b/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.test.tsx
@@ -13,7 +13,7 @@ describe('ButtonIcon', () => {
     expect(button).toHaveClass(
       'h-8',
       'w-8',
-      'rounded',
+      'rounded-lg',
       'bg-transparent',
       'hover:bg-hover',
       'active:bg-pressed',

--- a/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.tsx
@@ -41,7 +41,7 @@ export const ButtonIcon = forwardRef<HTMLButtonElement, ButtonIconProps>(
       ],
       // Non-floating styles
       !isFloating && [
-        'rounded bg-transparent',
+        'rounded-lg bg-transparent',
         // Only apply hover/active styles when interactive
         isInteractive && 'hover:bg-hover active:bg-pressed',
         !isInverse && 'text-icon-default',


### PR DESCRIPTION
## **Description**

This PR aligns the ButtonIcon component implementations in both React and React Native with the Figma design specifications. The icon sizes were misaligned across all three size variants, and the React Native implementation had an incorrect border radius for non-floating states.

**What is the reason for the change?**
The ButtonIcon component was using incorrect icon sizes that didn't match the Figma design. For example, ButtonIcon.Md was using Icon.Md (20px) when it should have been using Icon.Lg (24px) according to the Figma layers.

**What is the improvement/solution?**
- Updated icon size mapping to match Figma specifications for all three size variants
- Fixed React Native border radius to match the 4px specified in Figma (was 2px)
- Updated tests to reflect the border radius change

### Changes:
- ButtonIcon.Sm now uses Icon.Md (20px instead of 16px)
- ButtonIcon.Md now uses Icon.Lg (24px instead of 20px)  
- ButtonIcon.Lg now uses Icon.Xl (32px instead of 24px)
- React Native non-floating border radius: 2px → 4px

## **Related issues**

Fixes: N/A (design alignment with Figma)

## **Manual testing steps**

1. View ButtonIcon components in [Storybook for both React](https://diuv6g5fj9pvx.cloudfront.net/metamask-design-system/21531919965/storybook-build/index.html?path=/story/react-components-buttonicon--size) and React Native
2. Compare icon sizes in all three size variants (Sm, Md, Lg) with Figma design
3. Verify border radius matches Figma (4px for non-floating, fully rounded for floating)
4. Test all states: default, hover, pressed, disabled, floating, inverse

## **Screenshots/Recordings**

### **Before**

Icon sizes were smaller than designed:
- Sm: 16px icon (should be 20px)
- Md: 20px icon (should be 24px)
- Lg: 24px icon (should be 32px)

React Native had 2px border radius (should be 4px)

https://github.com/user-attachments/assets/d323f3d4-e49b-48ee-bdac-4aede368183a

https://github.com/user-attachments/assets/b985f32f-81d6-44df-b64d-12603a2ba944

### **After**

Icon sizes match Figma:
- Sm: 20px icon ✓
- Md: 24px icon ✓
- Lg: 32px icon ✓
- border radius: 8px ✓

https://github.com/user-attachments/assets/77ab534b-e9c9-44a2-b6f7-01ac7726d0ae

https://github.com/user-attachments/assets/f2a42f5c-225e-4447-9bff-d82d26f62c1f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared `ButtonIcon` visuals (icon size mapping and non-floating corner radius) in both React and React Native, which can cause widespread UI/layout diffs in consuming apps. No security or data-handling logic is affected.
> 
> **Overview**
> Updates `ButtonIcon` in both `design-system-react` and `design-system-react-native` to better match design specs by **increasing the rendered `Icon` size for each `ButtonIconSize`** (`Sm→Md`, `Md→Lg`, `Lg→Xl`).
> 
> Also adjusts non-floating `ButtonIcon` styling to use **larger rounding** (`rounded-lg` instead of the previous smaller radius), and updates corresponding unit tests to assert the new Tailwind classes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 518c34d138e6fdea31aa8295cd456531e058b764. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





