### PR TITLE
Revert Release 20.0.0 to redo properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "20.0.0",
+  "version": "19.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,31 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0]
-
-### Added
-
-- Added `CorporateFare` icon to represent stocks ([#920](https://github.com/MetaMask/metamask-design-system/pull/920))
-- Added `BottomSheetOverlay` component for modal bottom sheet interactions ([#897](https://github.com/MetaMask/metamask-design-system/pull/897))
-  - Provides consistent overlay pattern for bottom sheet components
-  - Includes press-to-dismiss functionality and accessibility features
-
-### Changed
-
-- **BREAKING:** Standardized non-icon enum runtime values to use kebab-case format ([#894](https://github.com/MetaMask/metamask-design-system/pull/894))
-  - Enum values now use lowercase/kebab-case (e.g., `'primary'` instead of `'Primary'`, `'top-right'` instead of `'TopRight'`)
-  - **Migration likely not needed** - continue using enum constants (e.g., `ButtonVariant.Primary`)
-  - **Migration needed** only if your app persists or transmits these enum values (localStorage, databases, APIs)
-  - This prepares for migration from enums to string union types per ADR #127
-- Updated component styling to use `tw.style()` instead of string-based `twClassName` for better type safety and conditional styling ([#889](https://github.com/MetaMask/metamask-design-system/pull/889))
-- Updated `@metamask/design-tokens` peer dependency from ^8.1.0 to ^8.2.0 to support `AnimationDuration` enum used by `BottomSheetOverlay`
-- Updated `@metamask/utils` peer dependency from 11.9.0 to 11.10.0 ([#903](https://github.com/MetaMask/metamask-design-system/pull/903))
-- Reorganized peer dependencies for better dependency management ([#901](https://github.com/MetaMask/metamask-design-system/pull/901))
-
-### Fixed
-
-- Fixed `ButtonBase` component sizing issues in flex layouts to prevent unexpected shrinking ([#870](https://github.com/MetaMask/metamask-design-system/pull/870))
-
 ## [0.6.0]
 
 ### Added
@@ -147,8 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.7.0...HEAD
-[0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.6.0...@metamask/design-system-react-native@0.7.0
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.6.0...HEAD
 [0.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.5.1...@metamask/design-system-react-native@0.6.0
 [0.5.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.5.0...@metamask/design-system-react-native@0.5.1
 [0.5.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.4.1...@metamask/design-system-react-native@0.5.0

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.7.0",
+  "version": "0.6.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",
@@ -90,7 +90,7 @@
   },
   "peerDependencies": {
     "@metamask/design-system-twrnc-preset": "^0.3.0",
-    "@metamask/design-tokens": "^8.2.0",
+    "@metamask/design-tokens": "^8.1.0",
     "@metamask/utils": "^11.10.0",
     "lodash": "^4.17.23",
     "react": ">=18.2.0",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,21 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.0]
-
-### Added
-
-- Added `CorporateFare` icon to represent stocks ([#920](https://github.com/MetaMask/metamask-design-system/pull/920))
-
-### Changed
-
-- **BREAKING:** Standardized non-icon enum runtime values to use kebab-case format ([#894](https://github.com/MetaMask/metamask-design-system/pull/894))
-  - Enum values now use lowercase/kebab-case (e.g., `'primary'` instead of `'Primary'`, `'top-right'` instead of `'TopRight'`)
-  - **Migration likely not needed** - continue using enum constants (e.g., `ButtonVariant.Primary`)
-  - **Migration needed** only if your app persists or transmits these enum values (localStorage, databases, APIs)
-  - This prepares for migration from enums to string union types per ADR #127
-- Updated `@metamask/utils` peer dependency from 11.9.0 to 11.10.0 ([#903](https://github.com/MetaMask/metamask-design-system/pull/903))
-
 ## [0.7.0]
 
 ### Added
@@ -144,8 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.8.0...HEAD
-[0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.7.0...@metamask/design-system-react@0.8.0
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.7.0...HEAD
 [0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.6.1...@metamask/design-system-react@0.7.0
 [0.6.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.6.0...@metamask/design-system-react@0.6.1
 [0.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.5.0...@metamask/design-system-react@0.6.0

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.8.0",
+  "version": "0.7.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3]
-
-### Changed
-
-- Updated `@metamask/utils` dependency from 11.9.0 to 11.10.0 ([#903](https://github.com/MetaMask/metamask-design-system/pull/903))
-
 ## [0.1.2]
 
 ### Changed
@@ -32,8 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.3...HEAD
-[0.1.3]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.2...@metamask/design-system-shared@0.1.3
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.2...HEAD
 [0.1.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.1...@metamask/design-system-shared@0.1.2
 [0.1.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.0...@metamask/design-system-shared@0.1.1
 [0.1.0]: https://github.com/MetaMask/metamask-design-system/releases/tag/@metamask/design-system-shared@0.1.0

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.2.0]
-
-### Added
-
-- Exported `AnimationDuration` enum for standardized animation timing values ([#897](https://github.com/MetaMask/metamask-design-system/pull/897))
-
 ## [8.1.1]
 
 ### Fixed
@@ -404,8 +398,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.2.0...HEAD
-[8.2.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.1.1...@metamask/design-tokens@8.2.0
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.1.1...HEAD
 [8.1.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.1.0...@metamask/design-tokens@8.1.1
 [8.1.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.0.0...@metamask/design-tokens@8.1.0
 [8.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@7.1.0...@metamask/design-tokens@8.0.0

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "8.2.0",
+  "version": "8.1.1",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Summary

Reverts the failed Release 20.0.0 (#921) to redo it properly with complete changelogs and correct yarn.lock.

## Context

Release 20.0.0 was merged to main but the publish workflow failed due to a yarn.lock issue:
- **Failed workflow:** https://github.com/MetaMask/metamask-design-system/actions/runs/22198282954
- **Root cause:** yarn.lock not updated when peer dependency changed

After the release was merged, 7 additional PRs were merged to main:
1. Label component (#907)
2. HeaderBase component (#902)
3. Skeleton (#891)
4. Card (#923)
5. BottomSheetFooter (#899)
6. Toast (#892)
7. Input component (#909)

## Why Revert?

To maintain clean version history and proper changelogs:
- Release 20.0.0 was never published to NPM (latest is 19.0.0)
- The 7 PRs merged after are not documented in Release 20.0.0 changelog
- Reverting allows us to create a proper Release 20.0.0 that includes ALL changes

## Changes

This PR reverts commit `45004196` which:
- Restores package versions to pre-release state (8.1.1, 0.7.0, 0.6.0, etc.)
- Restores root package.json version from 20.0.0 to 19.0.0
- Removes Release 20.0.0 changelog entries

## Next Steps

After this is merged:
1. Create new `release/20.0.0` branch using standard release process
2. Include all changes (original + 7 PRs) in changelogs
3. **Run `yarn install` to update yarn.lock**
4. Merge new Release 20.0.0 PR
5. Publish workflow will succeed with correct lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily metadata changes (versions/changelogs) with a small dependency range rollback; low runtime risk but could affect downstream installs expecting the newer peer range.
> 
> **Overview**
> Reverts the attempted `20.0.0` release by rolling back version bumps in the root `package.json` and multiple packages (`design-system-react`, `design-system-react-native`, `design-system-shared`, `design-tokens`).
> 
> Removes the corresponding unreleased changelog sections/compare links for those reverted versions and resets `@metamask/design-system-react-native`’s `@metamask/design-tokens` peer dependency from `^8.2.0` back to `^8.1.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b9617ac4549d83d68c9de05c2702b0342482343. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->