### PR TITLE
feat: `ModalBody` migration (extension)

### DIFF
--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -16,6 +16,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [Text Component](#text-component)
   - [Icon Component](#icon-component)
   - [Checkbox Component](#checkbox-component)
+  - [ModalBody Component](#modalbody-component)
   - [ModalOverlay Component](#modaloverlay-component)
 - [Version Updates](#version-updates)
   - [From version 0.17.0 to 0.18.0](#from-version-0170-to-0180)
@@ -1230,6 +1231,85 @@ import { Checkbox } from '@metamask/design-system-react';
 - `Checkbox` still exposes a `toggle` imperative handle via `ref`, but top-level `inputRef` is not available.
 - `inputProps` remains available and should be used for native input attributes such as `name`, `required`, and `title`.
 - `isInvalid` is available for error-state visuals and is not part of the extension checkbox API.
+
+### ModalBody Component
+
+The extension `modal-body` component maps to `ModalBody` in the design system. The default visual contract (horizontal padding, scrollable container) is preserved, but the polymorphic Box surface is removed and a keyboard-accessibility default is added.
+
+Refer to [General Extension Migration Guidance](#general-extension-migration-guidance) for shared Box/style-utility migration patterns.
+
+#### Breaking Changes
+
+##### Import Path
+
+| Extension Pattern                                               | Design System Migration                                               |
+| --------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `import { ModalBody } from '../../component-library'`           | `import { ModalBody } from '@metamask/design-system-react'`           |
+| `import type { ModalBodyProps } from '../../component-library'` | `import type { ModalBodyProps } from '@metamask/design-system-react'` |
+
+##### Props and Behavior Mapping
+
+| Extension API                                                                                 | Design System API       | Change Type | Notes                                                                                                                          |
+| --------------------------------------------------------------------------------------------- | ----------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `children?: ReactNode`                                                                        | `children?: ReactNode`  | unchanged   | rendered inside the scrollable container                                                                                       |
+| `className?: string`                                                                          | `className?: string`    | unchanged   | merged with default Tailwind classes via `twMerge`                                                                             |
+| Polymorphic `as` / `PolymorphicComponentPropWithRef<C, ...>`                                  | removed                 | removed     | always renders a `<div>`. If you need a different element, wrap or compose.                                                    |
+| Box style-utility props (`paddingLeft`, `paddingRight`, `flexDirection`, `gap`, `display`, …) | removed from public API | removed     | use `className` with Tailwind utilities. The default `px-4` remains, applied internally; override with `className="px-0"` etc. |
+| `mm-modal-body` SCSS class hook                                                               | removed                 | removed     | use `className` and Tailwind utilities to customize                                                                            |
+
+##### Default and Behavior Changes
+
+| Concern                | Extension Behavior                                                                                  | Design System Behavior                                                                                                                                        |
+| ---------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Horizontal padding     | `paddingLeft={4} paddingRight={4}` Box props (16px each side)                                       | `paddingHorizontal={4}` applied internally → `px-4`. Override with `className="px-0"` (or another `px-*` utility).                                            |
+| Scroll/overflow        | `position: relative; max-height: 100%; overflow-y: auto;` from `.mm-modal-body` SCSS                | Same behavior via `relative max-h-full overflow-y-auto` Tailwind utilities applied internally.                                                                |
+| Keyboard accessibility | No default `tabIndex` — scrollable text-only content was not reachable by keyboard for arrow scroll | `tabIndex={0}` applied by default so keyboard users can focus the scrollable region and arrow-scroll. Override with `tabIndex={-1}` if you need to remove it. |
+
+This satisfies the WCAG 2.1.1 "Keyboard" rule for scrollable regions (axe `scrollable-region-focusable`) — modals containing only static text now expose the body as a focusable scroll target out of the box.
+
+#### Migration Examples
+
+##### Before (Extension)
+
+```tsx
+import { ModalBody } from '../../component-library';
+import { FlexDirection } from '../../../helpers/constants/design-system';
+
+// Default usage
+<ModalBody>{description}</ModalBody>
+
+// Customized: remove default horizontal padding, lay out children as a column
+<ModalBody
+  paddingLeft={0}
+  paddingRight={0}
+  flexDirection={FlexDirection.Column}
+  gap={2}
+>
+  {options}
+</ModalBody>
+```
+
+##### After (Design System)
+
+```tsx
+import { ModalBody } from '@metamask/design-system-react';
+
+// Default usage — unchanged
+<ModalBody>{description}</ModalBody>
+
+// Customized: utility-prop overrides move into className
+<ModalBody className="flex flex-col gap-2 px-0">
+  {options}
+</ModalBody>
+```
+
+For typical call sites — for example `ui/components/app/connections-removed-modal/connections-removed-modal.tsx` (bare `<ModalBody>{text}</ModalBody>`) and `ui/components/app/alert-system/alert-modal/alert-modal.tsx` (bare with element children) (verified via fresh grep) — the only change is the import path. Sites that override Box utility props, such as `ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx` (`paddingLeft={0} paddingRight={0} flexDirection={FlexDirection.Column} gap={2}`), need the `className` translation shown above.
+
+#### API Differences
+
+- `ModalBody` no longer composes Box's polymorphic API. It always renders a `<div>` and forwards arbitrary HTML attributes (`id`, `role`, `data-*`, `aria-*`, `tabIndex`, `ref`) to it.
+- `tabIndex={0}` is now the default. Pass `tabIndex={-1}` (or any other value) to override; the consumer's value wins.
+- One-off styling that previously used Box utility props should move to Tailwind via `className` (`px-0`, `py-2`, `flex`, `flex-col`, `gap-2`, etc.).
 
 ### ModalOverlay Component
 

--- a/packages/design-system-react/src/components/ModalBody/ModalBody.stories.tsx
+++ b/packages/design-system-react/src/components/ModalBody/ModalBody.stories.tsx
@@ -29,6 +29,11 @@ const meta: Meta<ModalBodyProps> = {
   args: {
     children: 'Modal Body',
   },
+  render: (args) => (
+    <ModalBody {...args}>
+      <Text>{args.children}</Text>
+    </ModalBody>
+  ),
 };
 
 export default meta;
@@ -44,7 +49,9 @@ export const Children: Story = {
   },
   render: (args) => (
     <div className="h-[100px] w-[300px]">
-      <ModalBody {...args} />
+      <ModalBody {...args}>
+        <Text>{args.children}</Text>
+      </ModalBody>
     </div>
   ),
 };

--- a/packages/design-system-react/src/components/ModalBody/ModalBody.stories.tsx
+++ b/packages/design-system-react/src/components/ModalBody/ModalBody.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+
+import { Text } from '../Text';
+
+import { ModalBody } from './ModalBody';
+import type { ModalBodyProps } from './ModalBody.types';
+import README from './README.mdx';
+
+const meta: Meta<ModalBodyProps> = {
+  title: 'React Components/ModalBody',
+  component: ModalBody,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    className: {
+      control: 'text',
+      description:
+        'Optional prop for additional CSS classes to be applied to the ModalBody component',
+    },
+    children: {
+      control: 'text',
+      description: 'The content of the ModalBody',
+    },
+  },
+  args: {
+    children: 'Modal Body',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<ModalBodyProps>;
+
+export const Default: Story = {};
+
+export const Children: Story = {
+  args: {
+    children:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit libero, a pharetra augue. Nullam id dolor id nibh ultricies vehicula ut id elit. Cras mattis consectetur purus sit amet fermentum. Donec ullamcorper nulla non metus auctor fringilla.',
+  },
+  render: (args) => (
+    <div className="h-[100px] w-[300px]">
+      <ModalBody {...args} />
+    </div>
+  ),
+};
+
+export const Padding: Story = {
+  render: () => (
+    <div className="h-[200px] w-[300px]">
+      <ModalBody className="flex flex-col gap-4 px-0">
+        <Text className="px-4">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae
+          elit libero, a pharetra augue. Nullam id
+        </Text>
+        <Text className="bg-primary-muted px-4">
+          Element touches edge of ModalBody
+        </Text>
+        <Text className="px-4">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae
+          elit libero, a pharetra augue. Nullam id
+        </Text>
+      </ModalBody>
+    </div>
+  ),
+};

--- a/packages/design-system-react/src/components/ModalBody/ModalBody.test.tsx
+++ b/packages/design-system-react/src/components/ModalBody/ModalBody.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import React, { createRef } from 'react';
+
+import { ModalBody } from './ModalBody';
+
+describe('ModalBody', () => {
+  it('renders without crashing', () => {
+    render(<ModalBody data-testid="modal-body" />);
+    expect(screen.getByTestId('modal-body')).toBeInTheDocument();
+  });
+
+  it('renders children inside the body', () => {
+    render(
+      <ModalBody data-testid="modal-body">
+        <span data-testid="child">Hello</span>
+      </ModalBody>,
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('Hello');
+  });
+
+  it('applies the default scroll, overflow, and position classes', () => {
+    render(<ModalBody data-testid="modal-body" />);
+    expect(screen.getByTestId('modal-body')).toHaveClass(
+      'relative',
+      'max-h-full',
+      'overflow-y-auto',
+    );
+  });
+
+  it('applies the default horizontal padding via Box props', () => {
+    render(<ModalBody data-testid="modal-body" />);
+    expect(screen.getByTestId('modal-body')).toHaveClass('px-4');
+  });
+
+  it('merges custom className alongside default classes', () => {
+    render(<ModalBody data-testid="modal-body" className="opacity-50" />);
+    const body = screen.getByTestId('modal-body');
+    expect(body).toHaveClass('opacity-50');
+    expect(body).toHaveClass('relative', 'max-h-full', 'overflow-y-auto');
+  });
+
+  it('forwards ref to the underlying element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<ModalBody ref={ref} data-testid="modal-body" />);
+    expect(ref.current).toBe(screen.getByTestId('modal-body'));
+  });
+
+  it('forwards arbitrary HTML attributes to the underlying element', () => {
+    render(<ModalBody data-testid="modal-body" id="body" role="region" />);
+    const body = screen.getByTestId('modal-body');
+    expect(body).toHaveAttribute('id', 'body');
+    expect(body).toHaveAttribute('role', 'region');
+  });
+});

--- a/packages/design-system-react/src/components/ModalBody/ModalBody.test.tsx
+++ b/packages/design-system-react/src/components/ModalBody/ModalBody.test.tsx
@@ -32,6 +32,16 @@ describe('ModalBody', () => {
     expect(screen.getByTestId('modal-body')).toHaveClass('px-4');
   });
 
+  it('is keyboard-focusable by default so users can scroll the region', () => {
+    render(<ModalBody data-testid="modal-body" />);
+    expect(screen.getByTestId('modal-body')).toHaveAttribute('tabindex', '0');
+  });
+
+  it('allows consumers to override tabIndex', () => {
+    render(<ModalBody data-testid="modal-body" tabIndex={-1} />);
+    expect(screen.getByTestId('modal-body')).toHaveAttribute('tabindex', '-1');
+  });
+
   it('merges custom className alongside default classes', () => {
     render(<ModalBody data-testid="modal-body" className="opacity-50" />);
     const body = screen.getByTestId('modal-body');

--- a/packages/design-system-react/src/components/ModalBody/ModalBody.tsx
+++ b/packages/design-system-react/src/components/ModalBody/ModalBody.tsx
@@ -1,0 +1,21 @@
+import React, { forwardRef } from 'react';
+
+import { twMerge } from '../../utils/tw-merge';
+import { Box } from '../Box';
+
+import type { ModalBodyProps } from './ModalBody.types';
+
+export const ModalBody = forwardRef<HTMLDivElement, ModalBodyProps>(
+  ({ className, children, ...props }, ref) => (
+    <Box
+      ref={ref}
+      paddingHorizontal={4}
+      className={twMerge('relative max-h-full overflow-y-auto', className)}
+      {...props}
+    >
+      {children}
+    </Box>
+  ),
+);
+
+ModalBody.displayName = 'ModalBody';

--- a/packages/design-system-react/src/components/ModalBody/ModalBody.tsx
+++ b/packages/design-system-react/src/components/ModalBody/ModalBody.tsx
@@ -6,10 +6,11 @@ import { Box } from '../Box';
 import type { ModalBodyProps } from './ModalBody.types';
 
 export const ModalBody = forwardRef<HTMLDivElement, ModalBodyProps>(
-  ({ className, children, ...props }, ref) => (
+  ({ className, children, tabIndex = 0, ...props }, ref) => (
     <Box
       ref={ref}
       paddingHorizontal={4}
+      tabIndex={tabIndex}
       className={twMerge('relative max-h-full overflow-y-auto', className)}
       {...props}
     >

--- a/packages/design-system-react/src/components/ModalBody/ModalBody.types.ts
+++ b/packages/design-system-react/src/components/ModalBody/ModalBody.types.ts
@@ -1,0 +1,13 @@
+import type { ComponentProps, ReactNode } from 'react';
+
+export type ModalBodyProps = ComponentProps<'div'> & {
+  /**
+   * The content of the ModalBody.
+   */
+  children?: ReactNode;
+  /**
+   * Optional prop for additional CSS classes to be applied to the ModalBody component.
+   * These classes will be merged with the component's default classes using twMerge.
+   */
+  className?: string;
+};

--- a/packages/design-system-react/src/components/ModalBody/README.mdx
+++ b/packages/design-system-react/src/components/ModalBody/README.mdx
@@ -78,6 +78,18 @@ A common pattern in the extension was to drop the body's padding and let individ
 
 <Canvas of={ModalBodyStories.Padding} />
 
+### Accessibility
+
+`ModalBody` ships with `tabIndex={0}` by default so the scrollable region is reachable by keyboard — keyboard-only users can focus the body and arrow-scroll through long content. This satisfies the WCAG 2.1.1 "Keyboard" rule for scrollable regions (axe `scrollable-region-focusable`).
+
+If your modal body's content already includes focusable elements that own the keyboard scroll experience (forms, lists with focusable rows, etc.) and you don't want an extra tab stop on the body itself, opt out with `tabIndex={-1}` — your value wins over the default:
+
+```tsx
+<ModalBody tabIndex={-1}>{focusableContent}</ModalBody>
+```
+
+The `tabIndex` prop is forwarded to the underlying `<div>` like any other HTML attribute.
+
 ### `className`
 
 Use the `className` prop to add custom CSS classes to the component. These classes are merged with the component's defaults via `twMerge`, so consumer utilities override the defaults (for example, `className="px-0"` wins over the internal `px-4`).

--- a/packages/design-system-react/src/components/ModalBody/README.mdx
+++ b/packages/design-system-react/src/components/ModalBody/README.mdx
@@ -43,12 +43,44 @@ Content rendered inside the body. `ModalBody` handles vertical scrolling when it
 
 <Canvas of={ModalBodyStories.Children} />
 
+### Padding
+
+`ModalBody` applies horizontal padding by default so its contents align with the rest of the modal frame:
+
+- `padding-left: 16px` (`px-4`)
+- `padding-right: 16px` (`px-4`)
+
+Vertical padding is intentionally not set on `ModalBody` itself — `ModalHeader` and `ModalFooter` own the modal's top and bottom spacing.
+
+#### Overriding the default padding
+
+Pass any `px-*` / `py-*` Tailwind utility through `className`. Because the merge is handled by `twMerge`, your utility wins over the default `px-4` — there is no need to "unset" the default.
+
+```tsx
+// Remove the default horizontal padding so children can span the full width
+// (e.g. for full-bleed rows that own their own internal padding).
+<ModalBody className="px-0">{rows}</ModalBody>
+```
+
+#### Edge-to-edge children inside a padded body
+
+A common pattern in the extension was to drop the body's padding and let individual children own their inset. The same pattern works here, expressed with Tailwind:
+
+```tsx
+<ModalBody className="flex flex-col gap-4 px-0">
+  <Text className="px-4">Standard inset row</Text>
+  <Text className="bg-primary-muted px-4">
+    Highlighted row that touches the body edges
+  </Text>
+  <Text className="px-4">Standard inset row</Text>
+</ModalBody>
+```
+
+<Canvas of={ModalBodyStories.Padding} />
+
 ### `className`
 
-Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
-
-- Add new styles that don't exist in the default component
-- Override the component's default styles when needed (for example, removing the default `px-4` to let inner elements span the full width)
+Use the `className` prop to add custom CSS classes to the component. These classes are merged with the component's defaults via `twMerge`, so consumer utilities override the defaults (for example, `className="px-0"` wins over the internal `px-4`).
 
 <table>
   <thead>
@@ -70,8 +102,6 @@ Use the `className` prop to add custom CSS classes to the component. These class
     </tr>
   </tbody>
 </table>
-
-<Canvas of={ModalBodyStories.Padding} />
 
 ## Component API
 

--- a/packages/design-system-react/src/components/ModalBody/README.mdx
+++ b/packages/design-system-react/src/components/ModalBody/README.mdx
@@ -1,0 +1,86 @@
+import { Controls, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as ModalBodyStories from './ModalBody.stories';
+
+# ModalBody
+
+`ModalBody` is the scrollable content container of a modal. It applies the standard horizontal padding used across modal sections and handles vertical overflow with native scrolling so long content stays inside the modal frame.
+
+```tsx
+import { ModalBody } from '@metamask/design-system-react';
+
+<ModalBody>{content}</ModalBody>;
+```
+
+<Canvas of={ModalBodyStories.Default} />
+
+## Props
+
+### `children`
+
+Content rendered inside the body. `ModalBody` handles vertical scrolling when its content exceeds the available height of the modal.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={ModalBodyStories.Children} />
+
+### `className`
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed (for example, removing the default `px-4` to let inner elements span the full width)
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={ModalBodyStories.Padding} />
+
+## Component API
+
+<Controls of={ModalBodyStories.Default} />
+
+## Migration Guide
+
+Migrating from `ui/components/component-library/modal-body` in MetaMask Extension? See the [ModalBody Migration Guide](../../../MIGRATION.md#modalbody-component) for prop mappings, before/after examples, and breaking changes.
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/src/components/ModalBody/index.ts
+++ b/packages/design-system-react/src/components/ModalBody/index.ts
@@ -1,0 +1,2 @@
+export { ModalBody } from './ModalBody';
+export type { ModalBodyProps } from './ModalBody.types';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -94,6 +94,8 @@ export type { MaskiconProps } from './temp-components/Maskicon';
 
 export { ModalOverlay } from './ModalOverlay';
 export type { ModalOverlayProps } from './ModalOverlay';
+export { ModalBody } from './ModalBody';
+export type { ModalBodyProps } from './ModalBody';
 
 export { Text } from './Text';
 export {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Added `ModalBody` to DSRN.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-307

## **Manual testing steps**

1. Open storybook app
2. Check `ModalBody` component.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1035" height="489" alt="image" src="https://github.com/user-attachments/assets/738c6dc9-48d0-4f76-b4d7-e27bda746645" />

### **After**

<img width="1022" height="507" alt="image" src="https://github.com/user-attachments/assets/fca2751f-7bb6-4a78-bf19-94a7c65d996f" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new exported component with a default `tabIndex={0}`, which can change focus order/keyboard behavior in consuming modals. Otherwise the change is additive and scoped to UI/styling helpers and docs/tests.
> 
> **Overview**
> Adds a new `ModalBody` component to `@metamask/design-system-react`, exported from the root barrel, that provides the standard modal body layout (`px-4` + `relative max-h-full overflow-y-auto`) and forwards refs/HTML div props.
> 
> `ModalBody` is **keyboard-focusable by default** via `tabIndex={0}` (overridable) to improve accessibility of scrollable modal content. This PR also adds Storybook stories, unit tests, component docs, and a new section in `MIGRATION.md` describing extension-to-DS prop/behavior differences (notably removal of polymorphic/Box utility-prop surfaces in favor of Tailwind `className`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb0202c2f3e0677d53b88ab9ec522a77a437cd78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->