### PR TITLE
fix: resolve transitive content scanning requirement for design-system-shared in tailwind-preset

### DIFF
--- a/.cursor/rules/component-architecture.md
+++ b/.cursor/rules/component-architecture.md
@@ -114,10 +114,10 @@ Both React (Tailwind) and React Native (TWRNC) share the same design token class
 
 **Two patterns:**
 
-| Pattern | Example | Value is… | Used as… |
-| ------- | ------- | --------- | -------- |
-| Token identity | `TextColor.TextDefault = 'text-default'` | The class string itself (same on both platforms) | `className={color}` / `twClassName={color}` directly |
-| Semantic value | `FontWeight.Bold = 'bold'` | Abstract identifier (platforms need different class strings) | Mapped in platform `.constants.ts` |
+| Pattern        | Example                                  | Value is…                                                    | Used as…                                             |
+| -------------- | ---------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
+| Token identity | `TextColor.TextDefault = 'text-default'` | The class string itself (same on both platforms)             | `className={color}` / `twClassName={color}` directly |
+| Semantic value | `FontWeight.Bold = 'bold'`               | Abstract identifier (platforms need different class strings) | Mapped in platform `.constants.ts`                   |
 
 ### Token identity constants (`TextColor`, `BoxBackgroundColor`, `BoxBorderColor`, etc.)
 

--- a/.cursor/rules/component-architecture.md
+++ b/.cursor/rules/component-architecture.md
@@ -106,6 +106,37 @@ Separate shared design system concerns from platform-specific implementation con
 - ✅ React: `className?: string` (platform layer)
 - ✅ React Native: `twClassName?: string` (platform layer)
 
+## Const Object Value Patterns in Shared
+
+Not all constants in `design-system-shared` have the same kind of value. The rule is simple: **if the class string is identical across both platforms, put it in shared; if the platforms need different class strings, use an abstract value in shared and map per platform.**
+
+Both React (Tailwind) and React Native (TWRNC) share the same design token class naming from their respective presets — so most token-identity constants can live in shared and be used directly as class names on both platforms.
+
+**Two patterns:**
+
+| Pattern | Example | Value is… | Used as… |
+| ------- | ------- | --------- | -------- |
+| Token identity | `TextColor.TextDefault = 'text-default'` | The class string itself (same on both platforms) | `className={color}` / `twClassName={color}` directly |
+| Semantic value | `FontWeight.Bold = 'bold'` | Abstract identifier (platforms need different class strings) | Mapped in platform `.constants.ts` |
+
+### Token identity constants (`TextColor`, `BoxBackgroundColor`, `BoxBorderColor`, etc.)
+
+- Values ARE the Tailwind/TWRNC class strings — identical across both platforms
+- Used directly: `className={color}` (React) / `twClassName={color}` (React Native)
+- ✅ Values live in shared and are used as-is on both platforms
+
+### Semantic constants (`FontWeight`, `FontStyle`, `FontFamily`, `TextVariant`)
+
+- Platforms need different class strings for these — they cannot share a single value:
+  - React: `FontWeight.Bold → 'font-bold'`
+  - React Native: `FontWeight.Bold → '-bold'` (TWRNC suffix strategy)
+- ✅ Abstract values in shared, class mappings in each platform's `Component.constants.ts`
+- ❌ Do NOT use const values as inline `style={{}}` — Tailwind/TWRNC is the styling approach for both platforms
+
+### Tailwind scanning consequence
+
+Token identity constants in shared require Tailwind's JIT to find their string values. This is handled automatically by `design-system-tailwind-preset`, which adds `design-system-shared`'s dist to its `content` array via `require.resolve` — hoisting-safe and zero-maintenance as new constants are added. Consumers never need to add `design-system-shared` to their own content glob. See `styling.md` for implementation details.
+
 ## Export Pattern: Avoiding TypeScript Errors
 
 When exporting both values and types with the same name, use inline `type` keyword to avoid "Duplicate identifier" errors:

--- a/.cursor/rules/styling.md
+++ b/.cursor/rules/styling.md
@@ -319,6 +319,35 @@ These examples show:
 - @packages/design-system-tailwind-preset/ (React Web token classes)
 - @packages/design-system-twrnc-preset/ (React Native token classes)
 
