### PR TITLE
docs: add component-enum-union-migration.md cursor rule

### DIFF
--- a/.cursor/rules/component-enum-union-migration.md
+++ b/.cursor/rules/component-enum-union-migration.md
@@ -1,0 +1,276 @@
+# Component Enum-to-Union Migration
+
+Guide for refactoring existing monorepo components to ADR-0003 (string unions) and ADR-0004 (centralized types) patterns.
+
+## Purpose
+
+This workflow is for **internal cleanup** of existing monorepo components that currently have:
+
+- Duplicate const object definitions across React and React Native packages
+- Types defined separately in each platform package
+- No shared type architecture
+
+**This is NOT for creating new components.** For new components, see:
+
+- @.cursor/rules/component-migration.md (bringing from extension/mobile)
+- @.cursor/rules/component-creation.md (creating from scratch)
+
+## When to Use This Workflow
+
+Migrate existing components when:
+
+- ✅ Component already exists in both React and React Native packages
+- ✅ Const objects are duplicated across platform packages
+- ✅ Types are defined separately in each platform (no shared source)
+- ✅ Component API needs to be unified/modernized
+
+**Common examples:** BadgeStatus, AvatarAccount, Button (if using old enums), any component with `export enum ComponentNameVariant` duplicated.
+
+## Migration Workflow
+
+### Step 1: Identify Duplicated Types
+
+Find components with duplicate enums in platform packages:
+
+```tsx
+// ❌ Current state: Duplicated in BOTH packages
+// packages/design-system-react/src/types/index.ts
+export enum BadgeStatusStatus { Active = 'active', ... }
+
+// packages/design-system-react-native/src/types/index.ts
+export enum BadgeStatusStatus { Active = 'active', ... } // Duplicate!
+```
+
+### Steps 2-7: Apply ADR Patterns
+
+**Follow @.cursor/rules/component-architecture.md patterns exactly.**
+
+**Workflow checklist:**
+
+1. **Create shared types** in `packages/design-system-shared/src/types/ComponentName/`
+
+   - Use const objects (ADR-0003): `export const ComponentVariant = { Primary: 'primary' } as const;`
+   - Derive types: `export type ComponentVariant = (typeof ComponentVariant)[keyof typeof ComponentVariant];`
+   - Use `type` not `interface` for props
+   - Add "Shared" suffix: `ComponentNamePropsShared`
+   - Export from `packages/design-system-shared/src/index.ts` with inline `type` keyword
+
+2. **Update React package** `src/components/ComponentName/ComponentName.types.ts`:
+
+   - Import shared type for extension
+   - **DO NOT re-export const objects** (causes coverage loss - exports belong in index.ts)
+   - Extend `ComponentProps<'element'>`, add `className?: string`
+   - Import ordering: shared before react
+
+   ```tsx
+   // ✅ Correct - Import only, no const object re-exports
+   import type { ComponentPropsShared } from '@metamask/design-system-shared';
+   import type { ComponentProps } from 'react';
+
+   export type ComponentProps = ComponentProps<'div'> &
+     ComponentPropsShared & {
+       className?: string;
+     };
+   ```
+
+3. **Update React Native package** `src/components/ComponentName/ComponentName.types.ts`:
+
+   - Import shared type for extension
+   - **DO NOT re-export const objects** (causes coverage loss - exports belong in index.ts)
+   - Extend `ViewProps`/`PressableProps`, add `twClassName?: string`
+   - Import ordering: shared before react-native
+
+   ```tsx
+   // ✅ Correct - Import only, no const object re-exports
+   import type { ComponentPropsShared } from '@metamask/design-system-shared';
+   import type { ViewProps } from 'react-native';
+
+   export type ComponentProps = ComponentPropsShared &
+     ViewProps & {
+       twClassName?: string;
+     };
+   ```
+
+4. **Remove old enums** from platform type indices:
+
+   ```tsx
+   // ❌ DELETE from src/types/index.ts:
+   // export enum BadgeStatusStatus { ... }
+
+   // ✅ Do NOT re-export in src/types/index.ts
+   // Component index.ts will export directly from shared
+   ```
+
+5. **Update component index.ts** to export directly from shared:
+
+   ```tsx
+   // src/components/ComponentName/index.ts
+   export {
+     ComponentVariant,
+     ComponentSize,
+   } from '@metamask/design-system-shared';
+   export { ComponentName } from './ComponentName';
+   export type { ComponentProps } from './ComponentName.types';
+   ```
+
+6. **Fix import ordering** (ESLint will enforce):
+
+   - Shared package imports before platform imports
+   - Type imports before value imports
+
+7. **Verify build/test/lint:**
+   ```bash
+   yarn build && yarn test && yarn lint
+   ```
+
+**Golden Path Reference:** See complete BadgeStatus implementation:
+
+- @packages/design-system-shared/src/types/BadgeStatus/BadgeStatus.types.ts
+- @packages/design-system-react/src/components/BadgeStatus/BadgeStatus.types.ts
+- @packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.types.ts
+
+**Related PR:** https://github.com/MetaMask/metamask-design-system/pull/912 (complete migration with all file changes)
+
+## Common Mistakes
+
+### ❌ Re-exporting Const Objects from .types.ts Files
+
+```tsx
+// ❌ Wrong - Duplicate exports reduce test coverage
+// ComponentName.types.ts
+export {
+  ComponentVariant, // Duplicate with index.ts export!
+  type ComponentPropsShared,
+} from '@metamask/design-system-shared';
+
+// ✅ Correct - Import only in .types.ts
+import type { ComponentPropsShared } from '@metamask/design-system-shared';
+// Const object exported from index.ts only
+```
+
+**Why this matters:** Duplicate const object exports create uncovered code paths in Jest coverage reports, causing tests to fail coverage thresholds.
+
+### ❌ Using `interface` instead of `type` for Shared Props
+
+```tsx
+// ❌ Wrong - ESLint error
+export interface BadgeStatusPropsShared { ... }
+
+// ✅ Correct
+export type BadgeStatusPropsShared = { ... };
+```
+
+### ❌ Separate Type Exports (Duplicate Identifier)
+
+```tsx
+// ❌ Wrong - Causes "Duplicate identifier" error
+export { BadgeStatusStatus } from '...';
+export type { BadgeStatusStatus } from '...';
+
+// ✅ Correct - Inline type keyword
+export { BadgeStatusStatus, type BadgeStatusPropsShared } from '...';
+```
+
+### ❌ Wrong Import Ordering
+
+```tsx
+// ❌ Wrong - React before shared
+import type { ComponentProps } from 'react';
+import type { BadgeStatusPropsShared } from '@metamask/design-system-shared';
+
+// ✅ Correct - Shared before react
+import type { BadgeStatusPropsShared } from '@metamask/design-system-shared';
+import type { ComponentProps } from 'react';
+```
+
+### ❌ Including Platform Props in Shared
+
+```tsx
+// ❌ Wrong - className in shared (violates ADR-0004)
+export type BadgeStatusPropsShared = {
+  status: BadgeStatusStatus;
+  className?: string; // Platform-specific!
+};
+
+// ✅ Correct - className only in platform package
+export type BadgeStatusPropsShared = {
+  status: BadgeStatusStatus;
+};
+
+export type BadgeStatusProps = ComponentProps<'div'> &
+  BadgeStatusPropsShared & {
+    className?: string; // Platform layer
+  };
+```
+
+## Verification Checklist
+
+### Shared Package
+
+- [ ] Types in `packages/design-system-shared/src/types/ComponentName/`
+- [ ] Const objects used (ADR-0003), NOT enums
+- [ ] Shared type named `ComponentNamePropsShared` (with "Shared" suffix)
+- [ ] Used `type` not `interface` for shared props
+- [ ] Exported from `packages/design-system-shared/src/index.ts`
+- [ ] Inline `type` keyword used in exports
+
+### React Package
+
+- [ ] Component `.types.ts` file imports shared type for extension
+- [ ] Component `.types.ts` DOES NOT re-export const objects (import only)
+- [ ] Component `index.ts` exports const objects directly from shared package (single location)
+- [ ] Extends `ComponentProps<'element'>`
+- [ ] Adds `className?: string`
+- [ ] Import ordering correct (shared before react)
+- [ ] Old enum removed from `src/types/index.ts`
+
+### React Native Package
+
+- [ ] Component `.types.ts` file imports shared type for extension
+- [ ] Component `.types.ts` DOES NOT re-export const objects (import only)
+- [ ] Component `index.ts` exports const objects directly from shared package (single location)
+- [ ] Extends `ViewProps` or `PressableProps`
+- [ ] Adds `twClassName?: string`
+- [ ] Import ordering correct (shared before react-native)
+- [ ] Old enum removed from `src/types/index.ts`
+
+### Cross-Platform Consistency
+
+- [ ] Identical `ComponentNamePropsShared` in shared package
+- [ ] Same const object names and values
+- [ ] Platform differences ONLY in extension layer
+
+### Build & Tests
+
+- [ ] Build succeeds: `yarn build`
+- [ ] Tests pass: `yarn test`
+- [ ] Coverage meets thresholds: `yarn test --coverage` (100% all metrics)
+- [ ] Lint passes: `yarn lint`
+- [ ] No TypeScript errors
+- [ ] No breaking changes to component API (backwards compatible)
+
+## References
+
+### Architectural Patterns
+
+- @.cursor/rules/component-architecture.md - All architectural patterns and decision trees (READ THIS FIRST)
+
+### Golden Path
+
+- @packages/design-system-shared/src/types/BadgeStatus/ - Complete example
+- [PR #912](https://github.com/MetaMask/metamask-design-system/pull/912) - Complete migration
+
+### Related Workflows
+
+- @.cursor/rules/component-migration.md - Bringing components from extension/mobile
+- @.cursor/rules/component-creation.md - Creating new components from scratch
+- @.cursor/rules/styling.md - Design tokens and styling patterns
+
+### Architecture Decision Records
+
+- [ADR-0003: Enum to String Union Migration](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0003-enum-to-string-union-migration.md)
+- [ADR-0004: Centralized Types Architecture](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0004-centralized-types-architecture.md)
+
+### MetaMask Standards
+
+- [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Repository-specific conventions and patterns:
 - @.cursor/rules/component-documentation.md
 - @.cursor/rules/component-architecture.md
 - @.cursor/rules/component-creation.md
+- @.cursor/rules/component-enum-union-migration.md
 - @.cursor/rules/figma-integration.md
 
 See @docs/ai-agents.md for comprehensive strategy explanation.


### PR DESCRIPTION
## **Description**

Adds `component-enum-union-migration.md` cursor rule providing workflow for refactoring existing monorepo components to ADR-0003 (const objects) and ADR-0004 (centralized types) patterns. This rule is specifically for internal cleanup of components with duplicate const object definitions across React and React Native packages.

**When to use this workflow:**
- Component already exists in both React and React Native packages
- Const objects are duplicated across platform packages
- Types are defined separately in each platform (no shared source)
- Component API needs to be unified/modernized

**Key workflow documented:**
1. Identify components with duplicate const objects across platforms
2. Create shared types in `@metamask/design-system-shared` package
3. Update React package to import (not re-export) shared types
4. Update React Native package to import (not re-export) shared types
5. Remove old duplicates from platform type indices
6. Update component index.ts to export directly from shared
7. Verify build/test/lint

**Critical mistakes documented:**
- Re-exporting const objects from `.types.ts` files (causes test coverage loss)
- Using `interface` instead of `type` for shared props (ESLint error)
- Separate type exports causing "Duplicate identifier" TypeScript errors
- Wrong import ordering (platform imports before shared imports)
- Including platform-specific props in shared types (violates ADR-0004)

**Why this matters:**
The BadgeCount migration (PR #942) revealed that duplicate const object exports in `.types.ts` files create uncovered code paths, failing Jest coverage thresholds at 81.81% instead of 100%. This rule documents the exact two-file pattern needed to prevent this issue.

**Relationship to other rules:**
- Depends on: `component-architecture.md` (foundational ADR patterns)
- Different from: `component-creation.md` (new components) and `component-migration.md` (extension/mobile migration)
- Use case: Internal monorepo cleanup only

**References:**
- Golden path: BadgeStatus component (SOURCE OF TRUTH for shared types)
- Complete example: PR #912 (full migration with all file changes)
- Validation: BadgeCount PR #942 (demonstrated coverage issue and fix)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-344

## **Manual testing steps**

1. Review the cursor rule file: `.cursor/rules/component-enum-union-migration.md`
2. Verify it references BadgeCount PR #942 and PR #912
3. Check workflow steps match the BadgeCount migration pattern
4. Confirm anti-patterns section shows duplicate export mistake
5. Verify it clarifies this is NOT for new components
6. Check golden path examples reference BadgeStatus implementation
7. Confirm verification checklist covers both platforms
8. Verify CLAUDE.md includes reference to this new rule

## **Screenshots/Recordings**

N/A - Documentation only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A - documentation)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A - markdown)
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds internal guidance; no runtime or build logic is modified.
> 
> **Overview**
> Adds a new Cursor rule, `.cursor/rules/component-enum-union-migration.md`, documenting a **standard workflow** for migrating existing cross-platform components from duplicated enums/consts to **shared string-union types** per ADR-0003/ADR-0004 (including export patterns, import ordering, and common pitfalls like `.types.ts` re-exports impacting coverage).
> 
> Updates `CLAUDE.md` to reference this new rule in the AI-agent documentation index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e257d78e00e6e7ff455ddb5d25c873127fca4169. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->