### PR TITLE
docs: `TabEmptyState` migration (docs)

### DIFF
--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -2508,10 +2508,6 @@ The mobile `TabEmptyStateProps` extended `Omit<BoxProps, 'children'>`, so design
 
 Current `metamask-mobile` call sites only pass `testID`, `style`, `twClassName`, `children`, and the explicit slot props — none of them pass `Box` shorthands at the root — so this narrowing is a no-op for every known consumer. If you were relying on root `Box` props, move them to `twClassName` or wrap the component in a `<Box>`.
 
-##### Action Button: `self-center` Removed
-
-The deprecated wrapper applied `twClassName="self-center"` on the internal action `Button`. The design-system version drops it. The outer root sets `alignItems={BoxAlignItems.Center}` so the button stays centered in practice — the removed class was redundant in every current call site. Only consumers that forced a non-center `alignItems` via `actionButtonProps` would see a visual change; pass `actionButtonProps={{ twClassName: 'self-center' }}` explicitly if you need the old behavior.
-
 #### Migration Examples
 
 ##### Basic usage
@@ -2609,7 +2605,6 @@ Only the import specifier changes.
 #### API Differences Summary
 
 - Root prop type narrows from `Omit<BoxProps, 'children'>` to `ViewProps`. Move any root-level `Box` shorthands to `twClassName` or a wrapper `<Box>`.
