### PR TITLE
docs: `TextField` migration

### DIFF
--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -16,6 +16,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [Text Component](#text-component)
   - [Icon Component](#icon-component)
   - [Checkbox Component](#checkbox-component)
+  - [TextField Component](#textfield-component)
 - [Version Updates](#version-updates)
   - [From version 0.18.0 to 0.19.0](#from-version-0180-to-0190)
   - [From version 0.16.0 to 0.17.0](#from-version-0160-to-0170)
@@ -1576,6 +1577,206 @@ import { Checkbox } from '@metamask/design-system-react-native';
 - MMDS `Checkbox` adds `twClassName` and `style` on the outer `Pressable`, plus `checkboxContainerProps` and `checkedIconProps` for targeted customization.
 - Mobile legacy `Checkbox` forwarded `TouchableOpacityProps`; MMDS forwards `PressableProps`.
 - Imperative `ref.toggle()` remains available in MMDS.
+
+### TextField Component
+
+The TextField component in `@metamask/design-system-react-native` is a near-identical replacement for the mobile `component-library` TextField. The core props API is preserved; the main changes are the import path, styling system (TWRNC instead of `useStyles`), and two new customization props.
+
+#### Breaking Changes
+
+##### Import Path
+
+| Mobile Pattern | Design System Migration |
+| --- | --- |
+| `import TextField from '.../component-library/components/Form/TextField'` | `import { TextField } from '@metamask/design-system-react-native'` |
+| `import TextField from '.../component-library/components/Form/TextField/TextField'` | `import { TextField } from '@metamask/design-system-react-native'` |
+| `import { TextFieldProps } from '.../component-library/components/Form/TextField/TextField.types'` | `import type { TextFieldProps } from '@metamask/design-system-react-native'` |
+
+The mobile component uses a **default export**; the design system uses a **named export**.
+
+##### `testID` Target Changed
+
+| Mobile Behavior | Design System Behavior |
+| --- | --- |
+| `testID` is forwarded to the inner `Input` (the `TextInput`) | `testID` is applied to the root `Pressable` container |
+
+If your tests rely on `testID` to query the native `TextInput` (e.g. for `fireEvent.changeText`), you may need to adjust your test selectors. The inner `Input` in the design system component does not receive a separate `testID` by default.
+
+##### Accessory Wrapper Removed
+
+| Mobile Behavior | Design System Behavior |
+| --- | --- |
+| `startAccessory` and `endAccessory` are each wrapped in a `<View>` with a dedicated `testID` (`textfield-startacccessory`, `textfield-endacccessory`) | Accessories are rendered directly as children of the `Pressable` — no wrapper `<View>`, no dedicated `testID` |
+
+If your tests query `textfield-startacccessory` or `textfield-endacccessory`, set `testID` on the accessory element itself:
+
+```tsx
+// Before (Mobile)
+<TextField startAccessory={<Icon name={IconName.Search} />} />
+// Test: getByTestId('textfield-startacccessory')
+
+// After (Design System)
+<TextField startAccessory={<Icon name={IconName.Search} testID="search-icon" />} />
+// Test: getByTestId('search-icon')
+```
+
+##### `style` Prop Type Changed
+
+| Mobile Behavior | Design System Behavior |
+| --- | --- |
+| `style` is passed into `useStyles` and merged into the container style sheet | `style` is typed as `StyleProp<ViewStyle>` and applied as an array alongside the TWRNC container style |
+
+Most inline `style` overrides will continue to work. However, if you were relying on the old `useStyles` merge behavior (where `style` could influence border, background, or other sheet-level vars), verify that the override still applies correctly.
+
+##### Accessibility: `accessible={false}` on Container
+
+The design system TextField sets `accessible={false}` on the root `Pressable`. The mobile version does not set this. This means the container itself is not announced as an accessible element — only the inner `TextInput` is. This is generally the correct behavior but may affect custom accessibility setups.
+
+#### Unchanged Props
+
+These props work identically in both versions — no migration needed:
+
+| Prop | Type | Notes |
+| --- | --- | --- |
+| `value` | `string` | Controlled input value |
+| `placeholder` | `string` | Placeholder text |
+| `onChangeText` | `(text: string) => void` | Text change handler |
+| `onFocus` | `(e) => void` | Focus handler (skipped when disabled) |
+| `onBlur` | `(e) => void` | Blur handler (skipped when disabled) |
+| `isError` | `boolean` | Error border state |
+| `isDisabled` | `boolean` | Disabled state (opacity + no interaction) |
+| `isReadonly` | `boolean` | Read-only state |
+| `autoFocus` | `boolean` | Auto-focus on mount |
+| `startAccessory` | `ReactNode` | Content before the input |
+| `endAccessory` | `ReactNode` | Content after the input |
+| `inputElement` | `ReactNode` | Custom input replacement |
+| `ref` | `Ref<TextInput>` | Forwarded to inner TextInput |
+| `numberOfLines` | Forced to `1` | Single-line enforced |
+| `multiline` | Forced to `false` | Single-line enforced |
+| All `TextInputProps` | Various | Spread to inner Input |
+
+#### New Props (Design System Only)
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `twClassName` | `string` | TWRNC utility classes merged into the container style |
+| `style` | `StyleProp<ViewStyle>` | React Native style applied to the container (array-merged) |
+
+#### Styling Differences
+
+The design system TextField uses TWRNC (Tailwind React Native CSS) instead of the `useStyles`/`StyleSheet` approach:
+
+| Concern | Mobile | Design System |
+| --- | --- | --- |
+| Styling system | `useStyles` hook + `StyleSheet.create` | `useTailwind()` + `tw.style()` |
+| Border radius | `12px` | `8px` (`rounded-lg`) |
+| Background | `theme.colors.background.muted` | `bg-muted` (equivalent token) |
+| Disabled opacity | `0.5` | `0.5` (identical) |
+| Height | `48px` | `48px` (identical) |
+| Horizontal padding | `16px` | `16px` (`px-4`, identical) |
+| Accessory gap | `marginRight/Left: 12` | `gap-3` (12px, identical) |
+
+The `border-radius` change from `12px` to `8px` is the most visible visual difference.
+
+#### Migration Examples
+
+##### Basic TextField
+
+Before (Mobile):
+
+```tsx
+import TextField from '../../../component-library/components/Form/TextField';
+
+<TextField
+  value={name}
+  onChangeText={setName}
+  placeholder="Enter name"
+  testID="name-input"
+/>;
+```
+
+After (Design System):
+
+```tsx
+import { TextField } from '@metamask/design-system-react-native';
+
+<TextField
+  value={name}
+  onChangeText={setName}
+  placeholder="Enter name"
+  testID="name-input"
+/>;
+```
+
+##### TextField with Accessories and Error
+
+Before (Mobile):
+
+```tsx
+import TextField from '../../../component-library/components/Form/TextField';
+
+<TextField
+  ref={inputRef}
+  value={url}
+  onChangeText={setUrl}
+  placeholder="https://example.com"
+  isError={hasError}
+  autoCapitalize="none"
+  autoCorrect={false}
+  startAccessory={<Icon name={IconName.Link} />}
+  endAccessory={<Icon name={IconName.Close} onPress={handleClear} />}
+/>;
+```
+
+After (Design System):
+
+```tsx
+import { TextField } from '@metamask/design-system-react-native';
+
+<TextField
+  ref={inputRef}
+  value={url}
+  onChangeText={setUrl}
+  placeholder="https://example.com"
+  isError={hasError}
+  autoCapitalize="none"
+  autoCorrect={false}
+  startAccessory={<Icon name={IconName.Link} />}
+  endAccessory={<Icon name={IconName.Close} onPress={handleClear} />}
+/>;
+```
+
+##### TextField with Type Import
+
+Before (Mobile):
+
+```tsx
+import TextField from '../../../component-library/components/Form/TextField';
+import { TextFieldProps } from '../../../component-library/components/Form/TextField/TextField.types';
+
+const MyInput: React.FC<TextFieldProps> = (props) => (
+  <TextField {...props} autoCapitalize="none" autoCorrect={false} />
+);
+```
+
+After (Design System):
+
+```tsx
+import { TextField } from '@metamask/design-system-react-native';
+import type { TextFieldProps } from '@metamask/design-system-react-native';
+
+const MyInput: React.FC<TextFieldProps> = (props) => (
+  <TextField {...props} autoCapitalize="none" autoCorrect={false} />
+);
+```
+
+#### API Differences
+
+- MMDS `TextField` adds `twClassName` for Tailwind-based style overrides and a `style` prop typed as `StyleProp<ViewStyle>`.
+- Mobile legacy `TextField` wrapped accessories in `<View>` elements with hardcoded `testID`s; MMDS renders accessories directly.
+- The `testID` prop targets the root `Pressable` in MMDS vs. the inner `TextInput` in the mobile version.
+- MMDS sets `accessible={false}` on the root `Pressable`; the mobile version does not.
+- Border radius is `8px` in MMDS vs. `12px` in the mobile version.
 
 ## Version Updates
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -1586,26 +1586,26 @@ The TextField component in `@metamask/design-system-react-native` is a near-iden
 
 ##### Import Path
 
-| Mobile Pattern | Design System Migration |
-| --- | --- |
-| `import TextField from '.../component-library/components/Form/TextField'` | `import { TextField } from '@metamask/design-system-react-native'` |
-| `import TextField from '.../component-library/components/Form/TextField/TextField'` | `import { TextField } from '@metamask/design-system-react-native'` |
+| Mobile Pattern                                                                                     | Design System Migration                                                      |
+| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `import TextField from '.../component-library/components/Form/TextField'`                          | `import { TextField } from '@metamask/design-system-react-native'`           |
+| `import TextField from '.../component-library/components/Form/TextField/TextField'`                | `import { TextField } from '@metamask/design-system-react-native'`           |
 | `import { TextFieldProps } from '.../component-library/components/Form/TextField/TextField.types'` | `import type { TextFieldProps } from '@metamask/design-system-react-native'` |
 
 The mobile component uses a **default export**; the design system uses a **named export**.
 
 ##### `testID` Target Changed
 
-| Mobile Behavior | Design System Behavior |
-| --- | --- |
+| Mobile Behavior                                              | Design System Behavior                                |
+| ------------------------------------------------------------ | ----------------------------------------------------- |
 | `testID` is forwarded to the inner `Input` (the `TextInput`) | `testID` is applied to the root `Pressable` container |
 
 If your tests rely on `testID` to query the native `TextInput` (e.g. for `fireEvent.changeText`), you may need to adjust your test selectors. The inner `Input` in the design system component does not receive a separate `testID` by default.
 
 ##### Accessory Wrapper Removed
 
-| Mobile Behavior | Design System Behavior |
-| --- | --- |
+| Mobile Behavior                                                                                                                                       | Design System Behavior                                                                                        |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `startAccessory` and `endAccessory` are each wrapped in a `<View>` with a dedicated `testID` (`textfield-startacccessory`, `textfield-endacccessory`) | Accessories are rendered directly as children of the `Pressable` — no wrapper `<View>`, no dedicated `testID` |
 
 If your tests query `textfield-startacccessory` or `textfield-endacccessory`, set `testID` on the accessory element itself:
@@ -1622,8 +1622,8 @@ If your tests query `textfield-startacccessory` or `textfield-endacccessory`, se
 
 ##### `style` Prop Type Changed
 
-| Mobile Behavior | Design System Behavior |
-| --- | --- |
+| Mobile Behavior                                                              | Design System Behavior                                                                                 |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `style` is passed into `useStyles` and merged into the container style sheet | `style` is typed as `StyleProp<ViewStyle>` and applied as an array alongside the TWRNC container style |
 
 Most inline `style` overrides will continue to work. However, if you were relying on the old `useStyles` merge behavior (where `style` could influence border, background, or other sheet-level vars), verify that the override still applies correctly.
@@ -1636,45 +1636,45 @@ The design system TextField sets `accessible={false}` on the root `Pressable`. T
 
 These props work identically in both versions — no migration needed:
 
-| Prop | Type | Notes |
-| --- | --- | --- |
-| `value` | `string` | Controlled input value |
-| `placeholder` | `string` | Placeholder text |
-| `onChangeText` | `(text: string) => void` | Text change handler |
-| `onFocus` | `(e) => void` | Focus handler (skipped when disabled) |
-| `onBlur` | `(e) => void` | Blur handler (skipped when disabled) |
-| `isError` | `boolean` | Error border state |
-| `isDisabled` | `boolean` | Disabled state (opacity + no interaction) |
-| `isReadonly` | `boolean` | Read-only state |
-| `autoFocus` | `boolean` | Auto-focus on mount |
-| `startAccessory` | `ReactNode` | Content before the input |
-| `endAccessory` | `ReactNode` | Content after the input |
-| `inputElement` | `ReactNode` | Custom input replacement |
-| `ref` | `Ref<TextInput>` | Forwarded to inner TextInput |
-| `numberOfLines` | Forced to `1` | Single-line enforced |
-| `multiline` | Forced to `false` | Single-line enforced |
-| All `TextInputProps` | Various | Spread to inner Input |
+| Prop                 | Type                     | Notes                                     |
+| -------------------- | ------------------------ | ----------------------------------------- |
+| `value`              | `string`                 | Controlled input value                    |
+| `placeholder`        | `string`                 | Placeholder text                          |
+| `onChangeText`       | `(text: string) => void` | Text change handler                       |
+| `onFocus`            | `(e) => void`            | Focus handler (skipped when disabled)     |
+| `onBlur`             | `(e) => void`            | Blur handler (skipped when disabled)      |
+| `isError`            | `boolean`                | Error border state                        |
+| `isDisabled`         | `boolean`                | Disabled state (opacity + no interaction) |
+| `isReadonly`         | `boolean`                | Read-only state                           |
+| `autoFocus`          | `boolean`                | Auto-focus on mount                       |
+| `startAccessory`     | `ReactNode`              | Content before the input                  |
+| `endAccessory`       | `ReactNode`              | Content after the input                   |
+| `inputElement`       | `ReactNode`              | Custom input replacement                  |
+| `ref`                | `Ref<TextInput>`         | Forwarded to inner TextInput              |
+| `numberOfLines`      | Forced to `1`            | Single-line enforced                      |
+| `multiline`          | Forced to `false`        | Single-line enforced                      |
+| All `TextInputProps` | Various                  | Spread to inner Input                     |
 
 #### New Props (Design System Only)
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| `twClassName` | `string` | TWRNC utility classes merged into the container style |
-| `style` | `StyleProp<ViewStyle>` | React Native style applied to the container (array-merged) |
+| Prop          | Type                   | Description                                                |
+| ------------- | ---------------------- | ---------------------------------------------------------- |
+| `twClassName` | `string`               | TWRNC utility classes merged into the container style      |
+| `style`       | `StyleProp<ViewStyle>` | React Native style applied to the container (array-merged) |
 
 #### Styling Differences
 
 The design system TextField uses TWRNC (Tailwind React Native CSS) instead of the `useStyles`/`StyleSheet` approach:
 
-| Concern | Mobile | Design System |
-| --- | --- | --- |
-| Styling system | `useStyles` hook + `StyleSheet.create` | `useTailwind()` + `tw.style()` |
-| Border radius | `12px` | `8px` (`rounded-lg`) |
-| Background | `theme.colors.background.muted` | `bg-muted` (equivalent token) |
-| Disabled opacity | `0.5` | `0.5` (identical) |
-| Height | `48px` | `48px` (identical) |
-| Horizontal padding | `16px` | `16px` (`px-4`, identical) |
-| Accessory gap | `marginRight/Left: 12` | `gap-3` (12px, identical) |
+| Concern            | Mobile                                 | Design System                  |
+| ------------------ | -------------------------------------- | ------------------------------ |
+| Styling system     | `useStyles` hook + `StyleSheet.create` | `useTailwind()` + `tw.style()` |
+| Border radius      | `12px`                                 | `8px` (`rounded-lg`)           |
+| Background         | `theme.colors.background.muted`        | `bg-muted` (equivalent token)  |
+| Disabled opacity   | `0.5`                                  | `0.5` (identical)              |
+| Height             | `48px`                                 | `48px` (identical)             |
+| Horizontal padding | `16px`                                 | `16px` (`px-4`, identical)     |
+| Accessory gap      | `marginRight/Left: 12`                 | `gap-3` (12px, identical)      |
 
 The `border-radius` change from `12px` to `8px` is the most visible visual difference.
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Added migration docs for `TextField` component.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-278

## **Manual testing steps**

1. Go repo
2. Check `MIGRATION.MD` file

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

<img width="1042" height="917" alt="image" src="https://github.com/user-attachments/assets/103f0aa4-e2e3-4591-b0c2-621a23d20f41" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime or API behavior modifications; risk is limited to potential confusion if the guidance is incorrect.
> 
> **Overview**
> Adds migration documentation for `TextField` in `packages/design-system-react-native/MIGRATION.md`, including import-path changes (default export → named export) and explicit callouts for behavior differences that can break tests (root `testID` target and removal of accessory wrapper `testID`s).
> 
> Documents design-system-only customization props (`twClassName`, container `style`), accessibility behavior (`accessible={false}` on the container), and a notable visual change (border radius), plus concrete before/after code examples for common usage patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdb366df50cd32c542c6c3962cc3066889ab824e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->