### PR TITLE
feat: add React 19 support to peer dependency ranges

### DIFF
--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -83,8 +83,8 @@
     "@metamask/design-system-tailwind-preset": "^0.6.0",
     "@metamask/design-tokens": "^8.1.0",
     "@metamask/utils": "^11.11.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -60,7 +60,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,8 +3436,8 @@ __metadata:
     "@metamask/design-system-tailwind-preset": ^0.6.0
     "@metamask/design-tokens": ^8.1.0
     "@metamask/utils": ^11.11.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -3456,7 +3456,7 @@ __metadata:
     ts-jest: "npm:^29.2.5"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    react: ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -5695,8 +5695,8 @@ __metadata:
   linkType: hard
 
 "@testing-library/react@npm:^16.0.1":
-  version: 16.1.0
-  resolution: "@testing-library/react@npm:16.1.0"
+  version: 16.3.2
+  resolution: "@testing-library/react@npm:16.3.2"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
   peerDependencies:
@@ -5710,7 +5710,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/2a20e0dbfadbc93d45a84e82281ed47deed54a6a5fc1461a523172d7fbc0481e8502cf98a2080f38aba94290b3d745671a1c9e320e6f76ad6afcca67c580b963
+  checksum: 10/0ca88c6f672d00c2afd1bdedeff9b5382dd8157038efeb9762dc016731030075624be7106b92d2b5e5c52812faea85263e69272c14b6f8700eb48a4a8af6feef
   languageName: node
   linkType: hard
 
@@ -7402,6 +7402,13 @@ __metadata:
   version: 1.0.0
   resolution: "async-function@npm:1.0.0"
   checksum: 10/1a09379937d846f0ce7614e75071c12826945d4e417db634156bf0e4673c495989302f52186dfa9767a1d9181794554717badd193ca2bbab046ef1da741d8efd
+  languageName: node
+  linkType: hard
+
+"async-generator-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-generator-function@npm:1.0.0"
+  checksum: 10/3d49e7acbeee9e84537f4cb0e0f91893df8eba976759875ae8ee9e3d3c82f6ecdebdb347c2fad9926b92596d93cdfc78ecc988bcdf407e40433e8e8e6fe5d78e
   languageName: node
   linkType: hard
 
@@ -12200,6 +12207,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generator-function@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "generator-function@npm:2.0.1"
+  checksum: 10/eb7e7eb896c5433f3d40982b2ccacdb3dd990dd3499f14040e002b5d54572476513be8a2e6f9609f6e41ab29f2c4469307611ddbfc37ff4e46b765c326663805
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -12215,20 +12229,23 @@ __metadata:
   linkType: hard
 
 "get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.1, get-intrinsic@npm:^1.2.2, get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "get-intrinsic@npm:1.3.0"
+  version: 1.3.1
+  resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
+    async-function: "npm:^1.0.0"
+    async-generator-function: "npm:^1.0.0"
     call-bind-apply-helpers: "npm:^1.0.2"
     es-define-property: "npm:^1.0.1"
     es-errors: "npm:^1.3.0"
     es-object-atoms: "npm:^1.1.1"
     function-bind: "npm:^1.1.2"
+    generator-function: "npm:^2.0.0"
     get-proto: "npm:^1.0.1"
     gopd: "npm:^1.2.0"
     has-symbols: "npm:^1.1.0"
     hasown: "npm:^2.0.2"
     math-intrinsics: "npm:^1.1.0"
-  checksum: 10/6e9dd920ff054147b6f44cb98104330e87caafae051b6d37b13384a45ba15e71af33c3baeac7cb630a0aaa23142718dcf25b45cfdd86c184c5dcb4e56d953a10
+  checksum: 10/bb579dda84caa4a3a41611bdd483dade7f00f246f2a7992eb143c5861155290df3fdb48a8406efa3dfb0b434e2c8fafa4eebd469e409d0439247f85fc3fa2cc1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Widens `peerDependencies` for `@metamask/design-system-react` and `@metamask/design-system-shared` to accept React 19 (`^19.0.0`) alongside existing React 17 and 18 support.

https://react.dev/blog/2024/04/25/react-19-upgrade-guide

### Audit Summary

A full audit of React 19 breaking changes was performed against the codebase. No breaking APIs are used:

| Breaking Change | Impact |
|---|---|
| `forwardRef` deprecated (not removed) | **None** — still works at runtime, deprecation warnings only |
| `defaultProps` removed for function components | **None** — not used, already using ES6 defaults |
| `propTypes` removed | **None** — not used |
| String refs / Legacy Context / `createFactory` removed | **None** — not used |
| `ReactDOM.render` / `hydrate` / `findDOMNode` removed | **None** — not used |
| `react-dom/test-utils` removed | **None** — not imported |
| `useRef` requires argument | **None** — all usages already pass `null` |
| `Context.Provider` deprecated | **None** — only in react-native packages (not in scope) |

### Verification

- Temporarily upgraded `storybook-react` to React 19.2.5 and confirmed all components render correctly
- Build, tests (100% coverage), constraints, and lint all pass

### Future Phases

- **Phase 2**: Bump `@types/react` to v19, fix any TypeScript strictness issues
- **Phase 3**: Migrate `forwardRef` to `ref` as prop pattern (large refactor, not required for compat)

## **Related issues**

N/A

## **Manual testing steps**

1. Install packages in a React 19 project
2. Verify no peer dependency warnings
3. Verify components render correctly

## **Screenshots/Recordings**

### **Storybook running on React 19.2.5**

Components render correctly with React 19:

https://github.com/user-attachments/assets/6f8529e9-cea3-4732-98cc-5ed991d63adb


> Screenrecording captured with `storybook-react` temporarily using `react@^19.0.0` / `react-dom@^19.0.0`. Confirmed via `yarn why react` → `react@npm:19.2.5` for storybook-react workspace.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency/metadata-only changes (peer range widening and lockfile updates) with no runtime code changes; primary risk is consumers encountering React 19-specific issues that aren’t covered by existing tests.
> 
> **Overview**
> Adds React 19 compatibility by widening `peerDependencies` in `@metamask/design-system-react` (also `react-dom`) and `@metamask/design-system-shared` to allow `^19.0.0` alongside React 17/18.
> 
> Updates `yarn.lock` accordingly, including a bump of `@testing-library/react` to `16.3.2` and related transitive lockfile entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1a72f92ec5bee41ed0a71021e233f4491e2b48c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->