### PR TITLE
docs: Add consumer-facing component documentation guidance

### DIFF
--- a/.cursor/rules/component-documentation.md
+++ b/.cursor/rules/component-documentation.md
@@ -11,6 +11,30 @@ Documentation standards for Storybook stories and README files for React and Rea
 - **ALWAYS** follow templates exactly: @docs/component-readme-examples/
 - **Cross-platform**: Keep documentation identical across web/native (same sections, descriptions, examples)
 
+### Consumer-Facing Descriptions
+
+- **ALWAYS** write component descriptions for consumers of the component, not for reviewers or implementers
+- Opening descriptions should explain:
+  - what the component is
+  - when to use it
+  - how to use it in the default/common case
+  - when not to use it, if there is a nearby alternative or a common misuse
+- **PREFER** stable usage guidance over internal reasoning. Document the recommended composition or default sizing, not why the implementation was changed during review.
+- **NEVER** include development-process or review-history context in component docs
+- **NEVER** explain implementation details unless they directly affect consumer usage or API behavior
+- **NEVER** add fluff, defensive narration, or “why we removed/changed X in this PR” language to README descriptions
+
+**Good examples:**
+
+- `AvatarIcon` displays an icon inside an avatar-shaped container. Use it when you need a static icon avatar rather than an image- or account-based avatar.
+- `TitleSubpage` lays out a leading avatar beside a title stack with optional supporting rows. For avatars passed to `titleAvatar`, use a large size such as `AvatarToken` at `AvatarTokenSize.Lg`.
+
+**Bad examples (avoid these):**
+
+- `On React Native, this is passed straight through with no fixed-size wrapper because we removed the old overflow-hidden container during review.`
+- `This implementation stays agnostic so you own composition when you need extra chrome.`
+- `We changed this in the latest review round so badges are no longer clipped.`
+
 ### Storybook Stories
 
 **Story Structure:**
@@ -102,6 +126,8 @@ After adding/updating component documentation, verify:
 - [ ] README exists in component directory (.mdx for web, .md for native)
 - [ ] README follows templates exactly: @docs/component-readme-examples/
 - [ ] README includes: description, usage, props documentation
+- [ ] README description is consumer-facing and explains what the component is, when to use it, and the default usage pattern
+- [ ] README avoids implementation-history, review-process context, and unnecessary internal details
 - [ ] Web README uses Canvas blocks for interactive examples
 - [ ] Cross-platform: documentation is identical across web/native
 - [ ] Stories file exports meta with proper argTypes


### PR DESCRIPTION
## **Description**

Add consumer-facing documentation guidance to the component documentation rule.

This updates the rule to require descriptions that explain what a component is, when to use it, and the default usage pattern, while avoiding implementation history and review-process context.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open `.cursor/rules/component-documentation.md`.
2. Confirm the new `Consumer-Facing Descriptions` section is present.
3. Confirm the verification checklist now requires consumer-facing descriptions and excludes implementation-history language.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- Not applicable. -->

### **After**

<!-- Not applicable. -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that tightens authoring guidance for component READMEs; no runtime or build behavior is affected.
> 
> **Overview**
> Adds a new **Consumer-Facing Descriptions** section to `.cursor/rules/component-documentation.md`, requiring component README intros to describe *what the component is*, *when to use it*, and the *default usage pattern*, and explicitly forbidding review-history/implementation-detail narration (with good/bad examples).
> 
> Updates the verification checklist to enforce these consumer-facing description requirements and to flag implementation-history language as invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6acabbbc7b6a504b839952810e6cdc28d9b3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->