### PR TITLE
docs: `TextButton` migration

### DIFF
--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -10,6 +10,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [ButtonHero Component](#buttonhero-component)
   - [ButtonFilter Component](#buttonfilter-component)
   - [ButtonIcon Component](#buttonicon-component)
+  - [TextButton Component (ButtonLink)](#textbutton-component-buttonlink)
   - [BottomSheet Component](#bottomsheet-component)
   - [BottomSheetHeader Component](#bottomsheetheader-component)
   - [BottomSheetFooter Component](#bottomsheetfooter-component)
@@ -1035,6 +1036,125 @@ After (Design System):
   size={ButtonIconSize.Sm}
   onPress={handleClose}
 />
+```
+
+### TextButton Component (ButtonLink)
+
+The legacy `ButtonLink` component is replaced by **two** design system components depending on the use case:
+
+- **`TextButton`** — for inline links within text flows (the primary replacement)
+- **`Button` with `variant={ButtonVariant.Tertiary}`** — for standalone link-style buttons with icons, full width, or other button-like affordances
+
+`TextButton` is a `Text`-based component (not a `Pressable`/`TouchableOpacity`). It only renders text — no icons, no size variants, no width control.
+
+#### Breaking Changes
+
+##### Import Path
+
+| Mobile Pattern                                                                                 | Design System Migration                                             |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `import ButtonLink from '.../component-library/components/Buttons/Button/variants/ButtonLink'` | `import { TextButton } from '@metamask/design-system-react-native'` |
+
+##### Content Model: `label` → `children`
+
+| Mobile Pattern                      | Design System Migration               |
+| ----------------------------------- | ------------------------------------- |
+| `<ButtonLink label="Learn more" />` | `<TextButton>Learn more</TextButton>` |
+| `<ButtonLink label={variable} />`   | `<TextButton>{variable}</TextButton>` |
+
+##### Size Removed
+
+The legacy `ButtonLink` inherited `ButtonSize` with a default of `ButtonSize.Auto`. The design system `TextButton` has no `size` prop — control typography via the `variant` prop instead.
+
+| Mobile Pattern           | Design System Migration                  |
+| ------------------------ | ---------------------------------------- |
+| `size={ButtonSize.Auto}` | Remove — default behavior                |
+| `size={ButtonSize.Lg}`   | `variant={TextVariant.BodyLg}`           |
+| `size={ButtonSize.Sm}`   | `variant={TextVariant.BodySm}`           |
+| `size={ButtonSize.Md}`   | `variant={TextVariant.BodyMd}` (default) |
+
+##### `isDanger` Removed
+
+The legacy `ButtonLink` supported `isDanger` for error-colored text. `TextButton` does not have this prop — it always uses primary color. For error-state links, use `Button` with `variant={ButtonVariant.Tertiary}` and `isDanger`.
+
+##### `labelTextVariant` → `variant`
+
+| Mobile Pattern                                | Design System Migration                                           |
+| --------------------------------------------- | ----------------------------------------------------------------- |
+| `labelTextVariant={TextVariant.BodyMDMedium}` | `variant={TextVariant.BodyMd}` + `fontWeight={FontWeight.Medium}` |
+
+##### `onPress` Signature
+
+The legacy `ButtonLink` with `size={ButtonSize.Auto}` used `Text.onPressIn`/`onPressOut`. The design system `TextButton` also uses `Text` press props, so the signature is the same for inline usage. For non-auto sizes, the legacy component wrapped `ButtonBase` (a `TouchableOpacity`), which passes `GestureResponderEvent`. `TextButton` always uses `Text` press events.
+
+##### Removed Props
+
+| Mobile Prop                     | Design System Migration                                           |
+| ------------------------------- | ----------------------------------------------------------------- |
+| `isDanger`                      | Use `Button` with `variant={ButtonVariant.Tertiary}` + `isDanger` |
+| `startIconName` / `endIconName` | Use `Button` with `variant={ButtonVariant.Tertiary}`              |
+| `width` / `isFullWidth`         | Use `Button` with `variant={ButtonVariant.Tertiary}`              |
+| `isDisabled`                    | Not available on `TextButton` — use `Button` if needed            |
+
+#### Migration Examples
+
+##### Inline "show more" link
+
+Before (Mobile):
+
+```tsx
+import ButtonLink from '../../../../component-library/components/Buttons/Button/variants/ButtonLink';
+
+<ButtonLink
+  onPress={toggleContent}
+  label={isExpanded ? 'Show less' : 'Show more'}
+/>;
+```
+
+After (Design System):
+
+```tsx
+import { TextButton } from '@metamask/design-system-react-native';
+
+<TextButton onPress={toggleContent}>
+  {isExpanded ? 'Show less' : 'Show more'}
+</TextButton>;
+```
+
+##### Link variant in a Button group → Tertiary Button
+
+Before (Mobile):
+
+```tsx
+import Button, {
+  ButtonVariants,
+  ButtonSize,
+} from '../../../../component-library/components/Buttons/Button';
+
+<Button
+  variant={ButtonVariants.Link}
+  size={ButtonSize.Lg}
+  label={strings('button.learn_more')}
+  onPress={handleLearnMore}
+/>;
+```
+
+After (Design System):
+
+```tsx
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
+
+<Button
+  variant={ButtonVariant.Tertiary}
+  size={ButtonSize.Lg}
+  onPress={handleLearnMore}
+>
+  {strings('button.learn_more')}
+</Button>;
 ```
 
 ### BottomSheet Component

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -1085,7 +1085,7 @@ The legacy `ButtonLink` supported `isDanger` for error-colored text. `TextButton
 
 ##### `onPress` Signature
 
-The legacy `ButtonLink` with `size={ButtonSize.Auto}` used `Text.onPressIn`/`onPressOut`. The design system `TextButton` also uses `Text` press props, so the signature is the same for inline usage. For non-auto sizes, the legacy component wrapped `ButtonBase` (a `TouchableOpacity`), which passes `GestureResponderEvent`. `TextButton` always uses `Text` press events.
+All press props (`onPress`, `onPressIn`, `onPressOut`) keep the same `GestureResponderEvent` type. The behavioral difference is that the legacy non-auto `ButtonBase` (`TouchableOpacity`) provided animated press feedback and handled `isDisabled`, whereas `TextButton` uses `Text` press handling throughout.
 
 ##### Removed Props
 

--- a/packages/design-system-react-native/src/components/TextButton/README.md
+++ b/packages/design-system-react-native/src/components/TextButton/README.md
@@ -86,6 +86,10 @@ Style for the label, merged after design-token styles. Prefer `twClassName` with
 
 Other `Text` / React Native `Text` props are supported via `TextButtonProps` (see [`TextProps`](../Text/Text.types.ts)).
 
+## Migration from MetaMask Mobile Component Library
+
+Migrating from the legacy `ButtonLink` in `app/component-library/components/Buttons/Button/variants/ButtonLink`? See the [TextButton (ButtonLink) migration guide](../../MIGRATION.md#textbutton-component-buttonlink) for the full prop mapping, `label` → `children`, and when to use `Button` with `variant={ButtonVariant.Tertiary}` instead.
+
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Added migration docs for `TextButton`.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-637

## **Manual testing steps**

1. Open Readme
2. Check migration instructions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

<img width="1055" height="1026" alt="image" src="https://github.com/user-attachments/assets/5ada93b2-5a84-4928-8de3-8fced44924d3" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that do not change runtime behavior or public APIs.
> 
> **Overview**
> Adds a new `TextButton` migration section to `MIGRATION.md` covering how to replace legacy Mobile `ButtonLink`, including prop mapping (`label` → `children`), removed capabilities (size/disabled/icons/danger), and when to use a tertiary `Button` instead.
> 
> Updates the `TextButton` README to link to this new migration guide for Mobile consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40edb1631ccff5f368f601efca36ba0d15be8c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->