### PR TITLE
fix: figma code connect mappings

### DIFF
--- a/.cursor/rules/figma-integration.md
+++ b/.cursor/rules/figma-integration.md
@@ -418,6 +418,6 @@ After creating or updating Code Connect files, verify:
 
 - [Figma Code Connect Documentation](https://www.figma.com/code-connect-docs/)
 - [Connecting React Components](https://www.figma.com/code-connect-docs/react/)
-- [MetaMask Design System Figma File](https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components)
+- [MetaMask Design System Figma File](https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?m=auto)
 - Initial setup guide: @docs/figma-code-connect.md
 - Related cursor rules: @.cursor/rules/component-creation.md

--- a/docs/figma-code-connect.md
+++ b/docs/figma-code-connect.md
@@ -103,5 +103,5 @@ See [`.cursor/rules/figma-integration.md`](../.cursor/rules/figma-integration.md
 
 - [Figma Code Connect Documentation](https://www.figma.com/code-connect-docs/)
 - [Connecting React Components](https://www.figma.com/code-connect-docs/react/)
-- [MetaMask Design System Figma File](https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components)
+- [MetaMask Design System Figma File](https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?m=auto)
 - [`.cursor/rules/figma-integration.md`](../.cursor/rules/figma-integration.md) - File creation patterns and best practices

--- a/packages/design-system-react-native/figma.config.json
+++ b/packages/design-system-react-native/figma.config.json
@@ -7,6 +7,6 @@
     "importPaths": {
       "packages/design-system-react-native/src/components/*": "@metamask/design-system-react-native"
     },
-    "interactiveSetupFigmaFileUrl": "https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?m=auto&node-id=1905-4770"
+    "interactiveSetupFigmaFileUrl": "https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?m=auto"
   }
 }

--- a/packages/design-system-react-native/src/components/AvatarAccount/AvatarAccount.figma.tsx
+++ b/packages/design-system-react-native/src/components/AvatarAccount/AvatarAccount.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarAccountSize } from '.';
 
 figma.connect(
   AvatarAccount,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=128%3A1673',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=128%3A1673',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/AvatarFavicon/AvatarFavicon.figma.tsx
+++ b/packages/design-system-react-native/src/components/AvatarFavicon/AvatarFavicon.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarFaviconSize } from '.';
 
 figma.connect(
   AvatarFavicon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=225%3A5186',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=225%3A5186',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/AvatarGroup/AvatarGroup.figma.tsx
+++ b/packages/design-system-react-native/src/components/AvatarGroup/AvatarGroup.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarGroupSize, AvatarGroupVariant } from '.';
 
 figma.connect(
   AvatarGroup,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=310%3A2005',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=310%3A2005',
   {
     props: {
       size: figma.enum('size', {
@@ -34,9 +34,8 @@ figma.connect(
         Networks: AvatarGroupVariant.Network,
         Favicons: AvatarGroupVariant.Favicon,
       }),
-      isReverse: figma.boolean('isReverse'),
     },
-    example: ({ variant, isReverse, ...props }) => (
+    example: ({ variant, ...props }) => (
       <AvatarGroup
         variant={variant}
         avatarPropsArr={
@@ -44,7 +43,6 @@ figma.connect(
             /** Add avatar prop objects here */
           ]
         }
-        isReverse={isReverse}
         {...props}
       />
     ),

--- a/packages/design-system-react-native/src/components/AvatarIcon/AvatarIcon.figma.tsx
+++ b/packages/design-system-react-native/src/components/AvatarIcon/AvatarIcon.figma.tsx
@@ -19,7 +19,7 @@ import { AvatarIconSize, AvatarIconSeverity } from '.';
 
 figma.connect(
   AvatarIcon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=224%3A1636',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=224%3A1636',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/AvatarNetwork/AvatarNetwork.figma.tsx
+++ b/packages/design-system-react-native/src/components/AvatarNetwork/AvatarNetwork.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarNetworkSize } from '.';
 
 figma.connect(
   AvatarNetwork,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=196%3A1563',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=196%3A1563',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/AvatarToken/AvatarToken.figma.tsx
+++ b/packages/design-system-react-native/src/components/AvatarToken/AvatarToken.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarTokenSize } from '.';
 
 figma.connect(
   AvatarToken,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=128%3A2312',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=128%3A2312',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/BadgeCount/BadgeCount.figma.tsx
+++ b/packages/design-system-react-native/src/components/BadgeCount/BadgeCount.figma.tsx
@@ -18,7 +18,7 @@ import { BadgeCountSize } from '.';
 
 figma.connect(
   BadgeCount,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=623%3A3506',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=623%3A3506',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/BadgeIcon/BadgeIcon.figma.tsx
+++ b/packages/design-system-react-native/src/components/BadgeIcon/BadgeIcon.figma.tsx
@@ -17,7 +17,7 @@ import { BadgeIcon } from './BadgeIcon';
 
 figma.connect(
   BadgeIcon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1973%3A2426',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1973%3A2426',
   {
     props: {
       iconName: figma.enum('iconName', {

--- a/packages/design-system-react-native/src/components/BadgeNetwork/BadgeNetwork.figma.tsx
+++ b/packages/design-system-react-native/src/components/BadgeNetwork/BadgeNetwork.figma.tsx
@@ -16,7 +16,7 @@ import { BadgeNetwork } from './BadgeNetwork';
 
 figma.connect(
   BadgeNetwork,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=580%3A4660',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=580%3A4660',
   {
     props: {},
     example: (props) => (

--- a/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.figma.tsx
+++ b/packages/design-system-react-native/src/components/BadgeStatus/BadgeStatus.figma.tsx
@@ -18,7 +18,7 @@ import { BadgeStatusSize, BadgeStatusStatus } from '.';
 
 figma.connect(
   BadgeStatus,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=623%3A3377',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=623%3A3377',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/Button/Button.figma.tsx
+++ b/packages/design-system-react-native/src/components/Button/Button.figma.tsx
@@ -20,7 +20,7 @@ import { ButtonVariant, ButtonSize } from '.';
 
 figma.connect(
   Button,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A304',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A304',
   {
     props: {
       variant: figma.enum('variant', {

--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.figma.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.figma.tsx
@@ -20,7 +20,7 @@ import { ButtonBaseSize } from '.';
 
 figma.connect(
   ButtonBase,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A432',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A432',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.figma.tsx
+++ b/packages/design-system-react-native/src/components/ButtonIcon/ButtonIcon.figma.tsx
@@ -19,7 +19,7 @@ import { ButtonIconSize, ButtonIconVariant } from '.';
 
 figma.connect(
   ButtonIcon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A2860',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A2860',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/Checkbox/Checkbox.figma.tsx
+++ b/packages/design-system-react-native/src/components/Checkbox/Checkbox.figma.tsx
@@ -16,7 +16,7 @@ import { Checkbox } from './Checkbox';
 
 figma.connect(
   Checkbox,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=385%3A18907',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=385%3A18907',
   {
     props: {
       isDisabled: figma.boolean('isDisabled'),

--- a/packages/design-system-react-native/src/components/Icon/Icon.figma.tsx
+++ b/packages/design-system-react-native/src/components/Icon/Icon.figma.tsx
@@ -14,7 +14,7 @@ import { IconName, IconSize } from '.';
 
 figma.connect(
   Icon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A2554',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A2554',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react-native/src/components/TextButton/TextButton.figma.tsx
+++ b/packages/design-system-react-native/src/components/TextButton/TextButton.figma.tsx
@@ -17,16 +17,16 @@ import { TextButton } from './TextButton';
 
 figma.connect(
   TextButton,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A398',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A398',
   {
     props: {
-      variant: figma.enum('variant', {
+      size: figma.enum('size', {
         BodyMd: TextVariant.BodyMd,
         BodySm: TextVariant.BodySm,
       }),
     },
-    example: ({ variant, ...props }) => (
-      <TextButton variant={variant} {...props} onPress={() => undefined}>
+    example: ({ size, ...props }) => (
+      <TextButton {...props} variant={size} onPress={() => undefined}>
         Text Button
       </TextButton>
     ),

--- a/packages/design-system-react/figma.config.json
+++ b/packages/design-system-react/figma.config.json
@@ -7,6 +7,6 @@
     "importPaths": {
       "packages/design-system-react/src/components/*": "@metamask/design-system-react"
     },
-    "interactiveSetupFigmaFileUrl": "https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?m=auto&node-id=1905-4770"
+    "interactiveSetupFigmaFileUrl": "https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?m=auto"
   }
 }

--- a/packages/design-system-react/src/components/AvatarAccount/AvatarAccount.figma.tsx
+++ b/packages/design-system-react/src/components/AvatarAccount/AvatarAccount.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarAccountSize } from '.';
 
 figma.connect(
   AvatarAccount,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=128%3A1673',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=128%3A1673',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/AvatarFavicon/AvatarFavicon.figma.tsx
+++ b/packages/design-system-react/src/components/AvatarFavicon/AvatarFavicon.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarFaviconSize } from '.';
 
 figma.connect(
   AvatarFavicon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=225%3A5186',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=225%3A5186',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/AvatarGroup/AvatarGroup.figma.tsx
+++ b/packages/design-system-react/src/components/AvatarGroup/AvatarGroup.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarGroupSize, AvatarGroupVariant } from '.';
 
 figma.connect(
   AvatarGroup,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=310%3A2005',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=310%3A2005',
   {
     props: {
       size: figma.enum('size', {
@@ -34,9 +34,8 @@ figma.connect(
         Networks: AvatarGroupVariant.Network,
         Favicons: AvatarGroupVariant.Favicon,
       }),
-      isReverse: figma.boolean('isReverse'),
     },
-    example: ({ variant, isReverse, ...props }) => (
+    example: ({ variant, ...props }) => (
       <AvatarGroup
         variant={variant}
         avatarPropsArr={
@@ -44,7 +43,6 @@ figma.connect(
             /** Add avatar prop objects here */
           ]
         }
-        isReverse={isReverse}
         {...props}
       />
     ),

--- a/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.figma.tsx
+++ b/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.figma.tsx
@@ -19,7 +19,7 @@ import { AvatarIconSize, AvatarIconSeverity } from '.';
 
 figma.connect(
   AvatarIcon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=224%3A1636',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=224%3A1636',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.figma.tsx
+++ b/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarNetworkSize } from '.';
 
 figma.connect(
   AvatarNetwork,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=196%3A1563',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=196%3A1563',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/AvatarToken/AvatarToken.figma.tsx
+++ b/packages/design-system-react/src/components/AvatarToken/AvatarToken.figma.tsx
@@ -18,7 +18,7 @@ import { AvatarTokenSize } from '.';
 
 figma.connect(
   AvatarToken,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=128%3A2312',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=128%3A2312',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/BadgeCount/BadgeCount.figma.tsx
+++ b/packages/design-system-react/src/components/BadgeCount/BadgeCount.figma.tsx
@@ -18,7 +18,7 @@ import { BadgeCountSize } from '.';
 
 figma.connect(
   BadgeCount,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=623%3A3506',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=623%3A3506',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/BadgeIcon/BadgeIcon.figma.tsx
+++ b/packages/design-system-react/src/components/BadgeIcon/BadgeIcon.figma.tsx
@@ -17,7 +17,7 @@ import { BadgeIcon } from './BadgeIcon';
 
 figma.connect(
   BadgeIcon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1973%3A2426',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1973%3A2426',
   {
     props: {
       iconName: figma.enum('iconName', {

--- a/packages/design-system-react/src/components/BadgeNetwork/BadgeNetwork.figma.tsx
+++ b/packages/design-system-react/src/components/BadgeNetwork/BadgeNetwork.figma.tsx
@@ -16,7 +16,7 @@ import { BadgeNetwork } from './BadgeNetwork';
 
 figma.connect(
   BadgeNetwork,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=580%3A4660',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=580%3A4660',
   {
     props: {},
     example: (props) => (

--- a/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.figma.tsx
+++ b/packages/design-system-react/src/components/BadgeStatus/BadgeStatus.figma.tsx
@@ -18,7 +18,7 @@ import { BadgeStatusSize, BadgeStatusStatus } from '.';
 
 figma.connect(
   BadgeStatus,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=623%3A3377',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=623%3A3377',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/Button/Button.figma.tsx
+++ b/packages/design-system-react/src/components/Button/Button.figma.tsx
@@ -20,7 +20,7 @@ import { ButtonVariant, ButtonSize } from '.';
 
 figma.connect(
   Button,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A304',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A304',
   {
     props: {
       variant: figma.enum('variant', {

--- a/packages/design-system-react/src/components/ButtonBase/ButtonBase.figma.tsx
+++ b/packages/design-system-react/src/components/ButtonBase/ButtonBase.figma.tsx
@@ -20,7 +20,7 @@ import { ButtonBaseSize } from '.';
 
 figma.connect(
   ButtonBase,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A432',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A432',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/ButtonHero/ButtonHero.figma.tsx
+++ b/packages/design-system-react/src/components/ButtonHero/ButtonHero.figma.tsx
@@ -7,7 +7,7 @@ import { ButtonHero } from './ButtonHero';
 
 figma.connect(
   ButtonHero,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=5416%3A15232',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=5416%3A15232',
   {
     props: {
       isDisabled: figma.boolean('isDisabled'),

--- a/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.figma.tsx
+++ b/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.figma.tsx
@@ -19,7 +19,7 @@ import { ButtonIconSize, ButtonIconVariant } from '.';
 
 figma.connect(
   ButtonIcon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A2860',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A2860',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.figma.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.figma.tsx
@@ -16,7 +16,7 @@ import { Checkbox } from './Checkbox';
 
 figma.connect(
   Checkbox,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=385%3A18907',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=385%3A18907',
   {
     props: {
       isDisabled: figma.boolean('isDisabled'),

--- a/packages/design-system-react/src/components/Icon/Icon.figma.tsx
+++ b/packages/design-system-react/src/components/Icon/Icon.figma.tsx
@@ -14,7 +14,7 @@ import { IconName, IconSize } from '.';
 
 figma.connect(
   Icon,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A2554',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A2554',
   {
     props: {
       size: figma.enum('size', {

--- a/packages/design-system-react/src/components/TextButton/TextButton.figma.tsx
+++ b/packages/design-system-react/src/components/TextButton/TextButton.figma.tsx
@@ -20,7 +20,7 @@ import { TextButtonSize } from '.';
 
 figma.connect(
   TextButton,
-  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-WIP--MMDS-Components?node-id=1%3A398',
+  'https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=1%3A398',
   {
     props: {
       size: figma.enum('size', {


### PR DESCRIPTION
## **Description**

This updates the Figma Code Connect configuration to point at the live `🦊 MMDS Components` file instead of the deprecated WIP file and fixes a small set of stale prop mappings that no longer matched the current Figma component schemas.

The main fixes are:
- repoint all affected `.figma.tsx` files and both `figma.config.json` files to `🦊 MMDS Components`
- migrate `ButtonIcon` to a single Figma `variant` axis (`Default` / `Filled` / `Floating`) and update React + React Native Code Connect to use that enum directly
- remove the stale `isReverse` mapping from `AvatarGroup`
- narrow the React Native `TextButton` mapping to the subset the current RN component actually supports
- update Code Connect documentation links to the live file

## **Figma branch reference**

Figma branch used for validation and direct component edits:
- https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/branch/3rDwcOTbo8e25WNCSjRBNt/%F0%9F%A6%8A-MMDS-Components?m=auto

Direct Figma changes made for reference:
- `ButtonIcon` (`node-id=1:2860`): migrated the component set from `isInverse` + `isFloating` variant properties to a single `variant` property with `Default`, `Filled`, and `Floating`
- `Text Button` (`node-id=1:398`): renamed the component set from `ButtonText` to `Text Button`

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn figma:connect:publish:dry-run`
2. Confirm React validation passes for all Code Connect files
3. Confirm React Native validation passes for all Code Connect files
4. Run `yarn figma:connect:publish`
5. Open `🦊 MMDS Components` in Figma Dev Mode and verify connected components show published React and React Native Code Connect docs

## **Screenshots/Recordings**

### **Before**

Not included. Validation was failing because several Code Connect mappings targeted stale file URLs or stale component properties.

### **After**

Not included. `yarn figma:connect:publish:dry-run` passes for both React and React Native, and `yarn figma:connect:publish` successfully uploads both platforms to `🦊 MMDS Components`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates Code Connect configuration/docs and a few component prop mappings, with no runtime production logic changes beyond Figma snippet generation.
> 
> **Overview**
> Repoints all Figma Code Connect URLs (docs, both `figma.config.json` files, and multiple `.figma.tsx` connectors) from the deprecated WIP file to the live `🦊 MMDS Components` design file.
> 
> Refreshes a few stale prop mappings to match current component schemas: removes `AvatarGroup`’s `isReverse` mapping, updates `ButtonIcon` to use a single `variant` enum (`Default`/`Filled`/`Floating`), and narrows React Native `TextButton` mapping to the supported text-size variants (wiring it through `variant`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1c61e2a54930f6a7a02f7710ef5190e25512830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

