### PR TITLE
docs: add CLAUDE.md entry point for AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,46 +10,32 @@ Repository-specific conventions and patterns:
 
 See @docs/ai-agents.md for comprehensive strategy explanation.
 
-## Critical Invariants (Never Break These)
+## Monorepo Structure
 
-### TypeScript
+**This is a yarn workspaces monorepo.** Run all commands from the repository root.
 
-- **NEVER** use string literals for component props (variants, sizes, colors)
-- **ALWAYS** use enums - import and use enum values
-- Example:
-  ```tsx
-  // ❌ Wrong
-  <Button variant="primary" size="md" />;
-  // ✅ Correct
-  import {
-    Button,
-    ButtonVariant,
-    ButtonSize,
-  } from '@metamask/design-system-react';
-  <Button variant={ButtonVariant.Primary} size={ButtonSize.Md} />;
-  ```
+### Command Patterns
 
-### Styling
+Two ways to run commands:
 
-- **NEVER** use arbitrary Tailwind values (`bg-[#037DD6]`, `p-[16px]`)
-- **NEVER** use default Tailwind colors (`bg-blue-500`, `text-gray-700`)
-- **ALWAYS** use design tokens only (`bg-primary-default`, `text-error-default`)
-- **ALWAYS** prefer component props over className/twClassName
-- Typography **ALWAYS** via Text component (never `text-sm font-bold` classes)
+1. **Root scripts** (preferred for common tasks)
 
-### Testing
+   ```bash
+   yarn build                 # Builds all packages
+   yarn test                  # Runs all tests
+   yarn lint                  # Lints entire monorepo
+   ```
 
-- **ALWAYS** write tests when creating/modifying components
-- **ALWAYS** include accessibility tests (axe-core via Storybook)
-- Use Testing Library queries (`getByRole` preferred)
+2. **Workspace-specific commands** (for targeting single packages)
+   ```bash
+   yarn workspace @metamask/design-system-react run test
+   yarn workspace @metamask/design-system-react run build
+   yarn workspace @metamask/design-system-react run lint
+   ```
 
-### Component Creation
+**Never** use `cd packages/*/` - always run commands from root using one of the patterns above.
 
-- **ALWAYS** use: `yarn create-component:react --name ComponentName --description "..."`
-- **NEVER** manually create component files
-- Script auto-generates: Component, types, tests, stories, README
-
-## Essential Commands
+### Essential Commands
 
 ```bash
 # Build
@@ -59,7 +45,7 @@ yarn build:types              # TypeScript only
 # Test
 yarn test                     # All tests
 yarn test:storybook           # Accessibility tests
-yarn workspace @metamask/design-system-react run test              # Package-specific
+yarn workspace @metamask/design-system-react run test              # Single package
 
 # Lint
 yarn lint                     # Check all
@@ -73,14 +59,12 @@ yarn storybook                # React web (port 6006)
 yarn storybook:ios            # React Native iOS
 yarn storybook:android        # React Native Android
 
-# Monorepo
+# Dependencies
 yarn constraints --fix        # Fix dependency constraints
-yarn && yarn dedupe           # After adding dependencies
+yarn dedupe                   # Deduplicate dependencies
 ```
 
-## Monorepo Structure
-
-Packages:
+### Packages
 
 - `@metamask/design-tokens` - Foundation tokens
 - `@metamask/design-system-shared` - Shared utilities
@@ -89,30 +73,24 @@ Packages:
 - `@metamask/design-system-tailwind-preset` - Web Tailwind preset
 - `@metamask/design-system-twrnc-preset` - Mobile twrnc preset
 
-**Import pattern:** Use package names, never file paths
+### Apps (Consumer Platforms)
+
+Storybook apps in `apps/` consume packages for development and testing:
+
+- `@metamask/storybook-react` - Web component development (`yarn storybook`)
+- `@metamask/storybook-react-native` - Mobile development (`yarn storybook:ios|android`)
+
+These platforms are for manual testing and component showcase. Visual regression testing is planned but not yet implemented.
+
+**Import using package names, never file paths:**
 
 ```tsx
 // ✅ Correct
 import { Button } from '@metamask/design-system-react';
-import { tokens } from '@metamask/design-tokens';
 
 // ❌ Wrong
 import { Button } from '../../../packages/design-system-react';
 ```
-
-## Platform-Specific
-
-### React (Web)
-
-- Package: `@metamask/design-system-react`
-- Styling: `className` prop with Tailwind utilities
-- Documentation: `README.mdx` with interactive examples
-
-### React Native (Mobile)
-
-- Package: `@metamask/design-system-react-native`
-- Styling: `twClassName` prop + `useTailwind()` hook
-- Documentation: `README.md` with code examples
 
 ## Personal Overrides
 


### PR DESCRIPTION
## **Description**

Adds `CLAUDE.md` as the entry point for AI coding agents (Claude Code and Cursor).

This is **Phase 2, Step 1a** of the AI agent documentation strategy (see #881). This PR creates the foundational CLAUDE.md file while the styling.md cursor rule will come in a separate PR for easier review.

### What's included:

- **Documentation references:** Points to cursor rules (starting with styling.md)
- **Monorepo structure:** Emphasizes yarn workspaces patterns and command execution from root
- **Essential commands:** Build, test, lint, component creation, Storybook
- **Packages & Apps:** Lists all packages and explains Storybook apps as consumer platforms
- **Import patterns:** Enforces package name imports (never file paths)

### What's intentionally omitted:

- **TypeScript guidance:** Deferred pending Issue #883 resolution (enum vs string union types migration proposal)
- **Platform-specific details:** Delegated to cursor rules (styling.md) to avoid duplication

### Key decisions:

1. **97 lines** - comfortably within the 40-120 line target from docs/ai-agents.md
2. **Split from styling.md** - easier to review foundation separately from first cursor rule
3. **Monorepo-first approach** - makes yarn workspaces pattern impossible to miss for AI agents
4. **Apps section added** - explains Storybook apps as consumer platforms for manual testing

## **Related issues**

Part of: #881 (AI agent documentation strategy)
Related: #883 (TypeScript enum → string union migration)

## **Manual testing steps**

1. Verify CLAUDE.md is present at repository root
2. Check line count is within 40-120 target
3. Review structure follows docs/ai-agents.md Layer 1 specification
4. Confirm @ notation used for file references

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A - documentation only)
- [x] I've documented my code using JSDoc format if applicable (N/A - markdown documentation)
- [ ] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds guidance for AI agents; no runtime code paths or dependencies are modified.
> 
> **Overview**
> Adds a new root `CLAUDE.md` as the **Layer 1 entry point for AI coding agents**, linking to `@.cursor/rules/styling.md` and `@docs/ai-agents.md`.
> 
> Documents the monorepo workflow (yarn workspaces, run commands from repo root), essential build/test/lint/storybook/component-creation commands, the primary packages and Storybook consumer apps, and a rule to import from published package names rather than local file paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12ab9b5edfcf05efdc17c0b4b069bb5c6afe2684. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->