### PR TITLE
Release 38.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "37.0.0",
+  "version": "38.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(icons): add Merge icon to shared assets and regenerate exports ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
+- feat(DSYS-488): Migrate Input to ADR-0003 and ADR-0004 ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
+- feat(DSYS-475): Migrate AvatarGroup to ADR-0003 and ADR-0004 ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
+- feat: new Toast API design ([#1104](https://github.com/MetaMask/metamask-design-system/pull/1104))
+
 ## [0.22.0]
 
 ### Changed

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.23.0]
 
-### Uncategorized
+### Added
 
-- feat(icons): add Merge icon to shared assets and regenerate exports ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
-- feat(DSYS-488): Migrate Input to ADR-0003 and ADR-0004 ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
-- feat(DSYS-475): Migrate AvatarGroup to ADR-0003 and ADR-0004 ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
-- feat: new Toast API design ([#1104](https://github.com/MetaMask/metamask-design-system/pull/1104))
+- Added `Merge` to the icon set so it can be used anywhere `IconName` is supported in `@metamask/design-system-react-native` ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
+- Added a `Toast` API that lets apps mount `<Toast />` once and show or hide toasts from anywhere with `Toast.show(...)` and `Toast.hide()` ([#1104](https://github.com/MetaMask/metamask-design-system/pull/1104))
+
+### Changed
+
+- Updated `Input` to use the shared cross-platform API. Consumers should pass a controlled `value`, replace `isReadonly` with `isReadOnly`, and use the shared state-style behavior expected by wrappers like `TextField` ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
+- Updated `AvatarGroup` to use shared cross-platform size and variant contracts, keeping React and React Native aligned on the same public API names and values ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
 
 ## [0.22.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0]
+
 ### Uncategorized
 
 - feat(icons): add Merge icon to shared assets and regenerate exports ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
@@ -393,7 +395,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.22.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.23.0...HEAD
+[0.23.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.22.0...@metamask/design-system-react-native@0.23.0
 [0.22.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.21.0...@metamask/design-system-react-native@0.22.0
 [0.21.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.20.0...@metamask/design-system-react-native@0.21.0
 [0.20.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.19.0...@metamask/design-system-react-native@0.20.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `Merge` to the icon set so it can be used anywhere `IconName` is supported in `@metamask/design-system-react-native` ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
-- Added a `Toast` API that lets apps mount `<Toast />` once and show or hide toasts from anywhere with `Toast.show(...)` and `Toast.hide()` ([#1104](https://github.com/MetaMask/metamask-design-system/pull/1104))
 
 ### Changed
 
+- **BREAKING:** Redesigned `Toast` to use a single mounted `<Toast />` plus static `Toast.show(...)` and `Toast.hide()` methods for application usage ([#1104](https://github.com/MetaMask/metamask-design-system/pull/1104))
+  - Removed `ToastContext`, `ToastContextWrapper`, and `ToastContextParams` from the public export surface
+  - Renamed `ToastVariants` to `ToastVariant`, changed icon-only close buttons to `ToastCloseButtonVariant.Icon`, and renamed `customBottomOffset` to `bottomOffset`
+  - `Toast.show()` and `Toast.hide()` now throw a descriptive error if called before `<Toast />` mounts
+  - See [Migration Guide](./MIGRATION.md#from-version-0220-to-0230)
 - Updated `Input` to use the shared cross-platform API. Consumers should pass a controlled `value`, replace `isReadonly` with `isReadOnly`, and use the shared state-style behavior expected by wrappers like `TextField` ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
 - Updated `AvatarGroup` to use shared cross-platform size and variant contracts, keeping React and React Native aligned on the same public API names and values ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -26,7 +26,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TabEmptyState Component](#tabemptystate-component)
   - [Toast Component](#toast-component)
 - [Version Updates](#version-updates)
-  - [From version 0.X.0 to 0.X.0](#from-version-0x0-to-0x0)
+  - [From version 0.22.0 to 0.23.0](#from-version-0220-to-0230)
   - [From version 0.21.0 to 0.22.0](#from-version-0210-to-0220)
   - [From version 0.19.0 to 0.20.0](#from-version-0190-to-0200)
   - [From version 0.18.0 to 0.19.0](#from-version-0180-to-0190)
@@ -40,9 +40,33 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Version Updates
 
-### From version 0.X.0 to 0.X.0
+### From version 0.22.0 to 0.23.0
 
-TODO(release): replace `0.X.0` with the actual version numbers when this PR lands in a release.
+#### Toast: static API replaces context-based usage
+
+**What changed:**
+
+- **`Toast`** now exposes static **`Toast.show(...)`** and **`Toast.hide()`** methods for application usage, instead of relying on **`ToastContext`**, **`ToastContextWrapper`**, or an app-level service singleton.
+- **`ToastContext`**, **`ToastContextWrapper`**, and **`ToastContextParams`** are no longer part of the public **`@metamask/design-system-react-native`** exports.
+- **`ToastVariants`** is renamed to **`ToastVariant`**.
+- Icon-only close buttons now use **`ToastCloseButtonVariant.Icon`** instead of **`ButtonVariants.Link`**.
+- **`customBottomOffset`** is renamed to **`bottomOffset`**.
+- Calling **`Toast.show()`** or **`Toast.hide()`** before **`<Toast />`** mounts now throws a descriptive runtime error instead of silently doing nothing.
+
+**Migration:**
+
+- Mount **`<Toast />`** exactly once near the root of the app.
+- Replace any **`useContext(ToastContext)`**, **`ToastContextWrapper`**, or app-level **`ToastService`** usage with **`Toast.show(...)`** and **`Toast.hide()`**.
+- Rename **`ToastVariants`** to **`ToastVariant`** in all call sites.
+- Replace icon-only close button usage from **`ButtonVariants.Link`** to **`ToastCloseButtonVariant.Icon`**.
+- Rename **`customBottomOffset`** to **`bottomOffset`**.
+
+See [Toast Component](#toast-component) for complete before/after examples and API mappings.
+
+**Impact:**
+
+- Existing **`@metamask/design-system-react-native`** consumers using the old context-based Toast flow must update imports, root mounting, and toast invocation patterns.
+- Existing call sites that already use the forwarded **`ToastRef`** methods for isolated cases can keep doing so, but app-level usage should move to the static API.
 
 #### Input: shared controlled contract and readonly naming alignment
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(icons): add Merge icon to shared assets and regenerate exports ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
+- feat: `ModalFooter` migration (extension) ([#1132](https://github.com/MetaMask/metamask-design-system/pull/1132))
+- feat(DSYS-488): Migrate Input to ADR-0003 and ADR-0004 ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
+- feat(DSYS-475): Migrate AvatarGroup to ADR-0003 and ADR-0004 ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
+- [2/N] feat: `ModalFocus` migration (extension) ([#1128](https://github.com/MetaMask/metamask-design-system/pull/1128))
+- feat: `ModalBody` migration (extension) ([#1121](https://github.com/MetaMask/metamask-design-system/pull/1121))
+- [1/N] feat: `ModalOverlay` migration (extension) ([#1120](https://github.com/MetaMask/metamask-design-system/pull/1120))
+
 ## [0.20.0]
 
 ### Changed

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0]
+
 ### Uncategorized
 
 - feat(icons): add Merge icon to shared assets and regenerate exports ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
@@ -292,7 +294,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.20.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.21.0...HEAD
+[0.21.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.20.0...@metamask/design-system-react@0.21.0
 [0.20.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.19.0...@metamask/design-system-react@0.20.0
 [0.19.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.18.0...@metamask/design-system-react@0.19.0
 [0.18.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.17.1...@metamask/design-system-react@0.18.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,15 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.21.0]
 
-### Uncategorized
+### Added
 
-- feat(icons): add Merge icon to shared assets and regenerate exports ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
-- feat: `ModalFooter` migration (extension) ([#1132](https://github.com/MetaMask/metamask-design-system/pull/1132))
-- feat(DSYS-488): Migrate Input to ADR-0003 and ADR-0004 ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
-- feat(DSYS-475): Migrate AvatarGroup to ADR-0003 and ADR-0004 ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
-- [2/N] feat: `ModalFocus` migration (extension) ([#1128](https://github.com/MetaMask/metamask-design-system/pull/1128))
-- feat: `ModalBody` migration (extension) ([#1121](https://github.com/MetaMask/metamask-design-system/pull/1121))
-- [1/N] feat: `ModalOverlay` migration (extension) ([#1120](https://github.com/MetaMask/metamask-design-system/pull/1120))
+- Added `Merge` to the icon set so it can be used anywhere `IconName` is supported in `@metamask/design-system-react` ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
+- Added `ModalOverlay`, `ModalBody`, `ModalFocus`, and `ModalFooter` to help Extension consumers migrate modal building blocks into `@metamask/design-system-react` ([#1120](https://github.com/MetaMask/metamask-design-system/pull/1120), [#1121](https://github.com/MetaMask/metamask-design-system/pull/1121), [#1128](https://github.com/MetaMask/metamask-design-system/pull/1128), [#1132](https://github.com/MetaMask/metamask-design-system/pull/1132))
+
+### Changed
+
+- Updated `Input` to use the shared cross-platform API. Consumers should pass a controlled `value`, use `isReadOnly` as the readonly prop name, and stop relying on `defaultValue` as part of the public component contract ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
+- Updated `AvatarGroup` to use shared cross-platform size and variant contracts, keeping React and React Native aligned on the same public API names and values ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
 
 ## [0.20.0]
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",
@@ -78,7 +78,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-tailwind-preset": "^0.6.0",
+    "@metamask/design-system-tailwind-preset": "^0.7.0",
     "@metamask/design-tokens": "^8.1.0",
     "@metamask/utils": "^11.11.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(icons): add Merge icon to shared assets and regenerate exports ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
+- feat(DSYS-488): Migrate Input to ADR-0003 and ADR-0004 ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
+- feat(DSYS-475): Migrate AvatarGroup to ADR-0003 and ADR-0004 ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
+
 ## [0.15.0]
 
 ### Added

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.16.0]
 
-### Uncategorized
+### Added
 
-- feat(icons): add Merge icon to shared assets and regenerate exports ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
-- feat(DSYS-488): Migrate Input to ADR-0003 and ADR-0004 ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
-- feat(DSYS-475): Migrate AvatarGroup to ADR-0003 and ADR-0004 ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
+- Added `Merge` to the shared icon exports so React and React Native consumers can access it through their existing `IconName` APIs ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
+- Added shared `Input` contracts for a controlled `value`, `isReadOnly`, and `isStateStylesDisabled`, making it easier to build cross-platform wrappers against one public input API ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
+- Added shared `AvatarGroup` size, variant, and prop contracts for consumers building cross-platform abstractions on top of `@metamask/design-system-shared` ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))
 
 ## [0.15.0]
 

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0]
+
 ### Uncategorized
 
 - feat(icons): add Merge icon to shared assets and regenerate exports ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))
@@ -172,7 +174,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.15.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.16.0...HEAD
+[0.16.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.15.0...@metamask/design-system-shared@0.16.0
 [0.15.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.14.0...@metamask/design-system-shared@0.15.0
 [0.14.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.13.0...@metamask/design-system-shared@0.14.0
 [0.13.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.12.0...@metamask/design-system-shared@0.13.0

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0]
 
+### Added
+
+- Added a `fade-in` animation utility so consumers can use `animate-fade-in` for simple opacity entrance transitions, including the new `ModalOverlay` web migration path ([#1120](https://github.com/MetaMask/metamask-design-system/pull/1120))
+
 ### Changed
 
 - Clarified the migration path for consumers moving to Tailwind CSS v4. Existing Tailwind v3 projects can keep using this preset, while Tailwind v4 projects should move to `@metamask/design-tokens/tailwind/theme.css` instead ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -9,19 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0]
 
-### Uncategorized
+### Changed
 
-- feat: add Tailwind v4 design-tokens foundation ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))
-- [1/N] feat: `ModalOverlay` migration (extension) ([#1120](https://github.com/MetaMask/metamask-design-system/pull/1120))
-- chore: centralize Icon types and assets (ADR-0003/ADR-0004) ([#1042](https://github.com/MetaMask/metamask-design-system/pull/1042))
-- chore(deps-dev): bump @metamask/auto-changelog from 6.0.0 to 6.1.0 ([#1079](https://github.com/MetaMask/metamask-design-system/pull/1079))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.3.2 to 6.0.0 ([#1077](https://github.com/MetaMask/metamask-design-system/pull/1077))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.3.1 to 5.3.2 ([#906](https://github.com/MetaMask/metamask-design-system/pull/906))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.3.0 to 5.3.1 ([#878](https://github.com/MetaMask/metamask-design-system/pull/878))
-- chore: remove unused eslint-disable comments after eslint upgrades ([#861](https://github.com/MetaMask/metamask-design-system/pull/861))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.2.0 to 5.3.0 ([#858](https://github.com/MetaMask/metamask-design-system/pull/858))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.1.0 to 5.2.0 ([#853](https://github.com/MetaMask/metamask-design-system/pull/853))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.0.2 to 5.1.0 ([#837](https://github.com/MetaMask/metamask-design-system/pull/837))
+- Clarified the migration path for consumers moving to Tailwind CSS v4. Existing Tailwind v3 projects can keep using this preset, while Tailwind v4 projects should move to `@metamask/design-tokens/tailwind/theme.css` instead ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))
 
 ## [0.6.1]
 

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0]
+
 ### Uncategorized
 
 - feat: add Tailwind v4 design-tokens foundation ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))
@@ -76,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.6.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.7.0...HEAD
+[0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.6.1...@metamask/design-system-tailwind-preset@0.7.0
 [0.6.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.6.0...@metamask/design-system-tailwind-preset@0.6.1
 [0.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.5.0...@metamask/design-system-tailwind-preset@0.6.0
 [0.5.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.4.0...@metamask/design-system-tailwind-preset@0.5.0

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add Tailwind v4 design-tokens foundation ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))
+- [1/N] feat: `ModalOverlay` migration (extension) ([#1120](https://github.com/MetaMask/metamask-design-system/pull/1120))
+- chore: centralize Icon types and assets (ADR-0003/ADR-0004) ([#1042](https://github.com/MetaMask/metamask-design-system/pull/1042))
+- chore(deps-dev): bump @metamask/auto-changelog from 6.0.0 to 6.1.0 ([#1079](https://github.com/MetaMask/metamask-design-system/pull/1079))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.3.2 to 6.0.0 ([#1077](https://github.com/MetaMask/metamask-design-system/pull/1077))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.3.1 to 5.3.2 ([#906](https://github.com/MetaMask/metamask-design-system/pull/906))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.3.0 to 5.3.1 ([#878](https://github.com/MetaMask/metamask-design-system/pull/878))
+- chore: remove unused eslint-disable comments after eslint upgrades ([#861](https://github.com/MetaMask/metamask-design-system/pull/861))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.2.0 to 5.3.0 ([#858](https://github.com/MetaMask/metamask-design-system/pull/858))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.1.0 to 5.2.0 ([#853](https://github.com/MetaMask/metamask-design-system/pull/853))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.0.2 to 5.1.0 ([#837](https://github.com/MetaMask/metamask-design-system/pull/837))
+
 ## [0.6.1]
 
 ### Fixed
@@ -42,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Removed variant-specific font family classnames in favor of base font families ([#533](https://github.com/MetaMask/metamask-design-system/pull/533)):
+- **BREAKING:** Removed variant-specific font family classnames in favor of base font families: ([#533](https://github.com/MetaMask/metamask-design-system/pull/533))
   - Removed all `s-*` and `l-*` typography font family classnames (e.g., `s-display-md`, `s-heading-lg`, etc.)
   - Now using three base font family classnames:
     - `font-default` for default text (Geist)
@@ -54,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated to use new font family configuration from @metamask/design-tokens@6.0.0 ([#499](https://github.com/MetaMask/metamask-design-system/pull/499)). Note: This includes breaking changes in the design-tokens package - see the [@metamask/design-tokens migration guide](../design-tokens/MIGRATION.md#from-version-510-to-600) for details.
+- Updated to use new font family configuration from @metamask/design-tokens@6.0.0. Note: This includes breaking changes in the design-tokens package - see the [@metamask/design-tokens migration guide](../design-tokens/MIGRATION.md#from-version-510-to-600) for details. ([#499](https://github.com/MetaMask/metamask-design-system/pull/499))
 
 ## [0.1.0]
 

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-tailwind-preset",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Design System Tailwind CSS preset for MetaMask projects",
   "keywords": [
     "MetaMask",

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.4.0]
+
 ### Uncategorized
 
 - feat: add Tailwind v4 design-tokens foundation ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))
@@ -436,7 +438,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.4.0...HEAD
+[8.4.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.3.0...@metamask/design-tokens@8.4.0
 [8.3.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.2.2...@metamask/design-tokens@8.3.0
 [8.2.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.2.1...@metamask/design-tokens@8.2.2
 [8.2.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.2.0...@metamask/design-tokens@8.2.1

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add Tailwind v4 design-tokens foundation ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))
+- chore: upgrade React Native v76.9 and Storybook v10 and align deps with MetaMask Mobile ([#844](https://github.com/MetaMask/metamask-design-system/pull/844))
+- chore(deps-dev): bump @metamask/auto-changelog from 6.0.0 to 6.1.0 ([#1079](https://github.com/MetaMask/metamask-design-system/pull/1079))
+- chore(deps-dev): bump @metamask/auto-changelog from 5.3.2 to 6.0.0 ([#1077](https://github.com/MetaMask/metamask-design-system/pull/1077))
+
 ## [8.3.0]
 
 ### Changed
 
-- `fontWeights.bold` and the `--font-weight-bold` CSS variable now return `600`, and the Storybook font loaders/`@font-face` declarations consume the new `Geist-SemiBold`/`Geist-SemiBoldItalic` assets instead of the retired bold files ([#1017](https://github.com/MetaMask/metamask-design-system/pull/1017)). The `design-system-twrnc-preset` mapping for `default-bold`/`default-bold-italic` now resolves to those semibold PostScript names, so custom Tailwind classnames should align with the new fonts. Update `@font-face` declarations, font bundles, and `font-weight: 700` styles to point at the semibold files, include the semibold assets from `apps/storybook-react-native/fonts/Geist` and `apps/storybook-react/fonts/Geist` when you bundle fonts manually, and run the [migration guide](./MIGRATION.md#from-version-822-to-830) to verify `fontWeights.bold` references propagate through CSS, JS, and Tailwind configurations.
+- `fontWeights.bold` and the `--font-weight-bold` CSS variable now return `600`, and the Storybook font loaders/`@font-face` declarations consume the new `Geist-SemiBold`/`Geist-SemiBoldItalic` assets instead of the retired bold files. The `design-system-twrnc-preset` mapping for `default-bold`/`default-bold-italic` now resolves to those semibold PostScript names, so custom Tailwind classnames should align with the new fonts. Update `@font-face` declarations, font bundles, and `font-weight: 700` styles to point at the semibold files, include the semibold assets from `apps/storybook-react-native/fonts/Geist` and `apps/storybook-react/fonts/Geist` when you bundle fonts manually, and run the [migration guide](./MIGRATION.md#from-version-822-to-830) to verify `fontWeights.bold` references propagate through CSS, JS, and Tailwind configurations. ([#1017](https://github.com/MetaMask/metamask-design-system/pull/1017))
 
 ## [8.2.2]
 
@@ -66,9 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Updated `background/muted` from opaque colors to transparent colors and added new `background/section` and `background/subsection` tokens ([#682](https://github.com/MetaMask/metamask-design-system/pull/682)). This is a breaking change that affects components requiring opaque backgrounds like BadgeNetwork, avatar fallbacks, and non-action elements. Applications must swap `background/muted` with `background/section` for opaque backgrounds.
-- **BREAKING:** Removed deprecated typography tokens `sHeadingSMRegular` and `lHeadingSMRegular` ([#699](https://github.com/MetaMask/metamask-design-system/pull/699)). Choose an appropriate replacement typography token based on your design needs. See the [migration guide](./MIGRATION.md#from-version-700-to-800) for details.
-- **BREAKING:** Changed default font from CentraNo1 to Geist ([#756](https://github.com/MetaMask/metamask-design-system/pull/756)). This affects all typography tokens and requires updating font imports and references. See the [migration guide](./MIGRATION.md#from-version-700-to-800) for details.
+- **BREAKING:** Updated `background/muted` from opaque colors to transparent colors and added new `background/section` and `background/subsection` tokens. This is a breaking change that affects components requiring opaque backgrounds like BadgeNetwork, avatar fallbacks, and non-action elements. Applications must swap `background/muted` with `background/section` for opaque backgrounds. ([#682](https://github.com/MetaMask/metamask-design-system/pull/682))
+- **BREAKING:** Removed deprecated typography tokens `sHeadingSMRegular` and `lHeadingSMRegular`. Choose an appropriate replacement typography token based on your design needs. See the [migration guide](./MIGRATION.md#from-version-700-to-800) for details. ([#699](https://github.com/MetaMask/metamask-design-system/pull/699))
+- **BREAKING:** Changed default font from CentraNo1 to Geist. This affects all typography tokens and requires updating font imports and references. See the [migration guide](./MIGRATION.md#from-version-700-to-800) for details. ([#756](https://github.com/MetaMask/metamask-design-system/pull/756))
 - Fixed `text/alternative`, `text/muted`, `icon/alternative`, and `icon/muted` colors in dark mode to match design specifications ([#709](https://github.com/MetaMask/metamask-design-system/pull/709))
 
 ## [7.1.0]
@@ -82,7 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **BREAKING:** Removed individual typography font family tokens in favor of base font family tokens. See the [migration guide](./MIGRATION.md#from-version-600-to-700) for details.
-- **BREAKING:** Updated Body variants(BodyXs, BodySm, BodyMd, BodyLg) font size for small screens ([#533](https://github.com/MetaMask/metamask-design-system/pull/533)). See the [migration guide](./MIGRATION.md#from-version-700-to-800) for details.
+- **BREAKING:** Updated Body variants(BodyXs, BodySm, BodyMd, BodyLg) font size for small screens. See the [migration guide](./MIGRATION.md#from-version-700-to-800) for details. ([#533](https://github.com/MetaMask/metamask-design-system/pull/533))
 
 ## [6.1.0]
 
@@ -100,7 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Replaced Euclid Circular B with CentraNo1 as the primary font family ([#499](https://github.com/MetaMask/metamask-design-system/pull/499)). See the [migration guide](./MIGRATION.md#from-version-510-to-600) for details.
+- **BREAKING:** Replaced Euclid Circular B with CentraNo1 as the primary font family. See the [migration guide](./MIGRATION.md#from-version-510-to-600) for details. ([#499](https://github.com/MetaMask/metamask-design-system/pull/499))
 
   - Removed `--font-family-euclid-circular-b` and `--font-family-roboto` CSS variables
   - Changed `--font-family-sans` to use CentraNo1 with updated fallback chain
@@ -118,16 +125,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **BREAKING:** Following the unintentional breaking change in `4.2.0` we are now exporting the types from root index instead of requiring deep imports ([#340](https://github.com/MetaMask/metamask-design-system/pull/340)). See the [migration guide](./MIGRATION.md#from-version-410-to-500) for details.
-
+- **BREAKING:** Following the unintentional breaking change in `4.2.0` we are now exporting the types from root index instead of requiring deep imports. See the [migration guide](./MIGRATION.md#from-version-410-to-500) for details. ([#340](https://github.com/MetaMask/metamask-design-system/pull/340))
 - Added 8 new colors (4 muted-hover & 4 muted-pressed) to design-tokens Figma Json. ([#325](https://github.com/MetaMask/metamask-design-system/pull/325))
 
 ## [4.2.0]
 
 ### Added
 
-- feat: color updates to the design tokens package ([#230](https://github.com/metamask/metamask-design-system/pull/230))
-
+- feat: color updates to the design tokens package ([#230](https://github.com/MetaMask/metamask-design-system/pull/230))
 - **BREAKING:** `@metamask/design-tokens` package migrated from standalone repository into the design system monorepo, which unintentionally broke type imports ([128](https://github.com/MetaMask/metamask-design-system/pull/128)). See the [migration guide](./MIGRATION.md#from-version-410-to-500) for details on the fix in 5.0.0.
 
 ## [4.1.0]

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,12 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.4.0]
 
-### Uncategorized
+### Added
 
-- feat: add Tailwind v4 design-tokens foundation ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))
-- chore: upgrade React Native v76.9 and Storybook v10 and align deps with MetaMask Mobile ([#844](https://github.com/MetaMask/metamask-design-system/pull/844))
-- chore(deps-dev): bump @metamask/auto-changelog from 6.0.0 to 6.1.0 ([#1079](https://github.com/MetaMask/metamask-design-system/pull/1079))
-- chore(deps-dev): bump @metamask/auto-changelog from 5.3.2 to 6.0.0 ([#1077](https://github.com/MetaMask/metamask-design-system/pull/1077))
+- Added `@metamask/design-tokens/tailwind/theme.css` for Tailwind CSS v4, giving consumers a single import for MetaMask token variables, theme values, typography utilities, font utilities, and shadow utilities. See the [migration guide](./MIGRATION.md#tailwind-css-v3-to-v4) for upgrade steps ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))
 
 ## [8.3.0]
 

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,7 +3378,7 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-tailwind-preset": ^0.6.0
+    "@metamask/design-system-tailwind-preset": ^0.7.0
     "@metamask/design-tokens": ^8.1.0
     "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0


### PR DESCRIPTION
## Release 38.0.0

This release updates the shared, web, native, tokens, and Tailwind packages with new cross-platform input and avatar-group contracts, new modal building blocks for React, a breaking React Native Toast API redesign, and Tailwind CSS v4 support for web consumers.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.16.0**
- `@metamask/design-system-react`: **0.21.0**
- `@metamask/design-system-react-native`: **0.23.0**
- `@metamask/design-system-tailwind-preset`: **0.7.0**
- `@metamask/design-tokens`: **8.4.0**

### 🔄 Shared Type Updates (0.16.0)

#### Input and AvatarGroup shared contracts ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043), [#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))

**What Changed:**

- Added shared `Input` contracts for controlled `value`, `isReadOnly`, and `isStateStylesDisabled`
- Added shared `AvatarGroup` size, variant, and prop contracts
- Added the shared `Merge` icon export ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))

**Impact:**

- React and React Native consumers can build against one aligned input and avatar-group API surface
- Cross-platform wrappers can depend on `@metamask/design-system-shared` instead of maintaining platform-specific type assumptions

### 🌐 React Web Updates (0.21.0)

#### Added

- Added `ModalOverlay`, `ModalBody`, `ModalFocus`, and `ModalFooter` to support Extension modal migrations into `@metamask/design-system-react` ([#1120](https://github.com/MetaMask/metamask-design-system/pull/1120), [#1121](https://github.com/MetaMask/metamask-design-system/pull/1121), [#1128](https://github.com/MetaMask/metamask-design-system/pull/1128), [#1132](https://github.com/MetaMask/metamask-design-system/pull/1132))
- Added the `Merge` icon to the React icon set ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))

#### Changed

- Updated `Input` to follow the shared controlled input API and use `isReadOnly` as the public readonly prop name ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
- Updated `AvatarGroup` to use shared cross-platform size and variant contracts ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))

### 📱 React Native Updates (0.23.0)

#### Added

- Added the `Merge` icon to the React Native icon set ([#1155](https://github.com/MetaMask/metamask-design-system/pull/1155))

#### Changed

- **BREAKING:** Redesigned `Toast` to use a single mounted `<Toast />` plus static `Toast.show(...)` and `Toast.hide()` methods for application usage ([#1104](https://github.com/MetaMask/metamask-design-system/pull/1104))
  - Removed `ToastContext`, `ToastContextWrapper`, and `ToastContextParams` from the public export surface
  - Renamed `ToastVariants` to `ToastVariant`, changed icon-only close buttons to `ToastCloseButtonVariant.Icon`, and renamed `customBottomOffset` to `bottomOffset`
  - `Toast.show()` and `Toast.hide()` now throw a descriptive error if called before `<Toast />` mounts
  - See the [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0220-to-0230)
- Updated `Input` to follow the shared controlled input API and rename `isReadonly` to `isReadOnly` ([#1043](https://github.com/MetaMask/metamask-design-system/pull/1043))
- Updated `AvatarGroup` to use shared cross-platform size and variant contracts ([#1067](https://github.com/MetaMask/metamask-design-system/pull/1067))

### 🎨 Tokens and Tailwind Updates

#### `@metamask/design-tokens` 8.4.0

- Added `@metamask/design-tokens/tailwind/theme.css` for Tailwind CSS v4 consumers, providing a single import for token variables, theme values, typography, fonts, and shadow utilities ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))

#### `@metamask/design-system-tailwind-preset` 0.7.0

- Added a `fade-in` animation utility so consumers can use `animate-fade-in` for simple opacity entrance transitions, including the new `ModalOverlay` web migration path ([#1120](https://github.com/MetaMask/metamask-design-system/pull/1120))
- Clarified that Tailwind CSS v3 consumers should keep using this preset, while Tailwind CSS v4 consumers should migrate to `@metamask/design-tokens/tailwind/theme.css` ([#1117](https://github.com/MetaMask/metamask-design-system/pull/1117))

### ⚠️ Breaking Changes

#### Toast API redesign (React Native)

**What Changed:**

- `Toast` application usage moved from context/service patterns to static `Toast.show(...)` and `Toast.hide()` methods
- `ToastContext`, `ToastContextWrapper`, and `ToastContextParams` were removed from the public API
- `ToastVariants` was renamed to `ToastVariant`
- Icon-only close buttons now use `ToastCloseButtonVariant.Icon`
- `customBottomOffset` was renamed to `bottomOffset`

**Impact:**

- Existing `@metamask/design-system-react-native` consumers using the old Toast context flow need import, root-mount, and call-site updates
- Existing app code must ensure `<Toast />` is mounted before invoking `Toast.show()` / `Toast.hide()`

See migration guides for complete instructions:

- [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0220-to-0230)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn workspace <package> changelog:validate`)
- [x] Version bumps follow semantic versioning
- [x] design-system-shared: minor (`0.15.0` → `0.16.0`) - new shared `Input`, `AvatarGroup`, and icon exports
- [x] design-system-react: minor (`0.20.0` → `0.21.0`) - new modal components, icon, and shared API alignment
- [x] design-system-react-native: minor (`0.22.0` → `0.23.0`) - breaking Toast redesign, icon, and shared API alignment
- [x] design-system-tailwind-preset: minor (`0.6.1` → `0.7.0`) - new `fade-in` utility and Tailwind CSS v4 migration guidance
- [x] design-tokens: minor (`8.3.0` → `8.4.0`) - Tailwind CSS v4 `theme.css` export
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples (if breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs
