### PR TITLE
Release 20.0.0 - Fix yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,7 +3411,7 @@ __metadata:
     typescript: "npm:~5.2.2"
   peerDependencies:
     "@metamask/design-system-twrnc-preset": ^0.3.0
-    "@metamask/design-tokens": ^8.1.0
+    "@metamask/design-tokens": ^8.2.0
     "@metamask/utils": ^11.10.0
     lodash: ^4.17.23
     react: ">=18.2.0"


### PR DESCRIPTION
## Summary

Fixes the failed Release 20.0.0 publish workflow by updating yarn.lock to match the peer dependency change.

## Issue

The original Release 20.0.0 PR (#921) updated `@metamask/design-tokens` peer dependency from `^8.1.0` to `^8.2.0` in `@metamask/design-system-react-native`, but the `yarn.lock` file was not updated. This caused the publish workflow to fail during the `yarn install --immutable` check.

**Failed workflow:** https://github.com/MetaMask/metamask-design-system/actions/runs/22198282954

## Changes

- Updates `yarn.lock` to reflect the peer dependency change from `^8.1.0` to `^8.2.0`

## Testing

- ✅ `yarn install --mode=skip-build` runs successfully
- ✅ No other changes to lock file

## Release Process

When this PR is merged to main, the commit message starting with "Release 20.0.0" will trigger the publish workflow to retry the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only change to align declared peer dependency versions; no runtime code changes.
> 
> **Overview**
> Updates `yarn.lock` to reflect the `@metamask/design-system-react-native` peer dependency bump of `@metamask/design-tokens` from `^8.1.0` to `^8.2.0`, restoring consistency for `yarn install --immutable` during release publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e8935afb30b8fe933a56f623a6f0d1942270957. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->