### PR TITLE
fix: apply textAlignVertical on Android in Input

### DIFF
--- a/packages/design-system-react-native/src/components/Input/Input.tsx
+++ b/packages/design-system-react-native/src/components/Input/Input.tsx
@@ -98,7 +98,7 @@ export const Input = forwardRef<TextInput, InputProps>(
 
     const resolvedStyle = [
       inputStyle,
-      Platform.OS === 'ios' && { textAlignVertical: 'center' as const },
+      Platform.OS === 'android' && { textAlignVertical: 'center' as const },
       style,
     ].filter(Boolean);
 


### PR DESCRIPTION
## **Description**

**Reason for the change:**  
`textAlignVertical` was only applied when `Platform.OS === 'ios'`. In React Native this prop is supported on **Android** and ignored on **iOS**, so the style was applied on the wrong platform and vertical text alignment was inconsistent on Android.

**Improvement/solution:**  
Apply `textAlignVertical: 'center'` only when `Platform.OS === 'android'`, so the style is used on the platform where it has effect and single-line Input text is vertically centered on Android.

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Open Storybook for React Native (`yarn storybook:ios` and/or `yarn storybook:android`).
2. Go to the Input component and use a single-line Input.
3. **Android:** Confirm text is vertically centered in the input.
4. **iOS:** Confirm appearance is unchanged (no regression).

## **Screenshots/Recordings**

### **Before**


### **After**


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized style change limited to the `Input` component with minimal behavioral impact beyond Android text alignment.
> 
> **Overview**
> Updates the React Native `Input` component to apply `textAlignVertical: 'center'` **only on Android** (instead of iOS), improving single-line vertical text alignment consistency on Android without affecting iOS rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 601d2c68eda320a9a6221cb6ec738148d572a42c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->