### PR TITLE
chore: remove unused eslint disable comments

### DIFF
--- a/packages/design-system-react-native/scripts/create-component/create-component.ts
+++ b/packages/design-system-react-native/scripts/create-component/create-component.ts
@@ -1,7 +1,5 @@
-/* eslint-disable import-x/no-nodejs-modules */
 import { promises as fs } from 'fs';
 import * as path from 'path';
-/* eslint-enable import-x/no-nodejs-modules */
 
 type CreateComponentArgs = {
   name: string;

--- a/packages/design-system-react/scripts/create-component/create-component.ts
+++ b/packages/design-system-react/scripts/create-component/create-component.ts
@@ -1,7 +1,5 @@
-/* eslint-disable import-x/no-nodejs-modules */
 import { promises as fs } from 'fs';
 import * as path from 'path';
-/* eslint-enable import-x/no-nodejs-modules */
 
 type CreateComponentArgs = {
   name: string;


### PR DESCRIPTION
## **Description**

Removes two unused `eslint-disable` / `eslint-enable` wrappers for `import-x/no-nodejs-modules` in the React and React Native create-component scripts.

These comments are no longer needed and currently show up as warnings in `yarn lint`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check out this branch.
2. Run `yarn lint`.
3. Confirm the unused eslint-disable warnings are no longer reported.

## **Screenshots/Recordings**

Not applicable.

### **Before**

Not applicable.

### **After**

Not applicable.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only lint cleanup with no runtime or behavior changes.
> 
> **Overview**
> Removes unused `eslint-disable`/`eslint-enable` wrappers for `import-x/no-nodejs-modules` in the React and React Native `create-component` scripts, addressing `yarn lint` warnings without changing script behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9033d219fc5b0e4d4b8af5c8a68390d67aa034d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->