### PR TITLE
Revert Release 21.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "21.0.0",
+  "version": "20.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,29 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.0]
-
-### Added
-
-- Added `RadioButton` component for radio button form controls ([#926](https://github.com/MetaMask/metamask-design-system/pull/926))
-  - Supports checked, disabled, read-only, and danger states
-  - Full accessibility support with `role="radio"` and `accessibilityState`
-  - Optional label rendering for improved usability
-
-### Changed
-
-- **BREAKING:** Migrated `BadgeStatus` component from TypeScript enums to string union types with const objects ([#912](https://github.com/MetaMask/metamask-design-system/pull/912))
-  - `BadgeStatusStatus` and `BadgeStatusSize` enums replaced with const objects and derived string union types
-  - **No migration required** - continue importing from `@metamask/design-system-react-native` as usual
-  - Const object values remain the same (e.g., `BadgeStatusStatus.Active` still works)
-  - String literals now also accepted thanks to structural typing (e.g., `'active'` works where `BadgeStatusStatus.Active` is expected)
-  - We are still evaluating best practices for const objects vs string literals - use whichever approach works best for your codebase
-  - This change implements [ADR-0003](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0003-enum-to-string-union-migration.md) and [ADR-0004](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0004-centralized-types-architecture.md)
-- Refactored `BottomSheetFooter` component location for better organization ([#933](https://github.com/MetaMask/metamask-design-system/pull/933))
-  - Moved from `BottomSheets/BottomSheetFooter/` to `BottomSheetFooter/`
-  - Updated import paths and Storybook title
-  - No breaking changes - all imports from package entry point continue to work
-
 ## [0.7.0]
 
 ### Added
@@ -177,8 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.8.0...HEAD
-[0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.7.0...@metamask/design-system-react-native@0.8.0
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.7.0...HEAD
 [0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.6.0...@metamask/design-system-react-native@0.7.0
 [0.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.5.1...@metamask/design-system-react-native@0.6.0
 [0.5.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.5.0...@metamask/design-system-react-native@0.5.1

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.8.0",
+  "version": "0.7.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,18 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.0]
-
-### Changed
-
-- **BREAKING:** Migrated `BadgeStatus` component from TypeScript enums to string union types with const objects ([#912](https://github.com/MetaMask/metamask-design-system/pull/912))
-  - `BadgeStatusStatus` and `BadgeStatusSize` enums replaced with const objects and derived string union types
-  - **No migration required** - continue importing from `@metamask/design-system-react` as usual
-  - Const object values remain the same (e.g., `BadgeStatusStatus.Active` still works)
-  - String literals now also accepted thanks to structural typing (e.g., `'active'` works where `BadgeStatusStatus.Active` is expected)
-  - We are still evaluating best practices for const objects vs string literals - use whichever approach works best for your codebase
-  - This change implements [ADR-0003](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0003-enum-to-string-union-migration.md) and [ADR-0004](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0004-centralized-types-architecture.md)
-
 ## [0.8.0]
 
 ### Added
@@ -157,8 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.9.0...HEAD
-[0.9.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.8.0...@metamask/design-system-react@0.9.0
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.8.0...HEAD
 [0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.7.0...@metamask/design-system-react@0.8.0
 [0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.6.1...@metamask/design-system-react@0.7.0
 [0.6.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.6.0...@metamask/design-system-react@0.6.1

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.9.0",
+  "version": "0.8.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",
@@ -80,8 +80,8 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-tailwind-preset": "^0.6.1",
-    "@metamask/design-tokens": "^8.2.0",
+    "@metamask/design-system-tailwind-preset": "^0.6.0",
+    "@metamask/design-tokens": "^8.1.0",
     "@metamask/utils": "^11.10.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0]
-
-### Added
-
-- Added centralized `BadgeStatus` types and constants ([#912](https://github.com/MetaMask/metamask-design-system/pull/912))
-  - `BadgeStatusStatus` const object with derived string union type for status variants (`active`, `inactive`, `warning`, `danger`, `success`)
-  - `BadgeStatusSize` const object with derived string union type for size variants (`sm`, `md`, `lg`)
-  - `BadgeStatusPropsShared` type interface for shared component props
-  - Enables structural typing - both const object values (`BadgeStatusStatus.Active`) and string literals (`'active'`) are now accepted
-  - Implements [ADR-0003](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0003-enum-to-string-union-migration.md) and [ADR-0004](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0004-centralized-types-architecture.md)
-
 ## [0.1.3]
 
 ### Changed
@@ -43,8 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.3...@metamask/design-system-shared@0.2.0
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.3...HEAD
 [0.1.3]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.2...@metamask/design-system-shared@0.1.3
 [0.1.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.1...@metamask/design-system-shared@0.1.2
 [0.1.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.1.0...@metamask/design-system-shared@0.1.1

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.2.0",
+  "version": "0.1.3",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Summary

Reverts Release 21.0.0 (#938) to redo the release without peer dependency updates that caused the release workflow to fail.

## Issue

The release workflow failed with:
```
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

This was caused by peer dependency updates in `@metamask/design-system-react`:
- `@metamask/design-system-tailwind-preset`: ^0.6.0 → ^0.6.1
- `@metamask/design-tokens`: ^8.1.0 → ^8.2.0

## Resolution

This PR reverts the release merge to allow resubmission without the peer dependency changes. The new release will include:
- ✅ Version bumps
- ✅ Changelog updates  
- ❌ No peer dependency changes (to avoid yarn.lock modifications in CI)

## Next Steps

After this revert is merged, a new Release 21.0.0 PR will be created with only the necessary version and changelog updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping-only changes (versions/changelogs/peer dependency ranges) with no runtime code modifications; main risk is publishing/versioning confusion if merged out of sequence.
> 
> **Overview**
> Reverts the prior `21.0.0` release metadata by rolling the monorepo version back to `20.0.0` and downgrading package versions for `@metamask/design-system-react` (`0.9.0`→`0.8.0`), `@metamask/design-system-react-native` (`0.8.0`→`0.7.0`), and `@metamask/design-system-shared` (`0.2.0`→`0.1.3`).
> 
> Removes the newly-added `Unreleased` changelog sections/compare links for those versions and reverts `@metamask/design-system-react` peer dependency bumps (`@metamask/design-system-tailwind-preset` and `@metamask/design-tokens`) back to their previous ranges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dda38a0bf016c24c29ccb4292aeeae925b53e7eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->