+## Tailwind Preset Content Scanning
+
+Token-identity constants (e.g. `TextColor`, `BoxBackgroundColor`) live in `@metamask/design-system-shared` and their values are used directly as class strings. To ensure Tailwind's JIT finds these classes — regardless of how `node_modules` is hoisted — `design-system-tailwind-preset` adds the shared package's dist to its `content` array using `require.resolve` from within the preset's own dependency graph:
+
+```ts
+// packages/design-system-tailwind-preset/src/index.ts
+const sharedDistGlob = path.join(
+  path.dirname(
+    require.resolve('@metamask/design-system-shared/package.json'),
+  ),
+  'dist/**/*.{mjs,cjs}',
+);
+
+const tailwindConfig: Config = {
+  content: [sharedDistGlob],
+  // ...
+};
+```
+
+**Why `require.resolve` instead of a path string:**
+`@metamask/design-system-shared` is a direct dependency of the preset, so `require.resolve` finds it from the preset's own dep graph — not the consumer's. This is hoisting-safe: it works even in strict hoisting environments where transitive deps are not accessible from the consumer's root.
+
+**Consequences for contributors:**
+
+- ✅ Adding a new token-identity constant to shared → automatically picked up, no preset changes needed
+- ✅ Consumers never need to add `@metamask/design-system-shared` to their Tailwind `content` glob
+- ✅ Tailwind only emits classes that are actually referenced — no bundle bloat from over-emitting
+- ❌ Do NOT add a manual safelist as a workaround — the content scanning approach scales automatically as more types move to shared
+
 ## Verification
 
 After styling changes, verify:

--- a/.cursor/rules/styling.md
+++ b/.cursor/rules/styling.md
@@ -325,12 +325,7 @@ Token-identity constants (e.g. `TextColor`, `BoxBackgroundColor`) live in `@meta
 
 ```ts
 // packages/design-system-tailwind-preset/src/index.ts
-const sharedDistGlob = path.join(
-  path.dirname(
-    require.resolve('@metamask/design-system-shared/package.json'),
-  ),
-  'dist/**/*.{mjs,cjs}',
-);
+const sharedDistGlob = `${require.resolve('@metamask/design-system-shared/package.json').replace(/\/package\.json$/u, '')}/dist/**/*.{mjs,cjs}`;
 
 const tailwindConfig: Config = {
   content: [sharedDistGlob],

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -56,6 +56,9 @@
     "ts-jest": "^29.2.5",
     "typescript": "~5.2.2"
   },
