### PR TITLE
docs(stories): align WalletHome action icons with production Extension

### DIFF
--- a/apps/storybook-react-native/stories/WalletHome.stories.tsx
+++ b/apps/storybook-react-native/stories/WalletHome.stories.tsx
@@ -130,8 +130,8 @@ const WalletHome: React.FC = () => {
               alignItems={BoxAlignItems.Center}
               justifyContent={BoxJustifyContent.Center}
             >
-              <Icon name={IconName.Bank} />
-              <Text fontWeight={FontWeight.Medium}>Buy/Sell</Text>
+              <Icon name={IconName.AttachMoney} />
+              <Text fontWeight={FontWeight.Medium}>Buy</Text>
             </Box>
           </ButtonBase>
           <ButtonBase twClassName="h-20 flex-1 rounded-lg bg-muted px-0 py-4">
@@ -140,18 +140,8 @@ const WalletHome: React.FC = () => {
               alignItems={BoxAlignItems.Center}
               justifyContent={BoxJustifyContent.Center}
             >
-              <Icon name={IconName.SwapHorizontal} />
+              <Icon name={IconName.SwapVertical} />
               <Text fontWeight={FontWeight.Medium}>Swap</Text>
-            </Box>
-          </ButtonBase>
-          <ButtonBase twClassName="h-20 flex-1 rounded-lg bg-muted px-0 py-4">
-            <Box
-              flexDirection={BoxFlexDirection.Column}
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Center}
-            >
-              <Icon name={IconName.Receive} />
-              <Text fontWeight={FontWeight.Medium}>Receive</Text>
             </Box>
           </ButtonBase>
           <ButtonBase twClassName="h-20 flex-1 rounded-lg bg-muted px-0 py-4">
@@ -162,6 +152,16 @@ const WalletHome: React.FC = () => {
             >
               <Icon name={IconName.Send} />
               <Text fontWeight={FontWeight.Medium}>Send</Text>
+            </Box>
+          </ButtonBase>
+          <ButtonBase twClassName="h-20 flex-1 rounded-lg bg-muted px-0 py-4">
+            <Box
+              flexDirection={BoxFlexDirection.Column}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Center}
+            >
+              <Icon name={IconName.Received} />
+              <Text fontWeight={FontWeight.Medium}>Receive</Text>
             </Box>
           </ButtonBase>
         </Box>

--- a/apps/storybook-react/stories/WalletHome.stories.tsx
+++ b/apps/storybook-react/stories/WalletHome.stories.tsx
@@ -124,20 +124,20 @@ const WalletHome: React.FC = () => {
           className="md:px-8"
         >
           <ButtonBase className="h-auto flex-1 flex-col justify-center rounded-lg bg-muted py-4 hover:bg-muted-hover active:bg-muted-pressed">
-            <Icon name={IconName.Bank} className="mb-2" />
-            Buy/Sell
+            <Icon name={IconName.AttachMoney} className="mb-2" />
+            Buy
           </ButtonBase>
           <ButtonBase className="h-auto flex-1 flex-col justify-center rounded-lg bg-muted py-4 hover:bg-muted-hover active:bg-muted-pressed">
-            <Icon name={IconName.SwapHorizontal} className="mb-2" />
+            <Icon name={IconName.SwapVertical} className="mb-2" />
             Swap
-          </ButtonBase>
-          <ButtonBase className="h-auto flex-1 flex-col justify-center rounded-lg bg-muted py-4 hover:bg-muted-hover active:bg-muted-pressed">
-            <Icon name={IconName.Receive} className="mb-2" />
-            Receive
           </ButtonBase>
           <ButtonBase className="h-auto flex-1 flex-col justify-center rounded-lg bg-muted py-4 hover:bg-muted-hover active:bg-muted-pressed">
             <Icon name={IconName.Send} className="mb-2" />
             Send
+          </ButtonBase>
+          <ButtonBase className="h-auto flex-1 flex-col justify-center rounded-lg bg-muted py-4 hover:bg-muted-hover active:bg-muted-pressed">
+            <Icon name={IconName.Received} className="mb-2" />
+            Receive
           </ButtonBase>
         </Box>
         {/* Tabs */}


### PR DESCRIPTION
## Summary

The `WalletHome` example stories on both React and React Native were using icon names that don't match what ships in the production MetaMask Extension wallet. This PR aligns the storybook examples to the production reality.

## Changes

| Action | Before | After (matches production) |
|---|---|---|
| Buy | `IconName.Bank` | `IconName.AttachMoney` (pure `$` symbol) |
| Swap | `IconName.SwapHorizontal` | `IconName.SwapVertical` (vertical bi-directional) |
| Receive | `IconName.Receive` | `IconName.Received` (diagonal `↙` arrow) |
| Send | `IconName.Send` | unchanged (paper plane) |

Action button order also updated to match production canonical: **Buy → Swap → Send → Receive** (was Buy → Swap → Receive → Send).

## Why

When Trade-lane teams reference the WalletHome story to spec new screens, the icons they pull in look noticeably different from the live wallet. This caused real confusion in a Manage Tokens prototype review where reviewers flagged the icons as "looking nothing like the actual extension buttons."

The icons used in production:
- **AttachMoney** (not Cash) — pure `$` glyph, no card rectangle around it
- **SwapVertical** (not SwapHorizontal) — vertical `↑↓` bi-directional
- **Received** (not Receive) — diagonal `↙` arrow into corner (NOT the QR-code icon `Receive` represents)

All four icons are already in `@metamask/design-system-react`/`-react-native` — this PR just fixes the story to use them correctly.

## Test plan

- [ ] `yarn storybook` — visually compare WalletHome story to live Extension wallet home, icons match
- [ ] `yarn storybook:ios` / `yarn storybook:android` — same check on RN
- [ ] `yarn build && yarn lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: storybook-only UI example tweaks (icon swaps, label tweak, and button reorder) with no runtime/business logic changes.
> 
> **Overview**
> Updates the `WalletHome` Storybook examples (React and React Native) to match production wallet action buttons: **Buy** now uses `IconName.AttachMoney` (and label changes from *Buy/Sell* to *Buy*), **Swap** uses `IconName.SwapVertical`, and **Receive** uses `IconName.Received`.
> 
> Reorders the action buttons to **Buy → Swap → Send → Receive** (previously had Receive before Send).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c25a45d5f25e92e115bebf68ccaf9a891f1cd6da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->