### PR TITLE
docs: `ButtonFilter` migration guide

### DIFF
--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -7,6 +7,7 @@ This guide provides detailed instructions for migrating your project from one ve
 - [From Mobile Component Library](#from-mobile-component-library)
   - [Button Component](#button-component)
   - [ButtonBase Component](#buttonbase-component)
+  - [ButtonFilter Component](#buttonfilter-component)
   - [ButtonHero Component](#buttonhero-component)
   - [BottomSheet Component](#bottomsheet-component)
   - [BottomSheetHeader Component](#bottomsheetheader-component)
@@ -742,6 +743,86 @@ import { IconName } from '@metamask/design-system-react-native';
   {energyLabel}
 </ButtonBase>;
 ```
+
+### ButtonFilter Component
+
+The `ButtonFilter` component is a filter-chip style button that toggles between active/inactive visual states. The legacy version in `components-temp` already wraps `ButtonBase` from `@metamask/design-system-react-native`, so the migration is primarily an import change.
+
+#### Breaking Changes
+
+##### Import Path
+
+| Mobile Pattern                                                                  | Design System Migration                                               |
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `import ButtonFilter from '.../component-library/components-temp/ButtonFilter'` | `import { ButtonFilter } from '@metamask/design-system-react-native'` |
+
+Note: The legacy component uses a **default export**; the design system uses a **named export**.
+
+##### `textClassName` → `textProps.twClassName`
+
+The legacy `ButtonFilter` accepted `textClassName` as a pressed-state-aware function `(pressed: boolean) => string`. The design system version removes `textClassName` from the prop surface entirely and manages text styling internally based on `isActive`. If you need text overrides, use `textProps.twClassName` instead.
+
+| Mobile Pattern                                | Design System Migration                       |
+| --------------------------------------------- | --------------------------------------------- |
+| `textClassName={(pressed) => 'text-default'}` | Remove — handled automatically by `isActive`  |
+| Custom text class overrides                   | `textProps={{ twClassName: 'custom-class' }}` |
+
+##### `twClassName` Type Change
+
+The legacy version inherited `twClassName` as `string | ((pressed: boolean) => string)` from `ButtonBaseProps`. The design system `ButtonFilter` narrows `twClassName` to `string` only (no pressed-state function).
+
+| Mobile Pattern                                       | Design System Migration                  |
+| ---------------------------------------------------- | ---------------------------------------- |
+| `twClassName="mt-2"`                                 | `twClassName="mt-2"` (unchanged)         |
+| `twClassName={(pressed) => pressed ? '...' : '...'}` | Use `style` prop with a function instead |
+
+##### Props (Unchanged)
+
+These props work identically in both versions:
+
+- `isActive` — toggles between active (`bg-icon-default` + `text-icon-inverse`) and inactive (`bg-background-muted` + `text-default`) states
+- `children`, `size`, `isFullWidth`, `isDisabled`, `onPress`, `style`, `testID`
+- `accessibilityLabel`, `accessibilityRole`
+
+#### Migration Examples
+
+##### Filter button group
+
+Before (Mobile):
+
+```tsx
+import ButtonFilter from '../../../component-library/components-temp/ButtonFilter';
+import { ButtonSize } from '@metamask/design-system-react-native';
+
+<ButtonFilter
+  onPress={() => setFilter('ALL')}
+  isActive={filter === 'ALL'}
+  size={ButtonSize.Md}
+  accessibilityLabel="All"
+>
+  All
+</ButtonFilter>;
+```
+
+After (Design System):
+
+```tsx
+import {
+  ButtonFilter,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
+
+<ButtonFilter
+  onPress={() => setFilter('ALL')}
+  isActive={filter === 'ALL'}
+  size={ButtonBaseSize.Md}
+  accessibilityLabel="All"
+>
+  All
+</ButtonFilter>;
+```
+
+Note: `ButtonFilter` inherits its size prop from `ButtonBaseProps`. Use `ButtonBaseSize` (or the `ButtonSize` alias).
 
 ### ButtonHero Component
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -771,9 +771,9 @@ The legacy `ButtonFilter` accepted `textClassName` as a pressed-state-aware func
 
 The legacy version inherited `twClassName` as `string | ((pressed: boolean) => string)` from `ButtonBaseProps`. The design system `ButtonFilter` narrows `twClassName` to `string` only (no pressed-state function).
 
-| Mobile Pattern                                       | Design System Migration                  |
-| ---------------------------------------------------- | ---------------------------------------- |
-| `twClassName="mt-2"`                                 | `twClassName="mt-2"` (unchanged)         |
+| Mobile Pattern                                       | Design System Migration                                       |
+| ---------------------------------------------------- | ------------------------------------------------------------- |
+| `twClassName="mt-2"`                                 | `twClassName="mt-2"` (unchanged)                              |
 | `twClassName={(pressed) => pressed ? '...' : '...'}` | Remove — pressed styling is handled internally via `isActive` |
 
 ##### Props (Unchanged)

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -774,7 +774,7 @@ The legacy version inherited `twClassName` as `string | ((pressed: boolean) => s
 | Mobile Pattern                                       | Design System Migration                  |
 | ---------------------------------------------------- | ---------------------------------------- |
 | `twClassName="mt-2"`                                 | `twClassName="mt-2"` (unchanged)         |
-| `twClassName={(pressed) => pressed ? '...' : '...'}` | Use `style` prop with a function instead |
+| `twClassName={(pressed) => pressed ? '...' : '...'}` | Remove — pressed styling is handled internally via `isActive` |
 
 ##### Props (Unchanged)
 

--- a/packages/design-system-react-native/src/components/ButtonFilter/README.md
+++ b/packages/design-system-react-native/src/components/ButtonFilter/README.md
@@ -43,3 +43,7 @@ const [activeFilter, setActiveFilter] = useState('All');
   Sold
 </ButtonFilter>
 ```
+
+## Migration from MetaMask Mobile Component Library
+
+Migrating from the legacy `ButtonFilter` in `app/component-library/components-temp/ButtonFilter`? See the [ButtonFilter migration guide](../../MIGRATION.md#buttonfilter-component) for import changes and `textClassName` behavior differences.

--- a/packages/design-system-react-native/src/components/ButtonFilter/README.md
+++ b/packages/design-system-react-native/src/components/ButtonFilter/README.md
@@ -46,4 +46,4 @@ const [activeFilter, setActiveFilter] = useState('All');
 
 ## Migration from MetaMask Mobile Component Library
 
-Migrating from the legacy `ButtonFilter` in `app/component-library/components-temp/ButtonFilter`? See the [ButtonFilter migration guide](../../MIGRATION.md#buttonfilter-component) for import changes and `textClassName` behavior differences.
+Migrating from the legacy `ButtonFilter` in `app/component-library/components-temp/ButtonFilter`? See the [ButtonFilter migration guide](../../../MIGRATION.md#buttonfilter-component) for import changes and `textClassName` behavior differences.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Added `ButtonFilter` migration documentation.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-637

## **Manual testing steps**

1. Open Readme
2. Check migration instructions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

<img width="1031" height="865" alt="Screenshot 2026-04-10 at 18 55 05" src="https://github.com/user-attachments/assets/46b36496-37de-448f-b1b6-d9c18d2a4aca" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or API behavior is modified, but guidance accuracy affects downstream migrations.
> 
> **Overview**
> Adds a new **`ButtonFilter`** section to `MIGRATION.md`, documenting how to migrate from the Mobile component-library version to the design system (named vs default export, removal of `textClassName`, and `twClassName` narrowing to a string).
> 
> Updates the `ButtonFilter` component README to include a direct link to the new migration guide section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820c9ef485e00d1153fe60870b61eab184f16328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->