### PR TITLE
Release 33.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "32.0.0",
+  "version": "33.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0]
+
 ### Uncategorized
 
 - feat: migrate AvatarFavicon to ADR-0003 and ADR-0004 (DSYS-474) ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
@@ -327,7 +329,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.17.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.18.0...HEAD
+[0.18.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.17.0...@metamask/design-system-react-native@0.18.0
 [0.17.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.16.0...@metamask/design-system-react-native@0.17.0
 [0.16.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.15.0...@metamask/design-system-react-native@0.16.0
 [0.15.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.14.0...@metamask/design-system-react-native@0.15.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: migrate AvatarFavicon to ADR-0003 and ADR-0004 (DSYS-474) ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
+- feat: [DSRN] Added IconAlert ([#1060](https://github.com/MetaMask/metamask-design-system/pull/1060))
+
 ## [0.17.0]
 
 ### Changed

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 
-### Uncategorized
+### Added
 
-- feat: migrate AvatarFavicon to ADR-0003 and ADR-0004 (DSYS-474) ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
-- feat: [DSRN] Added IconAlert ([#1060](https://github.com/MetaMask/metamask-design-system/pull/1060))
+- Added `IconAlert` component for mapping a severity (`info`, `success`, `warning`, `error`) to a fixed icon glyph and theme color ([#1060](https://github.com/MetaMask/metamask-design-system/pull/1060))
+
+### Changed
+
+- Updated `AvatarFavicon` type internals to use ADR-0003/ADR-0004 shared types; imports from `@metamask/design-system-react-native` are unchanged ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
 
 ## [0.17.0]
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: migrate AvatarFavicon to ADR-0003 and ADR-0004 (DSYS-474) ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
+- feat(DSYS-489): Migrate Text to ADR-0003 and ADR-0004 ([#1047](https://github.com/MetaMask/metamask-design-system/pull/1047))
+
 ## [0.16.0]
 
 ### Changed

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.17.0]
 
-### Uncategorized
+### Changed
 
-- feat: migrate AvatarFavicon to ADR-0003 and ADR-0004 (DSYS-474) ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
-- feat(DSYS-489): Migrate Text to ADR-0003 and ADR-0004 ([#1047](https://github.com/MetaMask/metamask-design-system/pull/1047))
+- Updated `AvatarFavicon` type internals to use ADR-0003/ADR-0004 shared types; imports from `@metamask/design-system-react` are unchanged ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
+- **BREAKING:** Migrated `Text` typography types (`TextVariant`, `TextColor`, `FontWeight`, `FontStyle`, `FontFamily`) to `@metamask/design-system-shared`; all imports through `@metamask/design-system-react` continue to work without change ([#1047](https://github.com/MetaMask/metamask-design-system/pull/1047))
+  - `FontWeight`, `FontStyle`, and `FontFamily` underlying string values changed to semantic identifiers (e.g. `FontWeight.Bold` was `'font-bold'`, now `'bold'`); idiomatic usage is unaffected
+  - Projects scanning `node_modules` for Tailwind class names must also scan `@metamask/design-system-shared`
+  - See [Migration Guide](./MIGRATION.md#from-version-0160-to-0170)
 
 ## [0.16.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0]
+
 ### Uncategorized
 
 - feat: migrate AvatarFavicon to ADR-0003 and ADR-0004 (DSYS-474) ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
@@ -236,7 +238,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.16.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.17.0...HEAD
+[0.17.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.16.0...@metamask/design-system-react@0.17.0
 [0.16.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.15.0...@metamask/design-system-react@0.16.0
 [0.15.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.14.0...@metamask/design-system-react@0.15.0
 [0.14.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.13.0...@metamask/design-system-react@0.14.0

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: migrate AvatarFavicon to ADR-0003 and ADR-0004 (DSYS-474) ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
+- feat: [DSRN] Added IconAlert ([#1060](https://github.com/MetaMask/metamask-design-system/pull/1060))
+
 ## [0.10.0]
 
 ### Added

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0]
+
 ### Uncategorized
 
 - feat: migrate AvatarFavicon to ADR-0003 and ADR-0004 (DSYS-474) ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
@@ -119,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.10.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.11.0...HEAD
+[0.11.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.10.0...@metamask/design-system-shared@0.11.0
 [0.10.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.9.0...@metamask/design-system-shared@0.10.0
 [0.9.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.8.0...@metamask/design-system-shared@0.9.0
 [0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.7.0...@metamask/design-system-shared@0.8.0

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0]
 
-### Uncategorized
+### Added
 
-- feat: migrate AvatarFavicon to ADR-0003 and ADR-0004 (DSYS-474) ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
-- feat: [DSRN] Added IconAlert ([#1060](https://github.com/MetaMask/metamask-design-system/pull/1060))
+- Added `IconAlertSeverity` and `IconAlertPropsShared` shared types for cross-platform use ([#1060](https://github.com/MetaMask/metamask-design-system/pull/1060))
+- Added `AvatarFaviconSize` and `AvatarFaviconPropsShared` shared types for cross-platform use ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))
 
 ## [0.10.0]
 

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(deps-dev): bump @metamask/auto-changelog from 5.3.1 to 5.3.2 ([#906](https://github.com/MetaMask/metamask-design-system/pull/906))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.3.0 to 5.3.1 ([#878](https://github.com/MetaMask/metamask-design-system/pull/878))
+- chore: remove unused eslint-disable comments after eslint upgrades ([#861](https://github.com/MetaMask/metamask-design-system/pull/861))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.2.0 to 5.3.0 ([#858](https://github.com/MetaMask/metamask-design-system/pull/858))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.1.0 to 5.2.0 ([#853](https://github.com/MetaMask/metamask-design-system/pull/853))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.0.2 to 5.1.0 ([#837](https://github.com/MetaMask/metamask-design-system/pull/837))
+
 ## [0.6.1]
 
 ### Fixed

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- chore(deps-dev): bump @metamask/auto-changelog from 5.3.1 to 5.3.2 ([#906](https://github.com/MetaMask/metamask-design-system/pull/906))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.3.0 to 5.3.1 ([#878](https://github.com/MetaMask/metamask-design-system/pull/878))
-- chore: remove unused eslint-disable comments after eslint upgrades ([#861](https://github.com/MetaMask/metamask-design-system/pull/861))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.2.0 to 5.3.0 ([#858](https://github.com/MetaMask/metamask-design-system/pull/858))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.1.0 to 5.2.0 ([#853](https://github.com/MetaMask/metamask-design-system/pull/853))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.0.2 to 5.1.0 ([#837](https://github.com/MetaMask/metamask-design-system/pull/837))
-
 ## [0.6.1]
 
 ### Fixed


### PR DESCRIPTION
## Release 33.0.0

This release captures two features that landed on `main` after Release 32.0.0 was cut — `IconAlert` (new React Native component) and the `AvatarFavicon` ADR-0003/0004 type migration — plus the `Text` typography type migration that was inadvertently omitted from Release 32.0.0.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.11.0**
- `@metamask/design-system-react`: **0.17.0**
- `@metamask/design-system-react-native`: **0.18.0**

### 🔄 Shared Type Updates (0.11.0)

#### IconAlert and AvatarFavicon shared types (#1060, #1062)

**What Changed:**

- Added `IconAlertSeverity` and `IconAlertPropsShared` shared types for cross-platform use
- Added `AvatarFaviconSize` and `AvatarFaviconPropsShared` shared types for cross-platform use

**Impact:**

- Continues ADR-0003/0004 const-object + string-union pattern adoption

### 🌐 React Web Updates (0.17.0)

#### Changed

- **BREAKING:** Migrated `Text` typography types (`TextVariant`, `TextColor`, `FontWeight`, `FontStyle`, `FontFamily`) to `@metamask/design-system-shared`; all imports through `@metamask/design-system-react` continue to work without change ([#1047](https://github.com/MetaMask/metamask-design-system/pull/1047))
  - `FontWeight`, `FontStyle`, and `FontFamily` underlying string values changed to semantic identifiers (e.g. `FontWeight.Bold` was `'font-bold'`, now `'bold'`); idiomatic usage is unaffected
  - Projects scanning `node_modules` for Tailwind class names must also scan `@metamask/design-system-shared`
  - See [Migration Guide](./packages/design-system-react/MIGRATION.md#from-version-0160-to-0170)
- Updated `AvatarFavicon` type internals to use ADR-0003/ADR-0004 shared types; imports from `@metamask/design-system-react` are unchanged ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))

### 📱 React Native Updates (0.18.0)

#### Added

- Added `IconAlert` component for mapping a severity (`info`, `success`, `warning`, `error`) to a fixed icon glyph and theme color ([#1060](https://github.com/MetaMask/metamask-design-system/pull/1060))

#### Changed

- Updated `AvatarFavicon` type internals to use ADR-0003/ADR-0004 shared types; imports from `@metamask/design-system-react-native` are unchanged ([#1062](https://github.com/MetaMask/metamask-design-system/pull/1062))

### ⚠️ Breaking Changes

#### Text typography types moved to shared package (React Web Only)

**What Changed:**

- `FontWeight`, `FontStyle`, `FontFamily`, `TextVariant`, and `TextColor` now defined in `@metamask/design-system-shared` and re-exported from `@metamask/design-system-react`
- `FontWeight`, `FontStyle`, and `FontFamily` underlying string values changed to semantic identifiers

**Migration:**

```tsx
// ✅ Idiomatic usage — no change needed
import { FontWeight } from '@metamask/design-system-react';
<Text fontWeight={FontWeight.Bold} />

// ❌ Rare: comparing against raw string value — update to const member
if (fontWeight === 'font-bold') { ... }  // Before
if (fontWeight === FontWeight.Bold) { ... }  // After

// Tailwind config — add shared package scan if scanning node_modules
content: [
  './node_modules/@metamask/design-system-react/**/*.{mjs,cjs}',
  './node_modules/@metamask/design-system-shared/**/*.{mjs,cjs}', // Add this
]
```

See [React Migration Guide](./packages/design-system-react/MIGRATION.md#from-version-0160-to-0170) for complete instructions.

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: minor (0.10.0 → 0.11.0) - new shared types added
  - [x] design-system-react: minor (0.16.0 → 0.17.0) - breaking type value changes
  - [x] design-system-react-native: minor (0.17.0 → 0.18.0) - new component + type migration
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples (if breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This is primarily a release bookkeeping PR (version bumps + changelog entries) with no code changes; risk is limited to publishing the intended package versions and documenting the noted breaking type migration.
> 
> **Overview**
> Bumps the monorepo release to `33.0.0` and increments package versions for `@metamask/design-system-shared` (`0.11.0`), `@metamask/design-system-react` (`0.17.0`), and `@metamask/design-system-react-native` (`0.18.0`).
> 
> Updates changelogs to capture the included releases, including new shared types for `IconAlert`/`AvatarFavicon` and the documented **breaking** `Text` typography type migration to `@metamask/design-system-shared`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33608916ccf131e158051763675d2bbb7e63e583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->