### PR TITLE
docs(cursor): document optional ReactNode slots and testing conventions

### DIFF
--- a/.cursor/rules/component-architecture.md
+++ b/.cursor/rules/component-architecture.md
@@ -209,6 +209,17 @@ Both `Input` and `Text` are _consumers_ of `TextVariant` — neither owns it. Im
 - [ ] NO className/twClassName in shared package
 - [ ] NO unified event handlers in shared package
 
+## Optional slot rendering (`ReactNode`)
+
+Optional layout slots (accessories, labels, end nodes) are usually **strings or elements**. Use **standard React conditional rendering** only (`{optionalSlot}`, `condition && <Subtree />`, ternaries). **Do not** add shared `ReactNode` guard helpers.
+
+- **PREFER** `{optionalSlot}` when `null`, `undefined`, and `false` are acceptable and you do not need to skip mounting a subtree.
+- **PREFER** `condition && <Subtree />` when the subtree should not mount unless `condition` is truthy.
+- **PREFER** avoiding redundant patterns such as `x && x` (same expression twice); use `x` or `condition && x` once.
+- **NOTE:** The left-hand side of `&&` must be chosen deliberately if numeric `0` could appear and you mean “hide”; for typical string/element slots, idiomatic React patterns are sufficient.
+
+**Related:** @.cursor/rules/testing.md — how to test optional slots without speculative edge-case suites.
+
 ## Golden Path: BadgeStatus
 
 **BadgeStatus is THE proof-of-concept for ADR-0003 and ADR-0004. Always reference when in doubt.**
@@ -232,6 +243,7 @@ Both `Input` and `Text` are _consumers_ of `TextVariant` — neither owns it. Im
 - @.cursor/rules/component-migration.md - Extension/mobile migration workflow
 - @.cursor/rules/component-enum-union-migration.md - Internal ADR migration
 - @.cursor/rules/styling.md - Design tokens and styling patterns
+- @.cursor/rules/testing.md - Optional `ReactNode` / slot testing conventions
 
 ### MetaMask Standards
 

--- a/.cursor/rules/testing.md
+++ b/.cursor/rules/testing.md
@@ -10,6 +10,7 @@ This rule defines testing patterns for design system components to ensure:
 - 100% coverage thresholds are met consistently
 - Style assertions use built-in matchers (not duplicated helpers)
 - Tests remain maintainable as components evolve
+- Optional slot tests stay proportional to the documented API (no speculative edge-case suites)
 
 ## Critical Rules
 
@@ -47,6 +48,15 @@ render(<Button onPress={onPress} />);
 fireEvent.press(getByTestId('button'));
 expect(onPress).toHaveBeenCalledTimes(1);
 ```
+
+### Optional `ReactNode` / slot props
+
+Optional slots (accessories, labels, custom rows) are usually **strings or elements**. Tests should lock in the **public contract**, not every theoretical `ReactNode` value.
+
+- **ALWAYS** cover documented usage: prop **omitted** or `undefined`, meaningful **string** or **element** content, and **`false`** when callers rely on it to hide a slot (common with React conditional patterns).
+- **NEVER** add tests for undocumented exotic values (for example numeric `0`, or empty-string edge cases) unless the component README/types explicitly support them or you are fixing a **documented** regression.
+- **NEVER** add test helpers or micro-test suites to debate conditional rendering mechanics (`&&`, ternaries, `{node}`) versus shared `ReactNode` guard utilities. Those helpers are not part of this design system. Assert **observable** outcomes only. Optional-slot patterns live in @.cursor/rules/component-architecture.md.
+- **PREFER** one high-signal test per branch for mutual exclusion or priority (for example label vs accessory) instead of permuting many falsy types.
 
 ### Query and Assertion Conventions
 
@@ -228,6 +238,7 @@ After adding or updating tests, verify:
 - https://github.com/MetaMask/contributor-docs/blob/main/docs/testing/unit-testing.md
 - https://github.com/MetaMask/metamask-extension/tree/main/.cursor/rules/unit-testing-guidelines
 - https://github.com/MetaMask/metamask-mobile/blob/main/.cursor/rules/unit-testing-guidelines.mdc
+- @.cursor/rules/component-architecture.md
 - @.cursor/rules/styling.md
 - @packages/design-system-react-native/jest.config.js
 - @packages/design-system-react-native/jest.setup.js


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates Cursor rules only (no runtime or package code).

1. **Reason:** Contributors were unclear how optional layout slots (`ReactNode` props) should be implemented and tested. Without shared guidance, reviews can oscillate between ad-hoc patterns, redundant conditionals, and oversized “every falsy type” test suites.

2. **Improvement / solution:**
   - **`component-architecture.md`:** Documents that optional slots should use normal React conditional rendering (`{slot}`, `condition && <…>`, ternaries), discourages shared `ReactNode` guard helpers, calls out redundant `x && x`, and notes the numeric `0` caveat for `&&`. Links to the testing rule for how to test slots proportionally.
   - **`testing.md`:** Adds conventions for optional slot tests: assert the public contract (omitted/`undefined`, string/element, `false` to hide where that’s the API), avoid undocumented exotic values and micro-suites around conditional mechanics, prefer one high-signal test for mutual exclusion (e.g. label vs accessory). Cross-links back to `component-architecture.md`.

## **Related issues**

Fixes: N/A 

## **Manual testing steps**

1. Open `.cursor/rules/component-architecture.md` and confirm the new **Optional slot rendering (`ReactNode`)** section reads clearly and the **Related Cursor Rules** link to `testing.md` is correct.
2. Open `.cursor/rules/testing.md` and confirm the **Optional `ReactNode` / slot props** subsection aligns with the architecture doc and the **References** link to `component-architecture.md` is correct.
3. (Optional) In a scratch component or review, sanity-check that the guidance matches how you want `TitleStandard`-style slots implemented and tested.

## **Screenshots/Recordings**

N/A — Markdown-only changes to repository Cursor rules.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable (N/A — documentation-only)
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A — Markdown rules, not application code)
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Cursor rule documentation and add no runtime behavior. Risk is primarily guidance drift (teams adopting the new conventions inconsistently).
> 
> **Overview**
> Adds explicit Cursor rule guidance for **optional `ReactNode` layout slots**: prefer idiomatic React conditional rendering (`{slot}`, `condition && <Subtree />`, ternaries), avoid redundant patterns like `x && x`, and discourage shared `ReactNode` guard helpers (with a note about `0` + `&&`).
> 
> Updates the testing rules to define **proportional slot test coverage** (omit/`undefined`, meaningful string/element, `false` to hide when relied upon) while discouraging speculative edge-case suites and conditional-rendering helper debates, and cross-links the two docs for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8cddcf83bb80cfb10a64ea45e19d3fcf1263eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->