+  "dependencies": {
+    "@metamask/design-system-shared": "workspace:^"
+  },
   "peerDependencies": {
     "@metamask/design-tokens": "^8.0.0",
     "tailwindcss": "^3.0.0"

--- a/packages/design-system-tailwind-preset/src/index.test.ts
+++ b/packages/design-system-tailwind-preset/src/index.test.ts
@@ -21,7 +21,9 @@ describe('Tailwind Preset', () => {
   it('content includes design-system-shared dist glob for hoisting-safe class scanning', () => {
     const content = tailwindConfig.content as string[];
     expect(content.length).toBeGreaterThan(0);
-    expect(content.some((entry) => entry.includes('design-system-shared'))).toBe(true);
+    expect(
+      content.some((entry) => entry.includes('design-system-shared')),
+    ).toBe(true);
     expect(content.some((entry) => entry.includes('dist'))).toBe(true);
   });
 

--- a/packages/design-system-tailwind-preset/src/index.test.ts
+++ b/packages/design-system-tailwind-preset/src/index.test.ts
@@ -18,6 +18,13 @@ describe('Tailwind Preset', () => {
     expect(tailwindConfig).toHaveProperty('plugins');
   });
 
+  it('content includes design-system-shared dist glob for hoisting-safe class scanning', () => {
+    const content = tailwindConfig.content as string[];
+    expect(content.length).toBeGreaterThan(0);
+    expect(content.some((entry) => entry.includes('design-system-shared'))).toBe(true);
+    expect(content.some((entry) => entry.includes('dist'))).toBe(true);
+  });
+
   /**
    * Colors
    */

--- a/packages/design-system-tailwind-preset/src/index.ts
+++ b/packages/design-system-tailwind-preset/src/index.ts
@@ -14,7 +14,7 @@ import { typography } from './typography';
  * into shared, they are automatically picked up here without any changes to
  * this file.
  */
-const sharedDistGlob = `${require.resolve('@metamask/design-system-shared/package.json').replace(/\/package\.json$/, '')}/dist/**/*.{mjs,cjs}`;
+const sharedDistGlob = `${require.resolve('@metamask/design-system-shared/package.json').replace(/\/package\.json$/u, '')}/dist/**/*.{mjs,cjs}`;
 
 const tailwindConfig: Config = {
   content: [sharedDistGlob],

--- a/packages/design-system-tailwind-preset/src/index.ts
+++ b/packages/design-system-tailwind-preset/src/index.ts
@@ -1,11 +1,30 @@
+import path from 'path';
+
 import type { Config } from 'tailwindcss';
 
 import { colors } from './colors';
 import { shadows, shadowPlugin } from './shadows';
 import { typography } from './typography';
 
+/**
+ * Resolve the compiled output of @metamask/design-system-shared using this
+ * preset's own dependency graph, not the consumer's. This is hoisting-safe:
+ * shared is a direct dep of the preset so require.resolve always finds it
+ * regardless of how the consumer's node_modules is structured.
+ *
+ * As more token-identity constants (TextColor, BoxBackgroundColor, etc.) move
+ * into shared, they are automatically picked up here without any changes to
+ * this file.
+ */
+const sharedDistGlob = path.join(
+  path.dirname(
+    require.resolve('@metamask/design-system-shared/package.json'),
+  ),
+  'dist/**/*.{mjs,cjs}',
+);
+
 const tailwindConfig: Config = {
-  content: [],
+  content: [sharedDistGlob],
   theme: {
     extend: {
       colors: {

--- a/packages/design-system-tailwind-preset/src/index.ts
+++ b/packages/design-system-tailwind-preset/src/index.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import type { Config } from 'tailwindcss';
 
 import { colors } from './colors';
@@ -16,12 +14,7 @@ import { typography } from './typography';
  * into shared, they are automatically picked up here without any changes to
  * this file.
  */
-const sharedDistGlob = path.join(
-  path.dirname(
-    require.resolve('@metamask/design-system-shared/package.json'),
-  ),
-  'dist/**/*.{mjs,cjs}',
-);
+const sharedDistGlob = `${require.resolve('@metamask/design-system-shared/package.json').replace(/\/package\.json$/, '')}/dist/**/*.{mjs,cjs}`;
 
 const tailwindConfig: Config = {
   content: [sharedDistGlob],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,6 +3469,7 @@ __metadata:
   resolution: "@metamask/design-system-tailwind-preset@workspace:packages/design-system-tailwind-preset"
   dependencies:
     "@metamask/auto-changelog": "npm:^5.3.2"
+    "@metamask/design-system-shared": "workspace:^"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^27.4.1"
     "@types/node": "npm:^16.18.54"


### PR DESCRIPTION
## **Description**

From `@metamask/design-system-react@0.17.0`, typography type constants (`TextVariant`, `FontWeight`, `FontStyle`, `FontFamily`, `TextColor`) were moved to `@metamask/design-system-shared`. Because `design-system-shared` is a transitive dependency, Tailwind's JIT engine could not reliably scan its compiled output — consumers had to manually add `@metamask/design-system-shared` to their `content` glob, which is fragile in strict hoisting environments (yarn PnP, pnpm, etc.).

This PR fixes the issue at the right layer: the `design-system-tailwind-preset`.

**Solution:**

Add `@metamask/design-system-shared` as a direct dependency of the preset and include its `dist` output in the preset's `content` array, resolved via `require.resolve` from the preset's own dependency graph:

```ts
const sharedDistGlob = `${require
  .resolve('@metamask/design-system-shared/package.json')
  .replace(/\/package\.json$/u, '')}/dist/**/*.{mjs,cjs}`;

const tailwindConfig: Config = {
  content: [sharedDistGlob],
  // ...
};
```

**Why `require.resolve` instead of a relative path string:**
Since `design-system-shared` is a direct dep of the preset, `require.resolve` finds it from the preset's own dep graph — not the consumer's. This is hoisting-safe regardless of how the consumer's `node_modules` is structured.

**Why not a safelist:**
A safelist would need to grow manually as more token-identity constants move into `design-system-shared` (e.g. Box color constants). The `content` scanning approach scales automatically — new constants are picked up without any changes to this file.

Also documents the architectural decision in `.cursor/rules/` (token-identity vs semantic-value const objects, and the content scanning mechanism).

## **Related issues**

Fixes: #1071

Related: MetaMask/metamask-extension#41662 — once consumers upgrade to this preset version, the manual `@metamask/design-system-shared` content glob and direct dependency added in that PR can be removed.

## **Manual testing steps**

1. Build the preset: `yarn workspace @metamask/design-system-tailwind-preset run build`
2. Build Storybook: `yarn workspace @metamask/storybook-react run build-storybook`
3. Confirm `TextColor` utility classes (e.g. `text-default`, `text-primary-default`, `text-error-default`) are present in the generated CSS without `design-system-shared` in the app's own `content` glob

## **Screenshots/Recordings**

### **Before**

Consumers required:
```js
content: [
  './node_modules/@metamask/design-system-react/**/*.{mjs,cjs}',
  './node_modules/@metamask/design-system-shared/**/*.{mjs,cjs}', // manual, fragile
]
```

### **After**

Consumers only need:
```js
content: [
  './node_modules/@metamask/design-system-react/**/*.{mjs,cjs}',
  // design-system-shared covered automatically by the preset
]
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Tailwind `content` scanning behavior and package dependencies, which can affect generated CSS and downstream builds, but the change is narrowly scoped to the preset and covered by a new test.
> 
> **Overview**
> Fixes Tailwind JIT class generation for token-identity constants coming from `@metamask/design-system-shared` by making it a direct dependency of `@metamask/design-system-tailwind-preset` and adding a hoisting-safe `content` glob that resolves the shared package’s `dist` via `require.resolve`.
> 
> Adds a regression test asserting the preset’s `content` includes the shared `dist` path, and documents the *token-identity vs semantic-value* constant pattern plus the new scanning mechanism in `.cursor/rules`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b7617e9b23b02c49d539020601b9203835117c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->