### PR TITLE
Release 31.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "30.0.0",
+  "version": "31.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0]
+
 ### Uncategorized
 
 - refactor: Renamed BoxVertical to BoxColumn and BoxHorizontal to BoxRow ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))
@@ -307,7 +309,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.15.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.16.0...HEAD
+[0.16.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.15.0...@metamask/design-system-react-native@0.16.0
 [0.15.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.14.0...@metamask/design-system-react-native@0.15.0
 [0.14.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.13.0...@metamask/design-system-react-native@0.14.0
 [0.13.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.12.0...@metamask/design-system-react-native@0.13.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- refactor: Renamed BoxVertical to BoxColumn and BoxHorizontal to BoxRow ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))
+- feat: [DSRN] Update KeyValueRow ([#1023](https://github.com/MetaMask/metamask-design-system/pull/1023))
+- feat: [DSRN] Added HeaderSearch ([#1031](https://github.com/MetaMask/metamask-design-system/pull/1031))
+- feat(shared): migrate BadgeNetwork to ADR-0004 shared types (DSYS-480) ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
+- feat: [DSRN] Add KeyValueColumn ([#1046](https://github.com/MetaMask/metamask-design-system/pull/1046))
+
 ## [0.15.0]
 
 ### Added

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,13 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.16.0]
 
-### Uncategorized
+### Added
 
-- refactor: Renamed BoxVertical to BoxColumn and BoxHorizontal to BoxRow ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))
-- feat: [DSRN] Update KeyValueRow ([#1023](https://github.com/MetaMask/metamask-design-system/pull/1023))
-- feat: [DSRN] Added HeaderSearch ([#1031](https://github.com/MetaMask/metamask-design-system/pull/1031))
-- feat(shared): migrate BadgeNetwork to ADR-0004 shared types (DSYS-480) ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
-- feat: [DSRN] Add KeyValueColumn ([#1046](https://github.com/MetaMask/metamask-design-system/pull/1046))
+- Added `HeaderSearch` component for in-screen and inline search experiences ([#1031](https://github.com/MetaMask/metamask-design-system/pull/1031))
+- Added `KeyValueColumn` component for vertically-stacked key/value layouts ([#1046](https://github.com/MetaMask/metamask-design-system/pull/1046))
+
+### Changed
+
+- **BREAKING:** Renamed `BoxHorizontal` to `BoxRow` and `BoxVertical` to `BoxColumn` ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))
+  - See [Migration Guide](./MIGRATION.md#from-version-0150-to-0160)
+- **BREAKING:** Refactored `KeyValueRow` API — removed the legacy stub-based composition (`KeyValueRowStubs`, `field`/`value` objects); use `keyLabel`, `value`, `variant`, and accessory props directly ([#1023](https://github.com/MetaMask/metamask-design-system/pull/1023))
+  - See [Migration Guide](./MIGRATION.md#from-version-0150-to-0160)
+- Migrated `BadgeNetwork` type exports to `@metamask/design-system-shared`; imports from `@metamask/design-system-react-native` are unchanged ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
 
 ## [0.15.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - See [Migration Guide](./MIGRATION.md#from-version-0150-to-0160)
 - **BREAKING:** Refactored `KeyValueRow` API — removed the legacy stub-based composition (`KeyValueRowStubs`, `field`/`value` objects); use `keyLabel`, `value`, `variant`, and accessory props directly ([#1023](https://github.com/MetaMask/metamask-design-system/pull/1023))
   - See [Migration Guide](./MIGRATION.md#from-version-0150-to-0160)
-- Migrated `BadgeNetwork` type exports to `@metamask/design-system-shared`; imports from `@metamask/design-system-react-native` are unchanged ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
+- Updated `BadgeNetwork` type internals; imports from `@metamask/design-system-react-native` are unchanged ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
 
 ## [0.15.0]
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -67,7 +67,6 @@ If you do not want back navigation, omit `goBack`.
 
 - `BoxHorizontal` has been renamed to `BoxRow`
 - `BoxVertical` has been renamed to `BoxColumn`
-- Corresponding shared types `BoxHorizontalPropsShared` → `BoxRowPropsShared` and `BoxVerticalPropsShared` → `BoxColumnPropsShared`
 
 **Migration:**
 
@@ -99,26 +98,9 @@ import { BoxRow, BoxColumn } from '@metamask/design-system-react-native';
 </BoxColumn>
 ```
 
-Shared type users:
-
-```tsx
-// Before (0.15.0)
-import type {
-  BoxHorizontalPropsShared,
-  BoxVerticalPropsShared,
-} from '@metamask/design-system-shared';
-
-// After (0.16.0)
-import type {
-  BoxRowPropsShared,
-  BoxColumnPropsShared,
-} from '@metamask/design-system-shared';
-```
-
 **Impact:**
 
 - Any import of `BoxHorizontal` or `BoxVertical` must be renamed
-- Any TypeScript references to `BoxHorizontalPropsShared` or `BoxVerticalPropsShared` must be updated
 
 #### KeyValueRow API
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -16,7 +16,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [Icon Component](#icon-component)
   - [Checkbox Component](#checkbox-component)
 - [Version Updates](#version-updates)
-  - [From version 0.14.0 to 0.15.0](#from-version-0140-to-0150)
+  - [From version 0.15.0 to 0.16.0](#from-version-0150-to-0160)
   - [From version 0.13.0 to 0.14.0](#from-version-0130-to-0140)
   - [From version 0.12.0 to 0.13.0](#from-version-0120-to-0130)
   - [From version 0.11.0 to 0.12.0](#from-version-0110-to-0120)
@@ -59,14 +59,73 @@ If you do not want back navigation, omit `goBack`.
 - Affects BottomSheet usages that previously relied on `shouldNavigateBack`.
 - Navigation behavior is now explicit and controlled by the host app callback.
 
-### From version 0.14.0 to 0.15.0
+### From version 0.15.0 to 0.16.0
+
+#### BoxHorizontal and BoxVertical renamed to BoxRow and BoxColumn
+
+**What Changed:**
+
+- `BoxHorizontal` has been renamed to `BoxRow`
+- `BoxVertical` has been renamed to `BoxColumn`
+- Corresponding shared types `BoxHorizontalPropsShared` → `BoxRowPropsShared` and `BoxVerticalPropsShared` → `BoxColumnPropsShared`
+
+**Migration:**
+
+```tsx
+// Before (0.15.0)
+import { BoxHorizontal, BoxVertical } from '@metamask/design-system-react-native';
+
+<BoxHorizontal gap={2}>
+  <Text>Left</Text>
+  <Text>Right</Text>
+</BoxHorizontal>
+
+<BoxVertical gap={4}>
+  <Text>Top</Text>
+  <Text>Bottom</Text>
+</BoxVertical>
+
+// After (0.16.0)
+import { BoxRow, BoxColumn } from '@metamask/design-system-react-native';
+
+<BoxRow gap={2}>
+  <Text>Left</Text>
+  <Text>Right</Text>
+</BoxRow>
+
+<BoxColumn gap={4}>
+  <Text>Top</Text>
+  <Text>Bottom</Text>
+</BoxColumn>
+```
+
+Shared type users:
+
+```tsx
+// Before (0.15.0)
+import type {
+  BoxHorizontalPropsShared,
+  BoxVerticalPropsShared,
+} from '@metamask/design-system-shared';
+
+// After (0.16.0)
+import type {
+  BoxRowPropsShared,
+  BoxColumnPropsShared,
+} from '@metamask/design-system-shared';
+```
+
+**Impact:**
+
+- Any import of `BoxHorizontal` or `BoxVertical` must be renamed
+- Any TypeScript references to `BoxHorizontalPropsShared` or `BoxVerticalPropsShared` must be updated
 
 #### KeyValueRow API
 
 **What changed:**
 
 - `KeyValueRow` no longer accepts `field` and `value` configuration objects. Use flat props: `keyLabel`, `value`, optional `variant`, start/end accessories, optional `keyTextProps` / `valueTextProps`, and optional `keyEndButtonIconProps` / `valueEndButtonIconProps`.
-- Layout is handled inside the component (`BoxHorizontal` / `Box`). The old stub API used to compose custom rows is removed.
+- Layout is handled inside the component (`BoxRow` / `Box`). The old stub API used to compose custom rows is removed.
 - `KeyValueRowVariant` is defined in `@metamask/design-system-shared` (shared props follow ADR-0003 / ADR-0004); React Native–specific props remain on `KeyValueRowProps` in this package.
 
 **Removed from the public API:**
@@ -84,13 +143,13 @@ If you do not want back navigation, omit `goBack`.
 Simple labels:
 
 ```tsx
-// Before (0.14.0)
+// Before (0.15.0)
 <KeyValueRow
   field={{ label: { text: 'Network' } }}
   value={{ label: { text: 'Ethereum Mainnet' } }}
 />
 
-// After (0.15.0)
+// After (0.16.0)
 <KeyValueRow keyLabel="Network" value="Ethereum Mainnet" />
 ```
 
@@ -100,7 +159,7 @@ Typography via predefined label objects → `keyTextProps` / `valueTextProps`:
 import { KeyValueRow, KeyValueRowVariant } from '@metamask/design-system-react-native';
 import { TextColor, TextVariant } from '@metamask/design-system-react-native';
 
-// Before (0.14.0)
+// Before (0.15.0)
 <KeyValueRow
   field={{
     label: {
@@ -118,7 +177,7 @@ import { TextColor, TextVariant } from '@metamask/design-system-react-native';
   }}
 />
 
-// After (0.15.0)
+// After (0.16.0)
 <KeyValueRow
   keyLabel="Fee"
   value="$2.59"
@@ -132,7 +191,7 @@ Icons with `side` → accessories (use start and/or end nodes; “both sides” 
 ```tsx
 import { Icon, IconColor, IconName, IconSize } from '@metamask/design-system-react-native';
 
-// Before (0.14.0) — icon on the left of the key label
+// Before (0.15.0) — icon on the left of the key label
 <KeyValueRow
   field={{
     label: { text: 'Network' },
@@ -141,7 +200,7 @@ import { Icon, IconColor, IconName, IconSize } from '@metamask/design-system-rea
   value={{ label: { text: 'Mainnet' } }}
 />
 
-// After (0.15.0)
+// After (0.16.0)
 <KeyValueRow
   keyLabel="Network"
   value="Mainnet"
@@ -154,7 +213,7 @@ Info icon that previously used `tooltip` → `keyEndButtonIconProps` and host-co
 ```tsx
 import { IconName } from '@metamask/design-system-react-native';
 
-// Before (0.14.0)
+// Before (0.15.0)
 <KeyValueRow
   field={{ label: { text: 'Limit' } }}
   value={{
@@ -167,7 +226,7 @@ import { IconName } from '@metamask/design-system-react-native';
   }}
 />
 
-// After (0.15.0) — implement modal / sheet / tooltip in onPress
+// After (0.16.0) — implement modal / sheet / tooltip in onPress
 <KeyValueRow
   keyLabel="Limit"
   value="Unlimited"

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(shared): migrate BadgeNetwork to ADR-0004 shared types (DSYS-480) ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
+
 ## [0.15.0]
 
 ### Added

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Migrated `BadgeNetwork` type exports to `@metamask/design-system-shared`; imports from `@metamask/design-system-react` are unchanged ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
+- Updated `BadgeNetwork` type internals; imports from `@metamask/design-system-react` are unchanged ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
 
 ## [0.15.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.16.0]
 
-### Uncategorized
+### Changed
 
-- feat(shared): migrate BadgeNetwork to ADR-0004 shared types (DSYS-480) ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
+- Migrated `BadgeNetwork` type exports to `@metamask/design-system-shared`; imports from `@metamask/design-system-react` are unchanged ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
 
 ## [0.15.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0]
+
 ### Uncategorized
 
 - feat(shared): migrate BadgeNetwork to ADR-0004 shared types (DSYS-480) ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
@@ -229,7 +231,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.15.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.16.0...HEAD
+[0.16.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.15.0...@metamask/design-system-react@0.16.0
 [0.15.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.14.0...@metamask/design-system-react@0.15.0
 [0.14.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.13.0...@metamask/design-system-react@0.14.0
 [0.13.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.12.0...@metamask/design-system-react@0.13.0

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0]
+
 ### Uncategorized
 
 - refactor: Renamed BoxVertical to BoxColumn and BoxHorizontal to BoxRow ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))
@@ -102,7 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.8.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.9.0...HEAD
+[0.9.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.8.0...@metamask/design-system-shared@0.9.0
 [0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.7.0...@metamask/design-system-shared@0.8.0
 [0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.6.0...@metamask/design-system-shared@0.7.0
 [0.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.5.0...@metamask/design-system-shared@0.6.0

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0]
 
-### Uncategorized
+### Added
 
-- refactor: Renamed BoxVertical to BoxColumn and BoxHorizontal to BoxRow ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))
-- feat: [DSRN] Update KeyValueRow ([#1023](https://github.com/MetaMask/metamask-design-system/pull/1023))
-- feat: [DSRN] Added HeaderSearch ([#1031](https://github.com/MetaMask/metamask-design-system/pull/1031))
-- feat(shared): migrate BadgeNetwork to ADR-0004 shared types (DSYS-480) ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
-- feat: [DSRN] Add KeyValueColumn ([#1046](https://github.com/MetaMask/metamask-design-system/pull/1046))
+- Added `BadgeNetworkPropsShared` shared type for cross-platform use ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
+- Added `HeaderSearchVariant`, `HeaderSearchPropsShared`, `HeaderSearchInlinePropsShared`, and `HeaderSearchScreenPropsShared` shared types for cross-platform use ([#1031](https://github.com/MetaMask/metamask-design-system/pull/1031))
+- Added `KeyValueRowVariant` const object (`Summary`, `Input`) and `KeyValueRowPropsShared` shared type for cross-platform use ([#1023](https://github.com/MetaMask/metamask-design-system/pull/1023))
+- Added `KeyValueColumnPropsShared` shared type for cross-platform use ([#1046](https://github.com/MetaMask/metamask-design-system/pull/1046))
+
+### Changed
+
+- **BREAKING:** Renamed `BoxHorizontalPropsShared` to `BoxRowPropsShared` and `BoxVerticalPropsShared` to `BoxColumnPropsShared` ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))
+  - See [Migration Guide](../design-system-react-native/MIGRATION.md#from-version-0150-to-0160)
 
 ## [0.8.0]
 

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- refactor: Renamed BoxVertical to BoxColumn and BoxHorizontal to BoxRow ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))
+- feat: [DSRN] Update KeyValueRow ([#1023](https://github.com/MetaMask/metamask-design-system/pull/1023))
+- feat: [DSRN] Added HeaderSearch ([#1031](https://github.com/MetaMask/metamask-design-system/pull/1031))
+- feat(shared): migrate BadgeNetwork to ADR-0004 shared types (DSYS-480) ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))
+- feat: [DSRN] Add KeyValueColumn ([#1046](https://github.com/MetaMask/metamask-design-system/pull/1046))
+
 ## [0.8.0]
 
 ### Added

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(deps-dev): bump @metamask/auto-changelog from 5.3.1 to 5.3.2 ([#906](https://github.com/MetaMask/metamask-design-system/pull/906))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.3.0 to 5.3.1 ([#878](https://github.com/MetaMask/metamask-design-system/pull/878))
+- chore: remove unused eslint-disable comments after eslint upgrades ([#861](https://github.com/MetaMask/metamask-design-system/pull/861))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.2.0 to 5.3.0 ([#858](https://github.com/MetaMask/metamask-design-system/pull/858))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.1.0 to 5.2.0 ([#853](https://github.com/MetaMask/metamask-design-system/pull/853))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.0.2 to 5.1.0 ([#837](https://github.com/MetaMask/metamask-design-system/pull/837))
+
 ## [0.6.1]
 
 ### Fixed

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- chore(deps-dev): bump @metamask/auto-changelog from 5.3.1 to 5.3.2 ([#906](https://github.com/MetaMask/metamask-design-system/pull/906))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.3.0 to 5.3.1 ([#878](https://github.com/MetaMask/metamask-design-system/pull/878))
-- chore: remove unused eslint-disable comments after eslint upgrades ([#861](https://github.com/MetaMask/metamask-design-system/pull/861))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.2.0 to 5.3.0 ([#858](https://github.com/MetaMask/metamask-design-system/pull/858))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.1.0 to 5.2.0 ([#853](https://github.com/MetaMask/metamask-design-system/pull/853))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.0.2 to 5.1.0 ([#837](https://github.com/MetaMask/metamask-design-system/pull/837))
-
 ## [0.6.1]
 
 ### Fixed


### PR DESCRIPTION
## Release 31.0.0

This release adds new React Native components (`HeaderSearch`, `KeyValueColumn`), renames `BoxHorizontal`/`BoxVertical` to `BoxRow`/`BoxColumn`, refactors the `KeyValueRow` API, and continues ADR-0004 shared type migrations (`BadgeNetwork`).

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.9.0**
- `@metamask/design-system-react`: **0.16.0**
- `@metamask/design-system-react-native`: **0.16.0**

### 🔄 Shared Type Updates (0.9.0)

#### Added shared types ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021), [#1023](https://github.com/MetaMask/metamask-design-system/pull/1023), [#1031](https://github.com/MetaMask/metamask-design-system/pull/1031), [#1046](https://github.com/MetaMask/metamask-design-system/pull/1046))

- Added `BadgeNetworkPropsShared` for cross-platform use
- Added `KeyValueRowVariant` const object (`Summary`, `Input`) and `KeyValueRowPropsShared`
- Added `HeaderSearchVariant`, `HeaderSearchPropsShared`, `HeaderSearchInlinePropsShared`, `HeaderSearchScreenPropsShared`
- Added `KeyValueColumnPropsShared`

#### Breaking: Box type renames ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))

- **BREAKING:** Renamed `BoxHorizontalPropsShared` → `BoxRowPropsShared` and `BoxVerticalPropsShared` → `BoxColumnPropsShared`

### 🌐 React Web Updates (0.16.0)

#### Changed

- Migrated `BadgeNetwork` type exports to `@metamask/design-system-shared`; imports from `@metamask/design-system-react` are unchanged ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))

### 📱 React Native Updates (0.16.0)

#### Added

- Added `HeaderSearch` component for in-screen and inline search experiences ([#1031](https://github.com/MetaMask/metamask-design-system/pull/1031))
- Added `KeyValueColumn` component for vertically-stacked key/value layouts ([#1046](https://github.com/MetaMask/metamask-design-system/pull/1046))

#### Changed

- **BREAKING:** Renamed `BoxHorizontal` → `BoxRow` and `BoxVertical` → `BoxColumn` ([#1050](https://github.com/MetaMask/metamask-design-system/pull/1050))
- **BREAKING:** Refactored `KeyValueRow` API — removed legacy stub-based composition; use `keyLabel`, `value`, `variant`, and accessory props directly ([#1023](https://github.com/MetaMask/metamask-design-system/pull/1023))
- Migrated `BadgeNetwork` type exports to `@metamask/design-system-shared`; imports unchanged ([#1021](https://github.com/MetaMask/metamask-design-system/pull/1021))

### ⚠️ Breaking Changes

#### BoxHorizontal/BoxVertical renamed to BoxRow/BoxColumn (React Native + Shared)

**What Changed:**

- `BoxHorizontal` → `BoxRow`, `BoxVertical` → `BoxColumn`
- `BoxHorizontalPropsShared` → `BoxRowPropsShared`, `BoxVerticalPropsShared` → `BoxColumnPropsShared`

**Migration:**

```tsx
// Before (0.15.0)
import { BoxHorizontal, BoxVertical } from '@metamask/design-system-react-native';
<BoxHorizontal gap={2}>{children}</BoxHorizontal>
<BoxVertical gap={4}>{children}</BoxVertical>

// After (0.16.0)
import { BoxRow, BoxColumn } from '@metamask/design-system-react-native';
<BoxRow gap={2}>{children}</BoxRow>
<BoxColumn gap={4}>{children}</BoxColumn>
```

See [Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0150-to-0160)

#### KeyValueRow API refactor (React Native)

**What Changed:**

- Removed `field`/`value` configuration objects and all stub-based composition exports
- Use flat props: `keyLabel`, `value`, `variant`, `keyTextProps`, `valueTextProps`, `keyEndButtonIconProps`, `valueEndButtonIconProps`

**Migration:**

```tsx
// Before (0.15.0)
<KeyValueRow
  field={{ label: { text: 'Network' } }}
  value={{ label: { text: 'Ethereum Mainnet' } }}
/>

// After (0.16.0)
<KeyValueRow keyLabel="Network" value="Ethereum Mainnet" />
```

See [Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0150-to-0160)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: minor (0.8.0 → 0.9.0) - new shared types + breaking Box renames
  - [x] design-system-react: minor (0.15.0 → 0.16.0) - type migration
  - [x] design-system-react-native: minor (0.15.0 → 0.16.0) - new components + breaking changes
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly version/changelog/migration updates, but it formalizes a release that includes documented breaking API renames and a `KeyValueRow` refactor, which can impact downstream consumers when published.
> 
> **Overview**
> Prepares the `31.0.0` release by bumping the root version and publishing versions for `@metamask/design-system-react` (`0.16.0`), `@metamask/design-system-react-native` (`0.16.0`), and `@metamask/design-system-shared` (`0.9.0`).
> 
> Updates `CHANGELOG.md`/`MIGRATION.md` to document the release content, including new RN components (`HeaderSearch`, `KeyValueColumn`), **breaking** `BoxHorizontal`/`BoxVertical` → `BoxRow`/`BoxColumn` renames (and shared prop type renames), the **breaking** `KeyValueRow` API flattening/removal of stub exports, and the `BadgeNetwork` type migration notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81fb84f247b250ae48cff12f3fa69337b2e8c3d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->