-- Internal action `Button` no longer receives `twClassName="self-center"`. Re-add via `actionButtonProps={{ twClassName: 'self-center' }}` if a consumer overrides the outer `alignItems`.
 - All other props (`icon`, `description`, `descriptionProps`, `actionButtonText`, `actionButtonProps`, `onAction`, `children`, `twClassName`, `style`, `ViewProps`) are unchanged.
 
 ## Version Updates

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -22,6 +22,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [Checkbox Component](#checkbox-component)
   - [TextField Component](#textfield-component)
   - [ListItem Component](#listitem-component)
+  - [TabEmptyState Component](#tabemptystate-component)
 - [Version Updates](#version-updates)
   - [From version 0.18.0 to 0.19.0](#from-version-0180-to-0190)
   - [From version 0.16.0 to 0.17.0](#from-version-0160-to-0170)
@@ -2481,6 +2482,135 @@ The following mobile `component-library` sub-components build on `ListItem` but 
 - The mobile version sets `accessible accessibilityRole="none"` on the root element; MMDS does not.
 - The mobile version uses a default export; MMDS uses a named export.
 - `ListItemColumn`, `ListItemSelect`, and `ListItemMultiSelect` are not yet available in MMDS.
+
+### TabEmptyState Component
+
+`TabEmptyState` was previously incubated inside `metamask-mobile` at `app/component-library/components-temp/TabEmptyState` as a thin wrapper around `Box` / `Text` / `Button` from `@metamask/design-system-react-native`. It has graduated to the design system in `0.11.0` and the `components-temp` copy is now marked `@deprecated`. The public API (`icon`, `description`, `descriptionProps`, `actionButtonText`, `actionButtonProps`, `onAction`, `children`, `twClassName`, `style`) is preserved — the migration is essentially an import-path change.
+
+#### Breaking Changes
+
+##### Import Path
+
+| Mobile Pattern                                                                                  | Design System Migration                                                          |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `import { TabEmptyState } from '.../component-library/components-temp/TabEmptyState'`           | `import { TabEmptyState } from '@metamask/design-system-react-native'`           |
+| `import type { TabEmptyStateProps } from '.../component-library/components-temp/TabEmptyState'` | `import type { TabEmptyStateProps } from '@metamask/design-system-react-native'` |
+
+##### Root Props Narrowed from `BoxProps` to `ViewProps`
+
+The mobile `TabEmptyStateProps` extended `Omit<BoxProps, 'children'>`, so design-system `Box` props (`backgroundColor`, `flexDirection`, `alignItems`, `gap`, `padding`/`margin` shorthands, etc.) could be passed at the root. The design-system version intersects `ViewProps` only — standard React Native `View` props (`style`, `testID`, `accessibilityLabel`, …) are accepted, but `Box`-specific props are not.
+
+| Concern                                                                             | Mobile                       | Design System                                       |
+| ----------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------- |
+| Root type extension                                                                 | `Omit<BoxProps, 'children'>` | `ViewProps`                                         |
+| Root accepts `Box` shorthands at top level (`backgroundColor`, `gap`, `padding`, …) | ✅                           | ❌ — move these to `twClassName` or a wrapper `Box` |
+| Root accepts `ViewProps` (`style`, `testID`, …)                                     | ✅                           | ✅                                                  |
+
+Current `metamask-mobile` call sites only pass `testID`, `style`, `twClassName`, `children`, and the explicit slot props — none of them pass `Box` shorthands at the root — so this narrowing is a no-op for every known consumer. If you were relying on root `Box` props, move them to `twClassName` or wrap the component in a `<Box>`.
+
+##### Action Button: `self-center` Removed
+
+The deprecated wrapper applied `twClassName="self-center"` on the internal action `Button`. The design-system version drops it. The outer root sets `alignItems={BoxAlignItems.Center}` so the button stays centered in practice — the removed class was redundant in every current call site. Only consumers that forced a non-center `alignItems` via `actionButtonProps` would see a visual change; pass `actionButtonProps={{ twClassName: 'self-center' }}` explicitly if you need the old behavior.
+
+#### Migration Examples
+
+##### Basic usage
+
+Before (Mobile):
+
+```tsx
+import { TabEmptyState } from '../../../component-library/components-temp/TabEmptyState';
+import { strings } from '../../../../locales/i18n';
+
+<TabEmptyState description={strings('wallet.no_transactions')} />;
+```
+
+After (Design System):
+
+```tsx
+import { TabEmptyState } from '@metamask/design-system-react-native';
+import { strings } from '../../../../locales/i18n';
+
+<TabEmptyState description={strings('wallet.no_transactions')} />;
+```
+
+##### With action button and custom children
+
+Before (Mobile):
+
+```tsx
+import {
+  TabEmptyState,
+  type TabEmptyStateProps,
+} from '../../../component-library/components-temp/TabEmptyState';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+
+<TabEmptyState
+  testID="bridge-token-selector-empty-state"
+  icon={<NoSearchResultsIcon width={72} height={78} />}
+  description={strings('bridge.no_tokens_found')}
+  descriptionProps={{
+    variant: TextVariant.HeadingMd,
+    color: TextColor.TextDefault,
+    twClassName: 'text-center',
+  }}
+  style={styles.emptyStateContainer}
+  twClassName="self-center"
+>
+  <Text
+    variant={TextVariant.BodyMd}
+    color={TextColor.TextAlternative}
+    twClassName="text-center -mt-1"
+  >
+    {strings('bridge.no_tokens_found_description')}
+  </Text>
+</TabEmptyState>;
+```
+
+After (Design System):
+
+```tsx
+import {
+  TabEmptyState,
+  type TabEmptyStateProps,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+
+<TabEmptyState
+  testID="bridge-token-selector-empty-state"
+  icon={<NoSearchResultsIcon width={72} height={78} />}
+  description={strings('bridge.no_tokens_found')}
+  descriptionProps={{
+    variant: TextVariant.HeadingMd,
+    color: TextColor.TextDefault,
+    twClassName: 'text-center',
+  }}
+  style={styles.emptyStateContainer}
+  twClassName="self-center"
+>
+  <Text
+    variant={TextVariant.BodyMd}
+    color={TextColor.TextAlternative}
+    twClassName="text-center -mt-1"
+  >
+    {strings('bridge.no_tokens_found_description')}
+  </Text>
+</TabEmptyState>;
+```
+
+Only the import specifier changes.
+
+#### API Differences Summary
+
+- Root prop type narrows from `Omit<BoxProps, 'children'>` to `ViewProps`. Move any root-level `Box` shorthands to `twClassName` or a wrapper `<Box>`.
+- Internal action `Button` no longer receives `twClassName="self-center"`. Re-add via `actionButtonProps={{ twClassName: 'self-center' }}` if a consumer overrides the outer `alignItems`.
+- All other props (`icon`, `description`, `descriptionProps`, `actionButtonText`, `actionButtonProps`, `onAction`, `children`, `twClassName`, `style`, `ViewProps`) are unchanged.
 
 ## Version Updates
 

--- a/packages/design-system-react-native/src/components/TabEmptyState/README.md
+++ b/packages/design-system-react-native/src/components/TabEmptyState/README.md
@@ -163,6 +163,10 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 };
 ```
 
+## Migration from MetaMask Mobile Component Library
+
+Migrating from the legacy `TabEmptyState` in `app/component-library/components-temp/TabEmptyState`? See the [TabEmptyState migration guide](../../../MIGRATION.md#tabemptystate-component) for import changes, root prop narrowing (`BoxProps` → `ViewProps`), and the removal of `self-center` on the internal action `Button`.
+
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react-native/src/components/TabEmptyState/README.md
+++ b/packages/design-system-react-native/src/components/TabEmptyState/README.md
@@ -165,7 +165,7 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 
 ## Migration from MetaMask Mobile Component Library
 
-Migrating from the legacy `TabEmptyState` in `app/component-library/components-temp/TabEmptyState`? See the [TabEmptyState migration guide](../../../MIGRATION.md#tabemptystate-component) for import changes, root prop narrowing (`BoxProps` → `ViewProps`), and the removal of `self-center` on the internal action `Button`.
+Migrating from the legacy `TabEmptyState` in `app/component-library/components-temp/TabEmptyState`? See the [TabEmptyState migration guide](../../../MIGRATION.md#tabemptystate-component) for the import change and the root prop narrowing from `BoxProps` to `ViewProps`.
 
 ## References
 

--- a/packages/design-system-react-native/src/components/TabEmptyState/TabEmptyState.tsx
+++ b/packages/design-system-react-native/src/components/TabEmptyState/TabEmptyState.tsx
@@ -49,6 +49,7 @@ export const TabEmptyState = ({
       <Button
         variant={ButtonVariant.Secondary}
         onPress={onAction}
+        twClassName="self-center"
         {...actionButtonProps}
       >
         {actionButtonText}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Added migration guide for `TabEmptyState` component.

Added missing class to the `Button` to fix a regression 🤞 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-283

## **Manual testing steps**

1. Go to `MIGRATION.MD` file
2. Check `TabEmptyState` component

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

<img width="1062" height="898" alt="image" src="https://github.com/user-attachments/assets/e031a334-7847-48c9-ada8-86c3ed3ebbeb" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation changes plus a small, non-breaking style tweak to `TabEmptyState` button layout.
> 
> **Overview**
> Adds a new `TabEmptyState` section to `MIGRATION.md`, documenting the import-path change from MetaMask Mobile `components-temp` and calling out the root prop-type narrowing to `ViewProps` (vs legacy `BoxProps`) with before/after examples.
> 
> Updates `TabEmptyState` docs to link to the migration guide, and fixes a styling regression by centering the optional action button via `twClassName="self-center"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c67e16b67ac25ab4de4c35eef7060e42d2131d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->