### PR TITLE
fix: explicitly ignore node_modules in ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ const config = createConfig([
   ...base,
   {
     ignores: [
+      '**/node_modules/**',
       '**/dist/**',
       '**/docs/**',
       '**/coverage/**',


### PR DESCRIPTION
## **Description**

After merging #876 (migration to ESLint's native suppressions feature), `yarn lint` began hanging indefinitely or running extremely slowly. 

**Reason for change:** ESLint was scanning 11,865 `.d.ts` files in `node_modules` directories despite ESLint's default node_modules ignore. This occurred because the `createConfig()` utility from `@metamask/eslint-config` flattens and merges config objects in a way that interfered with ESLint's default ignore patterns being applied during directory traversal.

**The fix:** Explicitly add `'**/node_modules/**'` to the global ignores array in `eslint.config.mjs`. While ESLint flat config should ignore node_modules by default, the interaction between the `createConfig()` merging process and ESLint's ignore application broke this assumption.

**Performance improvement:**
- Before: Hanging/extremely slow (ESLint calculating config for all node_modules subdirectories)
- After: `yarn lint` completes in ~7 seconds

## **Related issues**

Fixes: N/A (discovered after #876 merge)

## **Manual testing steps**

1. Run `yarn lint:clear-cache` to clear ESLint cache
2. Run `yarn lint` - should complete in ~7 seconds without hanging
3. Verify no node_modules scanning by running: `yarn eslint --debug . --cache 2>&1 | grep -c "node_modules"` - should show minimal references

## **Screenshots/Recordings**

N/A - This is a configuration fix with no visual impact

### **Before**

https://github.com/user-attachments/assets/7fcb9d8b-8863-4894-8494-390b3da84d8e

### **After**

https://github.com/user-attachments/assets/d23236f0-d4e8-4a6f-9d82-27c7530654a2

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A - configuration change)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A - configuration change)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

**Technical Details:**

According to [ESLint's flat config documentation](https://eslint.org/docs/latest/use/configure/ignore), only **global** `ignores` patterns can match directories, and default ignores (`node_modules`, `.git`) apply to global ignores. However, when configs are merged and flattened by the `createConfig()` utility, this can interfere with how ESLint applies default ignores during directory traversal.

This may be worth investigating in the `@metamask/eslint-config` package to ensure the `createConfig()` utility preserves ESLint's default ignore behavior.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes linting configuration by expanding ignored paths, with the main impact being faster lint runs and reduced scanning of dependency files.
> 
> **Overview**
> **ESLint flat config now explicitly ignores `node_modules`.**
> 
> Updates `eslint.config.mjs` to add `**/node_modules/**` to the top-level `ignores` list, preventing ESLint from scanning dependency `.d.ts` files and dramatically improving `yarn lint` performance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 683441dbdb44028bda2e1dd065f3176324cb100c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->