### PR TITLE
fix: force font-normal for Hero font family to prevent browser synthesis

### DIFF
--- a/apps/storybook-react/tailwind.css
+++ b/apps/storybook-react/tailwind.css
@@ -67,24 +67,10 @@
   src: url('fonts/MMSans/MMSans-Bold.woff2') format('woff2');
 }
 
-/* MM Poly */
+/* MM Poly - Only regular weight is available */
 @font-face {
   font-family: 'MMPoly';
   font-style: normal;
   font-weight: 400;
-  src: url('fonts/MMPoly/MMPoly-Regular.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: 'MMPoly';
-  font-style: normal;
-  font-weight: 500;
-  src: url('fonts/MMPoly/MMPoly-Regular.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: 'MMPoly';
-  font-style: normal;
-  font-weight: 700;
   src: url('fonts/MMPoly/MMPoly-Regular.woff2') format('woff2');
 }

--- a/packages/design-system-react-native/src/components/Text/Text.constants.ts
+++ b/packages/design-system-react-native/src/components/Text/Text.constants.ts
@@ -1,6 +1,30 @@
 import { typography } from '@metamask/design-tokens';
 
-import { FontWeight, TextVariant } from '../../types';
+import { FontFamily, FontWeight, TextVariant } from '../../types';
+
+/**
+ * Defines which font weights are actually available for each font family.
+ * This prevents font synthesis when unavailable weights are requested.
+ */
+export const FONT_FAMILY_AVAILABLE_WEIGHTS: Record<FontFamily, FontWeight[]> = {
+  [FontFamily.Default]: [
+    FontWeight.Regular,
+    FontWeight.Medium,
+    FontWeight.Bold,
+  ],
+  [FontFamily.Accent]: [FontWeight.Regular, FontWeight.Medium, FontWeight.Bold],
+  [FontFamily.Hero]: [FontWeight.Regular], // Only regular weight available for MMPoly
+};
+
+/**
+ * Maps font families to their constrained weight.
+ * Used to override weight when a font family doesn't support all weights.
+ */
+export const FONTFAMILY_WEIGHT_OVERRIDE: Partial<
+  Record<FontFamily, FontWeight>
+> = {
+  [FontFamily.Hero]: FontWeight.Regular, // Force regular weight for Hero (MMPoly)
+};
 
 // Mappings
 export const TWCLASSMAP_TEXT_FONTWEIGHT: {

--- a/packages/design-system-react-native/src/components/Text/Text.stories.tsx
+++ b/packages/design-system-react-native/src/components/Text/Text.stories.tsx
@@ -132,6 +132,151 @@ export const FontFamilyStory: Story = {
   name: 'Font Family',
 };
 
+export const AllVariantsWithFontFamilies: Story = {
+  render: () => {
+    const tw = useTailwind();
+    return (
+      <ScrollView style={tw`p-4`}>
+        <View style={tw`mb-8`}>
+          <Text variant={TextVariant.HeadingSm} twClassName="mb-4">
+            Default Font Family (Geist)
+          </Text>
+          <View style={tw`gap-2`}>
+            <Text
+              variant={TextVariant.DisplayLg}
+              fontFamily={FontFamily.Default}
+            >
+              DisplayLg - The quick orange fox
+            </Text>
+            <Text
+              variant={TextVariant.DisplayMd}
+              fontFamily={FontFamily.Default}
+            >
+              DisplayMd - The quick orange fox
+            </Text>
+            <Text
+              variant={TextVariant.HeadingLg}
+              fontFamily={FontFamily.Default}
+            >
+              HeadingLg - The quick orange fox
+            </Text>
+            <Text
+              variant={TextVariant.HeadingMd}
+              fontFamily={FontFamily.Default}
+            >
+              HeadingMd - The quick orange fox
+            </Text>
+            <Text
+              variant={TextVariant.HeadingSm}
+              fontFamily={FontFamily.Default}
+            >
+              HeadingSm - The quick orange fox
+            </Text>
+            <Text variant={TextVariant.BodyLg} fontFamily={FontFamily.Default}>
+              BodyLg - The quick orange fox
+            </Text>
+            <Text variant={TextVariant.BodyMd} fontFamily={FontFamily.Default}>
+              BodyMd - The quick orange fox
+            </Text>
+            <Text variant={TextVariant.BodySm} fontFamily={FontFamily.Default}>
+              BodySm - The quick orange fox
+            </Text>
+            <Text variant={TextVariant.BodyXs} fontFamily={FontFamily.Default}>
+              BodyXs - The quick orange fox
+            </Text>
+          </View>
+        </View>
+
+        <View style={tw`mb-8`}>
+          <Text variant={TextVariant.HeadingSm} twClassName="mb-4">
+            Accent Font Family (MM Sans)
+          </Text>
+          <View style={tw`gap-2`}>
+            <Text
+              variant={TextVariant.DisplayLg}
+              fontFamily={FontFamily.Accent}
+            >
+              DisplayLg - The quick orange fox
+            </Text>
+            <Text
+              variant={TextVariant.DisplayMd}
+              fontFamily={FontFamily.Accent}
+            >
+              DisplayMd - The quick orange fox
+            </Text>
+            <Text
+              variant={TextVariant.HeadingLg}
+              fontFamily={FontFamily.Accent}
+            >
+              HeadingLg - The quick orange fox
+            </Text>
+            <Text
+              variant={TextVariant.HeadingMd}
+              fontFamily={FontFamily.Accent}
+            >
+              HeadingMd - The quick orange fox
+            </Text>
+            <Text
+              variant={TextVariant.HeadingSm}
+              fontFamily={FontFamily.Accent}
+            >
+              HeadingSm - The quick orange fox
+            </Text>
+            <Text variant={TextVariant.BodyLg} fontFamily={FontFamily.Accent}>
+              BodyLg - The quick orange fox
+            </Text>
+            <Text variant={TextVariant.BodyMd} fontFamily={FontFamily.Accent}>
+              BodyMd - The quick orange fox
+            </Text>
+            <Text variant={TextVariant.BodySm} fontFamily={FontFamily.Accent}>
+              BodySm - The quick orange fox
+            </Text>
+            <Text variant={TextVariant.BodyXs} fontFamily={FontFamily.Accent}>
+              BodyXs - The quick orange fox
+            </Text>
+          </View>
+        </View>
+
+        <View style={tw`mb-8`}>
+          <Text variant={TextVariant.HeadingSm} twClassName="mb-4">
+            Hero Font Family (MM Poly) - Always renders with regular weight
+          </Text>
+          <View style={tw`gap-2`}>
+            <Text variant={TextVariant.DisplayLg} fontFamily={FontFamily.Hero}>
+              DisplayLg - THE QUICK ORANGE FOX
+            </Text>
+            <Text variant={TextVariant.DisplayMd} fontFamily={FontFamily.Hero}>
+              DisplayMd - THE QUICK ORANGE FOX
+            </Text>
+            <Text variant={TextVariant.HeadingLg} fontFamily={FontFamily.Hero}>
+              HeadingLg - THE QUICK ORANGE FOX
+            </Text>
+            <Text variant={TextVariant.HeadingMd} fontFamily={FontFamily.Hero}>
+              HeadingMd - THE QUICK ORANGE FOX
+            </Text>
+            <Text variant={TextVariant.HeadingSm} fontFamily={FontFamily.Hero}>
+              HeadingSm - THE QUICK ORANGE FOX
+            </Text>
+            <Text variant={TextVariant.BodyLg} fontFamily={FontFamily.Hero}>
+              BodyLg - THE QUICK ORANGE FOX
+            </Text>
+            <Text variant={TextVariant.BodyMd} fontFamily={FontFamily.Hero}>
+              BodyMd - THE QUICK ORANGE FOX
+            </Text>
+            <Text variant={TextVariant.BodySm} fontFamily={FontFamily.Hero}>
+              BodySm - THE QUICK ORANGE FOX
+            </Text>
+            <Text variant={TextVariant.BodyXs} fontFamily={FontFamily.Hero}>
+              BodyXs - THE QUICK ORANGE FOX
+            </Text>
+          </View>
+        </View>
+      </ScrollView>
+    );
+  },
+  name: 'All Variants with Font Families',
+};
+
 export const FontStyleStory: Story = {
   render: () => (
     <View>

--- a/packages/design-system-react-native/src/components/Text/Text.tsx
+++ b/packages/design-system-react-native/src/components/Text/Text.tsx
@@ -5,6 +5,7 @@ import { Text as RNText } from 'react-native';
 import { FontFamily, FontStyle, TextVariant, TextColor } from '../../types';
 
 import {
+  FONTFAMILY_WEIGHT_OVERRIDE,
   MAP_TEXT_VARIANT_FONTWEIGHT,
   TWCLASSMAP_TEXT_FONTWEIGHT,
 } from './Text.constants';
@@ -26,7 +27,10 @@ export const Text: React.FC<TextProps> = ({
 
   const textStyle = useMemo(() => {
     const isItalic = fontStyle === FontStyle.Italic;
-    const fontSuffix = `${TWCLASSMAP_TEXT_FONTWEIGHT[finalFontWeight]}${
+    // Apply font family weight override if needed (e.g., Hero font only has regular weight)
+    const effectiveFontWeight =
+      FONTFAMILY_WEIGHT_OVERRIDE[fontFamily] ?? finalFontWeight;
+    const fontSuffix = `${TWCLASSMAP_TEXT_FONTWEIGHT[effectiveFontWeight]}${
       isItalic && fontFamily === FontFamily.Default ? '-italic' : ''
     }`;
     const fontClass = `font-${fontFamily}${fontSuffix}`;

--- a/packages/design-system-react/src/components/Text/Text.constants.ts
+++ b/packages/design-system-react/src/components/Text/Text.constants.ts
@@ -1,4 +1,28 @@
-import { TextVariant } from '../../types';
+import { FontFamily, FontWeight, TextVariant } from '../../types';
+
+/**
+ * Defines which font weights are actually available for each font family.
+ * This prevents browser font synthesis when unavailable weights are requested.
+ */
+export const FONT_FAMILY_AVAILABLE_WEIGHTS: Record<FontFamily, FontWeight[]> = {
+  [FontFamily.Default]: [
+    FontWeight.Regular,
+    FontWeight.Medium,
+    FontWeight.Bold,
+  ],
+  [FontFamily.Accent]: [FontWeight.Regular, FontWeight.Medium, FontWeight.Bold],
+  [FontFamily.Hero]: [FontWeight.Regular], // Only regular weight available for MMPoly
+};
+
+/**
+ * Maps font families to their constrained weight class.
+ * Used to override weight when a font family doesn't support all weights.
+ */
+export const CLASSMAP_FONTFAMILY_WEIGHT_OVERRIDE: Partial<
+  Record<FontFamily, string>
+> = {
+  [FontFamily.Hero]: 'font-regular', // Force regular weight for Hero (MMPoly)
+};
 
 export const CLASSMAP_TEXT_VARIANT_FONTSTYLE: Record<TextVariant, string> = {
   [TextVariant.DisplayLg]:

--- a/packages/design-system-react/src/components/Text/Text.stories.tsx
+++ b/packages/design-system-react/src/components/Text/Text.stories.tsx
@@ -250,6 +250,226 @@ export const FontFamilyStory: Story = {
   name: 'Font Family',
 };
 
+export const AllVariantsWithFontFamilies: Story = {
+  render: () => (
+    <div className="space-y-8">
+      <div>
+        <Text variant={TextVariant.HeadingSm} className="mb-4 block">
+          Default Font Family (Geist)
+        </Text>
+        <div className="space-y-2">
+          <Text
+            variant={TextVariant.DisplayLg}
+            fontFamily={FontFamily.Default}
+            className="block"
+          >
+            DisplayLg - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.DisplayMd}
+            fontFamily={FontFamily.Default}
+            className="block"
+          >
+            DisplayMd - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.HeadingLg}
+            fontFamily={FontFamily.Default}
+            className="block"
+          >
+            HeadingLg - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.HeadingMd}
+            fontFamily={FontFamily.Default}
+            className="block"
+          >
+            HeadingMd - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.HeadingSm}
+            fontFamily={FontFamily.Default}
+            className="block"
+          >
+            HeadingSm - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.BodyLg}
+            fontFamily={FontFamily.Default}
+            className="block"
+          >
+            BodyLg - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontFamily={FontFamily.Default}
+            className="block"
+          >
+            BodyMd - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            fontFamily={FontFamily.Default}
+            className="block"
+          >
+            BodySm - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.BodyXs}
+            fontFamily={FontFamily.Default}
+            className="block"
+          >
+            BodyXs - The quick orange fox
+          </Text>
+        </div>
+      </div>
+
+      <div>
+        <Text variant={TextVariant.HeadingSm} className="mb-4 block">
+          Accent Font Family (MM Sans)
+        </Text>
+        <div className="space-y-2">
+          <Text
+            variant={TextVariant.DisplayLg}
+            fontFamily={FontFamily.Accent}
+            className="block"
+          >
+            DisplayLg - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.DisplayMd}
+            fontFamily={FontFamily.Accent}
+            className="block"
+          >
+            DisplayMd - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.HeadingLg}
+            fontFamily={FontFamily.Accent}
+            className="block"
+          >
+            HeadingLg - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.HeadingMd}
+            fontFamily={FontFamily.Accent}
+            className="block"
+          >
+            HeadingMd - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.HeadingSm}
+            fontFamily={FontFamily.Accent}
+            className="block"
+          >
+            HeadingSm - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.BodyLg}
+            fontFamily={FontFamily.Accent}
+            className="block"
+          >
+            BodyLg - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontFamily={FontFamily.Accent}
+            className="block"
+          >
+            BodyMd - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            fontFamily={FontFamily.Accent}
+            className="block"
+          >
+            BodySm - The quick orange fox
+          </Text>
+          <Text
+            variant={TextVariant.BodyXs}
+            fontFamily={FontFamily.Accent}
+            className="block"
+          >
+            BodyXs - The quick orange fox
+          </Text>
+        </div>
+      </div>
+
+      <div>
+        <Text variant={TextVariant.HeadingSm} className="mb-4 block">
+          Hero Font Family (MM Poly) - Always renders with regular weight
+        </Text>
+        <div className="space-y-2">
+          <Text
+            variant={TextVariant.DisplayLg}
+            fontFamily={FontFamily.Hero}
+            className="block"
+          >
+            DisplayLg - THE QUICK ORANGE FOX
+          </Text>
+          <Text
+            variant={TextVariant.DisplayMd}
+            fontFamily={FontFamily.Hero}
+            className="block"
+          >
+            DisplayMd - THE QUICK ORANGE FOX
+          </Text>
+          <Text
+            variant={TextVariant.HeadingLg}
+            fontFamily={FontFamily.Hero}
+            className="block"
+          >
+            HeadingLg - THE QUICK ORANGE FOX
+          </Text>
+          <Text
+            variant={TextVariant.HeadingMd}
+            fontFamily={FontFamily.Hero}
+            className="block"
+          >
+            HeadingMd - THE QUICK ORANGE FOX
+          </Text>
+          <Text
+            variant={TextVariant.HeadingSm}
+            fontFamily={FontFamily.Hero}
+            className="block"
+          >
+            HeadingSm - THE QUICK ORANGE FOX
+          </Text>
+          <Text
+            variant={TextVariant.BodyLg}
+            fontFamily={FontFamily.Hero}
+            className="block"
+          >
+            BodyLg - THE QUICK ORANGE FOX
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontFamily={FontFamily.Hero}
+            className="block"
+          >
+            BodyMd - THE QUICK ORANGE FOX
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            fontFamily={FontFamily.Hero}
+            className="block"
+          >
+            BodySm - THE QUICK ORANGE FOX
+          </Text>
+          <Text
+            variant={TextVariant.BodyXs}
+            fontFamily={FontFamily.Hero}
+            className="block"
+          >
+            BodyXs - THE QUICK ORANGE FOX
+          </Text>
+        </div>
+      </div>
+    </div>
+  ),
+  name: 'All Variants with Font Families',
+};
+
 export const FontStyleStory: Story = {
   render: () => (
     <div className="space-y-4">

--- a/packages/design-system-react/src/components/Text/Text.tsx
+++ b/packages/design-system-react/src/components/Text/Text.tsx
@@ -5,6 +5,7 @@ import { FontFamily, TextColor, TextVariant } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
 
 import {
+  CLASSMAP_FONTFAMILY_WEIGHT_OVERRIDE,
   CLASSMAP_TEXT_VARIANT_FONTSTYLE,
   CLASSMAP_TEXT_VARIANT_FONTWEIGHT,
   MAP_TEXT_VARIANT_TAG,
@@ -31,10 +32,16 @@ export const Text: React.FC<TextProps> = ({
   // Otherwise, render the semantic HTML element mapped to this variant (e.g. h1-h4, p).
   const Component = asChild ? Slot : MAP_TEXT_VARIANT_TAG[variant];
 
+  // Apply font family weight override if needed (e.g., Hero font only has regular weight)
+  const effectiveFontWeight =
+    CLASSMAP_FONTFAMILY_WEIGHT_OVERRIDE[fontFamily] ||
+    fontWeight ||
+    CLASSMAP_TEXT_VARIANT_FONTWEIGHT[variant];
+
   const mergedClassName = `${twMerge(
     color,
     CLASSMAP_TEXT_VARIANT_FONTSTYLE[variant],
-    fontWeight || CLASSMAP_TEXT_VARIANT_FONTWEIGHT[variant],
+    effectiveFontWeight,
     fontStyle,
     fontFamily,
     textTransform,


### PR DESCRIPTION
## **Description**

This PR implements a refined, constants-based architecture for font family weight constraints to fix the MMPoly Hero font rendering issue.

**Problem:** The MMPoly Hero font only has a regular weight (400) font file available, but the design system was applying font-weight 700 (bold) for Display variants on small screens. This forced browsers to artificially synthesize bold text, resulting in muddy/blurry rendering—especially noticeable on mobile displays and with uppercase content.

**Solution - Constants-Based Architecture:**

### 1. Single Source of Truth
Created `FONT_FAMILY_AVAILABLE_WEIGHTS` constant that documents which font weights are actually available for each font family.

### 2. Weight Override Constants
- **React Web:** `CLASSMAP_FONTFAMILY_WEIGHT_OVERRIDE` maps to Tailwind classes
- **React Native:** `FONTFAMILY_WEIGHT_OVERRIDE` maps to FontWeight enum values

### 3. Consistent Component Logic
Both platforms apply weight constraints with the same pattern in Text.constants.ts → Text.tsx

### 4. Additional Improvements
- Removed `font-normal` from `FontFamily.Hero` enum (clean separation of concerns)
- Removed duplicate `@font-face` declarations for MMPoly in Tailwind CSS
- Added comprehensive "All Variants with Font Families" Storybook stories

### Benefits
✅ Consistent cross-platform architecture
✅ Self-documenting (shows which weights exist)
✅ Scalable (easy to add constrained families)
✅ Type-safe with clear separation of concerns

## **Related issues**

Fixes: #928

## **Manual testing steps**

1. Run `yarn storybook` (web) or `yarn storybook:ios/android` (native)
2. Navigate to Components/Text → "All Variants with Font Families"
3. Verify Hero Font Family section renders crisply without synthetic bolding
4. Test on mobile viewport/device to confirm no blurry rendering

## **Pre-merge author checklist**

- [x] Followed MetaMask Contributor Docs
- [x] Completed PR template
- [x] Included tests (Storybook stories)
- [x] Documented code with JSDoc
- [ ] Applied labels (not external contributor)

## **Pre-merge reviewer checklist**

- [ ] Manually tested the PR
- [ ] Confirms PR addresses all acceptance criteria