### PR TITLE
fix(react-native): align Icon props with SVG types

### DIFF
--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -80,7 +80,6 @@ No changes to visual appearance or API.
 **What Changed:**
 
 - `IconProps` now extends `Omit<SvgProps, 'color' | 'name'>` instead of `ViewProps`.
-- The component now forwards `hitSlop` as `hitSlop ?? undefined` to satisfy strict SVG prop typing.
 
 **Migration:**
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -75,6 +75,27 @@ The intermediate `Box` wrapper around the `BoxRow` in the left section has been 
 
 No changes to visual appearance or API.
 
+#### Icon: prop types now align with SVG usage
+
+**What Changed:**
+
+- `IconProps` now extends `Omit<SvgProps, 'color' | 'name'>` instead of `ViewProps`.
+- The component now forwards `hitSlop` as `hitSlop ?? undefined` to satisfy strict SVG prop typing.
+
+**Migration:**
+
+If TypeScript now flags props you were previously passing to `Icon`, those props were `View`-specific and are no longer part of the `Icon` public type. Move those props to a wrapper `View` and keep SVG-compatible props on `Icon`.
+
+```tsx
+// Before
+<Icon name={IconName.Lock} onLayout={handleLayout} />
+
+// After
+<View onLayout={handleLayout}>
+  <Icon name={IconName.Lock} />
+</View>
+```
+
 ---
 
 ### From version 0.16.0 to 0.17.0

--- a/packages/design-system-react-native/src/components/Icon/Icon.tsx
+++ b/packages/design-system-react-native/src/components/Icon/Icon.tsx
@@ -17,6 +17,7 @@ export const Icon = ({
 }: IconProps) => {
   const tw = useTailwind();
   const SVG = assetByIconName[name];
+  const { hitSlop, ...svgProps } = props;
   const twStyle = tw.style(
     color,
     TWCLASSMAP_ICON_SIZE_DIMENSION[size],
@@ -24,6 +25,12 @@ export const Icon = ({
   );
 
   return (
-    <SVG name={name} fill="currentColor" style={[twStyle, style]} {...props} />
+    <SVG
+      name={name}
+      fill="currentColor"
+      style={[twStyle, style]}
+      hitSlop={hitSlop ?? undefined}
+      {...svgProps}
+    />
   );
 };

--- a/packages/design-system-react-native/src/components/Icon/Icon.tsx
+++ b/packages/design-system-react-native/src/components/Icon/Icon.tsx
@@ -17,7 +17,6 @@ export const Icon = ({
 }: IconProps) => {
   const tw = useTailwind();
   const SVG = assetByIconName[name];
-  const { hitSlop, ...svgProps } = props;
   const twStyle = tw.style(
     color,
     TWCLASSMAP_ICON_SIZE_DIMENSION[size],
@@ -25,12 +24,6 @@ export const Icon = ({
   );
 
   return (
-    <SVG
-      name={name}
-      fill="currentColor"
-      style={[twStyle, style]}
-      hitSlop={hitSlop ?? undefined}
-      {...svgProps}
-    />
+    <SVG name={name} fill="currentColor" style={[twStyle, style]} {...props} />
   );
 };

--- a/packages/design-system-react-native/src/components/Icon/Icon.types.ts
+++ b/packages/design-system-react-native/src/components/Icon/Icon.types.ts
@@ -1,5 +1,4 @@
 import type React from 'react';
-import type { ViewProps } from 'react-native';
 import type { SvgProps } from 'react-native-svg';
 
 import type { IconColor, IconName, IconSize } from '../../types';
@@ -29,7 +28,7 @@ export type IconProps = {
    * Optional prop to add twrnc overriding classNames.
    */
   twClassName?: string;
-} & ViewProps;
+} & Omit<SvgProps, 'color' | 'name'>;
 
 /**
  * Asset stored by icon name


### PR DESCRIPTION
## **Description**

Cherry-picks the React Native `Icon` type fix out of [#844](https://github.com/MetaMask/metamask-design-system/pull/844) into a focused PR.

This updates `IconProps` to align with `react-native-svg` (`Omit<SvgProps, 'color' | 'name'>` instead of `ViewProps`).

Also adds migration guidance in `packages/design-system-react-native/MIGRATION.md` for consumers that were passing `View`-specific props to `Icon`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Pull this branch.
2. Open `packages/design-system-react-native/src/components/Icon/Icon.types.ts` and confirm `IconProps` extends `Omit<SvgProps, 'color' | 'name'>`.
3. Open `packages/design-system-react-native/MIGRATION.md` and confirm the new Icon migration note under `From version 0.18.0 to 0.19.0`.

## **Screenshots/Recordings**

N/A (type-only + docs update)

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
