### PR TITLE
feat: `PopoverHeader` migration (extension)

### DIFF
--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -24,6 +24,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [ModalFocus Component](#modalfocus-component)
   - [ModalFooter Component](#modalfooter-component)
   - [ModalOverlay Component](#modaloverlay-component)
+  - [PopoverHeader Component](#popoverheader-component)
   - [SensitiveText Component](#sensitivetext-component)
   - [Skeleton Component](#skeleton-component)
 - [Version Updates](#version-updates)
@@ -2007,6 +2008,121 @@ For typical call sites — for example `ui/components/multichain/network-list-me
 
 - `ModalOverlay` no longer composes Box's polymorphic API. It always renders a `<div>` and forwards arbitrary HTML attributes (`id`, `role`, `data-*`, `aria-*`, `ref`) to it.
 - One-off styling that previously used Box utility props (e.g. `backgroundColor={BackgroundColor.overlayAlternative}`) should now use `className` with the equivalent Tailwind utility (e.g. `className="bg-overlay-alternative"`).
+
+### PopoverHeader Component
+
+The extension `popover-header` component maps to `PopoverHeader` in the design system. The behavioral contract — a `<header>` with an optional back button on the start, a title in the center, and an optional close button on the end — is preserved. The polymorphic Box surface (`HeaderBaseStyleUtilityProps`), the `mm-popover-header` SCSS class hook, and the implicit `useI18nContext` coupling for the icon-button `aria-label`s are removed.
+
+`PopoverHeader` is built on top of the same three-column grid layout as `HeaderBase`, replicated locally so the outer element stays a single semantic `<header>` (no extra wrapper). Unlike `ModalHeader`, it applies no outer padding — popover surfaces own their own spacing.
+
+The auto-rendered icon buttons and the auto-wrapped title default to inheriting color from the popover surface (`text-inherit` / `TextColor.Inherit`), preserving the legacy `IconColor.inherit` / `TextColor.inherit` defaults so headers placed on inverse or semantic backgrounds pick up the right foreground color automatically.
+
+Refer to [General Extension Migration Guidance](#general-extension-migration-guidance) for shared Box/style-utility migration patterns.
+
+#### Breaking Changes
+
+##### Import Path
+
+| Extension Pattern                                                   | Design System Migration                                                   |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `import { PopoverHeader } from '../../component-library'`           | `import { PopoverHeader } from '@metamask/design-system-react'`           |
+| `import type { PopoverHeaderProps } from '../../component-library'` | `import type { PopoverHeaderProps } from '@metamask/design-system-react'` |
+
+##### Props and Behavior Mapping
+
+| Extension API                                                        | Design System API                                                                          | Change Type | Notes                                                                                                                                                                                                                  |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children?: ReactNode`                                               | `children?: ReactNode`                                                                     | unchanged   | string children still auto-wrap as `<Text variant={TextVariant.HeadingSm} textAlign={TextAlign.Center} color={TextColor.Inherit}>`; `ReactNode` children render as-is.                                                 |
+| `onBack?: () => void`                                                | `onBack?: () => void`                                                                      | unchanged   | when set, renders the back button — but **`backButtonProps` is now co-required** (see "i18n decoupling" below).                                                                                                        |
+| `onClose?: () => void`                                               | `onClose?: () => void`                                                                     | unchanged   | when set, renders the close button — but **`closeButtonProps` is now co-required**.                                                                                                                                    |
+| `backButtonProps?: ButtonIconProps<'button'>`                        | `backButtonProps: Omit<ButtonIconProps, 'iconName' \| 'size'>` (with `data-*` index sig.)  | shape       | type now bound to MMDS `ButtonIconProps`; `iconName` (`ArrowLeft`) and `size` (`Sm`) are owned by the component and cannot be overridden via the prop bag. `ariaLabel` is required (preserved from `ButtonIconProps`). |
+| `closeButtonProps?: ButtonIconProps<'button'>`                       | `closeButtonProps: Omit<ButtonIconProps, 'iconName' \| 'size'>` (with `data-*` index sig.) | shape       | same shape change as `backButtonProps`; component owns `iconName=Close` and `size=Sm`.                                                                                                                                 |
+| `startAccessory?: ReactNode`                                         | `startAccessory?: ReactNode`                                                               | unchanged   | when provided, replaces the auto-rendered back button — even if `onBack` is set (legacy precedence preserved).                                                                                                         |
+| `endAccessory?: ReactNode`                                           | `endAccessory?: ReactNode`                                                                 | unchanged   | when provided, replaces the auto-rendered close button — even if `onClose` is set.                                                                                                                                     |
+| `className?: string`                                                 | `className?: string`                                                                       | unchanged   | applied to the outer `<header>`; merged with the component's defaults via `twMerge`.                                                                                                                                   |
+| Polymorphic `as` / extension's `HeaderBaseStyleUtilityProps` surface | removed                                                                                    | removed     | always renders `<header>`. Box utility props on the root (`color`, `textAlign`, `justifyContent`, `padding*`, `width`, …) are removed — use `className` with Tailwind utilities.                                       |
+| `mm-popover-header` SCSS class hook                                  | removed                                                                                    | removed     | no SCSS rule referenced this class — only the legacy test asserted it. Use `className` to customize the root via Tailwind utilities.                                                                                   |
+| `childrenWrapperProps`                                               | removed                                                                                    | removed     | the auto-wrapped title slot is fixed at `col-start-2 col-end-3 w-full`. To customize the title layout, pass a custom `ReactNode` as `children` instead of relying on `childrenWrapperProps`.                           |
+
+##### i18n Decoupling
+
+The extension auto-defaulted the icon-button `aria-label`s to `t('back')` and `t('close')` via `useI18nContext`. The design system **does not** pull strings from any translation context, and there is **no** internal English fallback. The type system enforces this: `onBack` and `backButtonProps` (and `onClose` / `closeButtonProps`) are co-required via a discriminated union — when `onBack` is set, you must also pass `backButtonProps` with at least an `ariaLabel`:
+
+```tsx
+<PopoverHeader
+  onClose={handleClose}
+  closeButtonProps={{ ariaLabel: t('close') }}
+>
+  {t('headerTitle')}
+</PopoverHeader>
+```
+
+If a consumer sets `onClose` without `closeButtonProps`, TypeScript errors at the call site. This guarantees every dismiss button gets a properly localized label without the component reaching into any global i18n context.
+
+##### Color Inheritance
+
+The extension hard-coded `IconColor.inherit` and `TextColor.inherit` on the auto-rendered icon buttons and the auto-wrapped title. The design system preserves this default — the title uses `TextColor.Inherit`, and the auto-rendered `ButtonIcon`s receive `className="text-inherit"` (merged with any consumer-provided `className`). To force a specific color, pass `className` on the prop bag:
+
+```tsx
+closeButtonProps={{ ariaLabel: t('close'), className: 'text-error-default' }}
+```
+
+##### ButtonIcon API Differences
+
+The extension's `ButtonIconProps<'button'>` is replaced by MMDS `ButtonIconProps`. The most common difference for migrating consumers is that the polymorphic `as` typing is gone (the prop bag types against the underlying `<button>` HTML element directly). All standard ButtonIcon props (`ariaLabel`, `disabled`, `onClick`, `data-testid`, etc.) are preserved.
+
+#### Migration Examples
+
+##### Before (Extension)
+
+```tsx
+import { PopoverHeader } from '../../component-library';
+
+// i18n-defaulted close + Box utility props
+<PopoverHeader
+  color={TextColor.infoInverse}
+  textAlign={TextAlign.Center}
+  justifyContent={JustifyContent.spaceBetween}
+  onClose={onClose}
+  childrenWrapperProps={{ style: { whiteSpace: 'nowrap' } }}
+>
+  {title}
+</PopoverHeader>;
+```
+
+##### After (Design System)
+
+```tsx
+import { PopoverHeader } from '@metamask/design-system-react';
+
+// aria-label is explicit; Box utility props move to className.
+// The title and the auto-rendered close button inherit color from the
+// surrounding popover surface, so no `color` prop is needed on the header
+// itself — set the color on the popover container instead.
+<PopoverHeader
+  className="text-info-inverse"
+  onClose={onClose}
+  closeButtonProps={{ ariaLabel: t('close') }}
+>
+  <span className="whitespace-nowrap">{title}</span>
+</PopoverHeader>;
+```
+
+For the typical extension call site — `ui/pages/bridge/layout/tooltip.tsx` (the only consumer outside of the `popover-header/` package itself, verified via fresh grep) — the churn is:
+
+1. Swap the import path.
+2. Add `closeButtonProps={{ ariaLabel: t('close') }}` to every `<PopoverHeader>` that uses `onClose` (and `backButtonProps={{ ariaLabel: t('back') }}` for `onBack`). The compiler flags missing prop bags so this can be applied mechanically.
+3. Move any root-level Box utility props (`color`, `textAlign`, `justifyContent`, `padding*`, `width`, etc.) onto `className` with Tailwind utilities.
+4. Replace `childrenWrapperProps` with a custom `ReactNode` `children` that wraps the title in the desired layout.
+
+#### API Differences
+
+- `PopoverHeader` always renders a `<header>` and forwards arbitrary HTML attributes (`id`, `role`, `data-*`, `aria-*`, `ref`) to it.
+- The `useI18nContext` coupling for the icon-button `aria-label`s is gone. Discriminated unions enforce co-required `backButtonProps` / `closeButtonProps` at compile time.
+- The component owns `iconName` (`ArrowLeft` / `Close`) and `size` (`Sm`) on the built-in icon buttons. Consumers cannot override them via the prop bag.
+- The auto-rendered icon buttons and the auto-wrapped title default to `text-inherit` so they pick up the popover surface color, preserving the legacy `IconColor.inherit` / `TextColor.inherit` behavior.
+- `startAccessory` / `endAccessory` precedence over the auto-rendered back/close buttons is preserved from the legacy.
+- No outer padding is applied by default — popover surfaces own their own spacing.
 
 ### SensitiveText Component
 

--- a/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.stories.tsx
+++ b/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.stories.tsx
@@ -15,18 +15,24 @@ const meta: Meta<PopoverHeaderProps> = {
       page: README,
     },
   },
-  // Wrap each story in a dialog landmark so the `<header>` inside is scoped
-  // to its parent role and is not treated as a top-level `banner` landmark
-  // by axe. This mirrors real usage — `PopoverHeader` always lives inside a
-  // `Popover`/`<dialog>`.
+  // Wrap each story in a dialog landmark. The inner <article> is a sectioning
+  // element that scopes the <header> inside PopoverHeader so axe does NOT
+  // assign it the banner role (axe computes the header's role from the HTML
+  // element tag hierarchy: article/aside/main/nav/section all scope it).
+  // `text-default` on the dialog ensures `text-inherit` on the title
+  // resolves to the correct design-token color in both light and dark themes
+  // instead of falling back to the browser default.
   decorators: [
     (Story, context) => (
       <div
         role="dialog"
         aria-modal="true"
         aria-label={`PopoverHeader — ${context.name}`}
+        className="text-default"
       >
-        <Story />
+        <article>
+          <Story />
+        </article>
       </div>
     ),
   ],

--- a/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.stories.tsx
+++ b/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.stories.tsx
@@ -1,7 +1,10 @@
+import { BoxBackgroundColor, IconName } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
-import { Box, BoxBackgroundColor } from '../Box';
+import { Box } from '../Box';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
 
 import { PopoverHeader } from './PopoverHeader';
 import type { PopoverHeaderProps } from './PopoverHeader.types';
@@ -51,15 +54,20 @@ export const Default: Story = {
   },
 };
 
-export const WithCloseButton: Story = {
-  args: {
-    children: 'Popover title',
-    onClose: () => undefined,
-    closeButtonProps: { ariaLabel: 'Close' },
-  },
+export const Children: Story = {
+  render: () => (
+    <PopoverHeader
+      onClose={() => undefined}
+      closeButtonProps={{ ariaLabel: 'Close' }}
+    >
+      <Box backgroundColor={BoxBackgroundColor.PrimaryMuted} padding={2}>
+        <Text>Custom node children render as-is</Text>
+      </Box>
+    </PopoverHeader>
+  ),
 };
 
-export const WithBackAndCloseButtons: Story = {
+export const OnBack: Story = {
   args: {
     children: 'Popover title',
     onBack: () => undefined,
@@ -69,31 +77,18 @@ export const WithBackAndCloseButtons: Story = {
   },
 };
 
-export const StringTitle: Story = {
+export const OnClose: Story = {
   args: {
-    children: 'String children auto-wrap as centered HeadingSm Text',
+    children: 'Popover title',
     onClose: () => undefined,
     closeButtonProps: { ariaLabel: 'Close' },
   },
 };
 
-export const NodeTitle: Story = {
+export const StartAccessory: Story = {
   render: () => (
     <PopoverHeader
-      onClose={() => undefined}
-      closeButtonProps={{ ariaLabel: 'Close' }}
-    >
-      <Box backgroundColor={BoxBackgroundColor.PrimaryMuted} padding={2}>
-        Custom node children render as-is
-      </Box>
-    </PopoverHeader>
-  ),
-};
-
-export const StartAccessoryOverride: Story = {
-  render: () => (
-    <PopoverHeader
-      startAccessory={<span aria-label="custom start">⭐</span>}
+      startAccessory={<Icon name={IconName.Star} aria-label="custom start" />}
       onClose={() => undefined}
       closeButtonProps={{ ariaLabel: 'Close' }}
     >
@@ -102,12 +97,14 @@ export const StartAccessoryOverride: Story = {
   ),
 };
 
-export const EndAccessoryOverride: Story = {
+export const EndAccessory: Story = {
   render: () => (
     <PopoverHeader
       onBack={() => undefined}
       backButtonProps={{ ariaLabel: 'Back' }}
-      endAccessory={<span aria-label="custom end">🔔</span>}
+      endAccessory={
+        <Icon name={IconName.Notification} aria-label="custom end" />
+      }
     >
       Custom endAccessory replaces the close button
     </PopoverHeader>

--- a/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.stories.tsx
+++ b/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+
+import { Box, BoxBackgroundColor } from '../Box';
+
+import { PopoverHeader } from './PopoverHeader';
+import type { PopoverHeaderProps } from './PopoverHeader.types';
+import README from './README.mdx';
+
+const meta: Meta<PopoverHeaderProps> = {
+  title: 'React Components/PopoverHeader',
+  component: PopoverHeader,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  // Wrap each story in a dialog landmark so the `<header>` inside is scoped
+  // to its parent role and is not treated as a top-level `banner` landmark
+  // by axe. This mirrors real usage — `PopoverHeader` always lives inside a
+  // `Popover`/`<dialog>`.
+  decorators: [
+    (Story, context) => (
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`PopoverHeader — ${context.name}`}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    className: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<PopoverHeaderProps>;
+
+export const Default: Story = {
+  args: {
+    children: 'Popover title',
+  },
+};
+
+export const WithCloseButton: Story = {
+  args: {
+    children: 'Popover title',
+    onClose: () => undefined,
+    closeButtonProps: { ariaLabel: 'Close' },
+  },
+};
+
+export const WithBackAndCloseButtons: Story = {
+  args: {
+    children: 'Popover title',
+    onBack: () => undefined,
+    backButtonProps: { ariaLabel: 'Back' },
+    onClose: () => undefined,
+    closeButtonProps: { ariaLabel: 'Close' },
+  },
+};
+
+export const StringTitle: Story = {
+  args: {
+    children: 'String children auto-wrap as centered HeadingSm Text',
+    onClose: () => undefined,
+    closeButtonProps: { ariaLabel: 'Close' },
+  },
+};
+
+export const NodeTitle: Story = {
+  render: () => (
+    <PopoverHeader
+      onClose={() => undefined}
+      closeButtonProps={{ ariaLabel: 'Close' }}
+    >
+      <Box backgroundColor={BoxBackgroundColor.PrimaryMuted} padding={2}>
+        Custom node children render as-is
+      </Box>
+    </PopoverHeader>
+  ),
+};
+
+export const StartAccessoryOverride: Story = {
+  render: () => (
+    <PopoverHeader
+      startAccessory={<span aria-label="custom start">⭐</span>}
+      onClose={() => undefined}
+      closeButtonProps={{ ariaLabel: 'Close' }}
+    >
+      Custom startAccessory replaces the back button
+    </PopoverHeader>
+  ),
+};
+
+export const EndAccessoryOverride: Story = {
+  render: () => (
+    <PopoverHeader
+      onBack={() => undefined}
+      backButtonProps={{ ariaLabel: 'Back' }}
+      endAccessory={<span aria-label="custom end">🔔</span>}
+    >
+      Custom endAccessory replaces the close button
+    </PopoverHeader>
+  ),
+};

--- a/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.test.tsx
+++ b/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.test.tsx
@@ -1,0 +1,204 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { createRef } from 'react';
+
+import { PopoverHeader } from './PopoverHeader';
+
+describe('PopoverHeader', () => {
+  it('renders without crashing', () => {
+    render(<PopoverHeader data-testid="popover-header" />);
+    expect(screen.getByTestId('popover-header')).toBeInTheDocument();
+  });
+
+  it('renders as a <header> element with no outer padding utilities', () => {
+    render(<PopoverHeader data-testid="popover-header" />);
+    const header = screen.getByTestId('popover-header');
+    expect(header.tagName).toBe('HEADER');
+    // PopoverHeader does not bake in padding — popover surfaces own spacing.
+    expect(header).not.toHaveClass('px-4');
+    expect(header).not.toHaveClass('pb-4');
+  });
+
+  it('uses the three-column grid layout on the root', () => {
+    render(<PopoverHeader data-testid="popover-header" />);
+    expect(screen.getByTestId('popover-header')).toHaveClass(
+      'grid',
+      'grid-cols-[1fr_auto_1fr]',
+      'items-center',
+    );
+  });
+
+  it('wraps a string `children` in a centered HeadingSm Text that inherits color', () => {
+    render(<PopoverHeader>Popover title</PopoverHeader>);
+    const title = screen.getByText('Popover title');
+    expect(title).toHaveClass('text-center', 'text-inherit');
+  });
+
+  it('renders a non-string `children` as-is', () => {
+    render(
+      <PopoverHeader>
+        <span data-testid="custom-title">Custom title</span>
+      </PopoverHeader>,
+    );
+    expect(screen.getByTestId('custom-title')).toHaveTextContent(
+      'Custom title',
+    );
+  });
+
+  it('renders the back button when onBack + backButtonProps are provided and fires onClick', () => {
+    const onBack = jest.fn();
+    render(
+      <PopoverHeader
+        onBack={onBack}
+        backButtonProps={{
+          ariaLabel: 'Back',
+          'data-testid': 'back-button',
+        }}
+      >
+        Title
+      </PopoverHeader>,
+    );
+    const back = screen.getByTestId('back-button');
+    expect(back).toHaveAttribute('aria-label', 'Back');
+    // Auto-rendered icon button inherits surface color by default.
+    expect(back).toHaveClass('text-inherit');
+    fireEvent.click(back);
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the close button when onClose + closeButtonProps are provided and fires onClick', () => {
+    const onClose = jest.fn();
+    render(
+      <PopoverHeader
+        onClose={onClose}
+        closeButtonProps={{
+          ariaLabel: 'Close',
+          'data-testid': 'close-button',
+        }}
+      >
+        Title
+      </PopoverHeader>,
+    );
+    const close = screen.getByTestId('close-button');
+    expect(close).toHaveAttribute('aria-label', 'Close');
+    expect(close).toHaveClass('text-inherit');
+    fireEvent.click(close);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets `closeButtonProps.className` override the inherit-color default', () => {
+    render(
+      <PopoverHeader
+        onClose={() => undefined}
+        closeButtonProps={{
+          ariaLabel: 'Close',
+          'data-testid': 'close-button',
+          className: 'text-error-default',
+        }}
+      >
+        Title
+      </PopoverHeader>,
+    );
+    const close = screen.getByTestId('close-button');
+    expect(close).toHaveClass('text-error-default');
+    expect(close).not.toHaveClass('text-inherit');
+  });
+
+  it('does not render the back/close buttons when their callbacks are not provided', () => {
+    render(<PopoverHeader>Title</PopoverHeader>);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('startAccessory overrides the auto-rendered back button', () => {
+    const onBack = jest.fn();
+    render(
+      <PopoverHeader
+        startAccessory={<span data-testid="custom-start">start</span>}
+        onBack={onBack}
+        backButtonProps={{
+          ariaLabel: 'Back',
+          'data-testid': 'back-button',
+        }}
+      >
+        Title
+      </PopoverHeader>,
+    );
+    expect(screen.getByTestId('custom-start')).toBeInTheDocument();
+    expect(screen.queryByTestId('back-button')).not.toBeInTheDocument();
+  });
+
+  it('endAccessory overrides the auto-rendered close button', () => {
+    const onClose = jest.fn();
+    render(
+      <PopoverHeader
+        endAccessory={<span data-testid="custom-end">end</span>}
+        onClose={onClose}
+        closeButtonProps={{
+          ariaLabel: 'Close',
+          'data-testid': 'close-button',
+        }}
+      >
+        Title
+      </PopoverHeader>,
+    );
+    expect(screen.getByTestId('custom-end')).toBeInTheDocument();
+    expect(screen.queryByTestId('close-button')).not.toBeInTheDocument();
+  });
+
+  it('places start/title/end into columns 1/2/3 of the grid', () => {
+    render(
+      <PopoverHeader
+        startAccessory={<span data-testid="start">s</span>}
+        endAccessory={<span data-testid="end">e</span>}
+      >
+        Title
+      </PopoverHeader>,
+    );
+    expect(screen.getByTestId('start').parentElement).toHaveClass(
+      'col-start-1',
+      'justify-self-start',
+    );
+    expect(screen.getByText('Title').parentElement).toHaveClass(
+      'col-start-2',
+      'col-end-3',
+      'w-full',
+    );
+    expect(screen.getByTestId('end').parentElement).toHaveClass(
+      'col-start-3',
+      'justify-self-end',
+    );
+  });
+
+  it('merges custom className alongside default header classes', () => {
+    render(
+      <PopoverHeader data-testid="popover-header" className="opacity-50" />,
+    );
+    const header = screen.getByTestId('popover-header');
+    expect(header).toHaveClass(
+      'opacity-50',
+      'grid',
+      'grid-cols-[1fr_auto_1fr]',
+    );
+  });
+
+  it('forwards arbitrary HTML attributes to the root', () => {
+    render(
+      <PopoverHeader
+        data-testid="popover-header"
+        id="header-id"
+        role="banner"
+        aria-label="Popover header"
+      />,
+    );
+    const header = screen.getByTestId('popover-header');
+    expect(header).toHaveAttribute('id', 'header-id');
+    expect(header).toHaveAttribute('role', 'banner');
+    expect(header).toHaveAttribute('aria-label', 'Popover header');
+  });
+
+  it('forwards ref to the underlying <header> element', () => {
+    const ref = createRef<HTMLElement>();
+    render(<PopoverHeader ref={ref} data-testid="popover-header" />);
+    expect(ref.current).toBe(screen.getByTestId('popover-header'));
+    expect(ref.current?.tagName).toBe('HEADER');
+  });
+});

--- a/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.tsx
+++ b/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.tsx
@@ -1,11 +1,10 @@
-import React, { forwardRef } from 'react';
-
 import {
   ButtonIconSize,
   IconName,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-shared';
+import React, { forwardRef } from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
 import { Box } from '../Box';

--- a/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.tsx
+++ b/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.tsx
@@ -1,10 +1,16 @@
 import React, { forwardRef } from 'react';
 
+import {
+  ButtonIconSize,
+  IconName,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-shared';
+
 import { twMerge } from '../../utils/tw-merge';
 import { Box } from '../Box';
-import { ButtonIcon, ButtonIconSize } from '../ButtonIcon';
-import { IconName } from '../Icon';
-import { Text, TextAlign, TextColor, TextVariant } from '../Text';
+import { ButtonIcon } from '../ButtonIcon';
+import { Text, TextAlign } from '../Text';
 
 import type { PopoverHeaderProps } from './PopoverHeader.types';
 

--- a/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.tsx
+++ b/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.tsx
@@ -1,0 +1,102 @@
+import React, { forwardRef } from 'react';
+
+import { twMerge } from '../../utils/tw-merge';
+import { Box } from '../Box';
+import { ButtonIcon, ButtonIconSize } from '../ButtonIcon';
+import { IconName } from '../Icon';
+import { Text, TextAlign, TextColor, TextVariant } from '../Text';
+
+import type { PopoverHeaderProps } from './PopoverHeader.types';
+
+export const PopoverHeader = forwardRef<HTMLElement, PopoverHeaderProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      startAccessory,
+      endAccessory,
+      onBack,
+      backButtonProps,
+      onClose,
+      closeButtonProps,
+      ...rest
+    } = props;
+
+    // The discriminated union on `PopoverHeaderProps` guarantees that whenever
+    // `onBack` is set, `backButtonProps` is also set (with a required
+    // `ariaLabel`). Same for `onClose` / `closeButtonProps`. The `&&` checks
+    // below give TypeScript a narrowing point and double as runtime guards.
+    // The auto-rendered icon buttons default to `text-inherit` so they pick
+    // up the popover surface color (preserving the legacy `IconColor.inherit`
+    // behavior); consumers can still override via `className` on the prop bag.
+    const resolvedStartAccessory =
+      startAccessory ??
+      (onBack && backButtonProps ? (
+        <ButtonIcon
+          iconName={IconName.ArrowLeft}
+          size={ButtonIconSize.Sm}
+          onClick={onBack}
+          {...backButtonProps}
+          className={twMerge('text-inherit', backButtonProps.className)}
+        />
+      ) : null);
+
+    const resolvedEndAccessory =
+      endAccessory ??
+      (onClose && closeButtonProps ? (
+        <ButtonIcon
+          iconName={IconName.Close}
+          size={ButtonIconSize.Sm}
+          onClick={onClose}
+          {...closeButtonProps}
+          className={twMerge('text-inherit', closeButtonProps.className)}
+        />
+      ) : null);
+
+    const titleContent =
+      typeof children === 'string' ? (
+        <Text
+          variant={TextVariant.HeadingSm}
+          textAlign={TextAlign.Center}
+          color={TextColor.Inherit}
+        >
+          {children}
+        </Text>
+      ) : (
+        children
+      );
+
+    return (
+      <header
+        ref={ref}
+        className={twMerge(
+          // Three-column grid keeps the title visually centered regardless of
+          // which side accessories are present — same layout primitive as
+          // `HeaderBase`, replicated here so the outer element is the
+          // semantic `<header>` (no extra wrapper div). Unlike `ModalHeader`,
+          // PopoverHeader applies no outer padding — popover surfaces own
+          // their own spacing.
+          'grid grid-cols-[1fr_auto_1fr] items-center',
+          className,
+        )}
+        {...rest}
+      >
+        {resolvedStartAccessory && (
+          <Box className="col-start-1 justify-self-start">
+            {resolvedStartAccessory}
+          </Box>
+        )}
+        {titleContent !== undefined && titleContent !== null && (
+          <Box className="col-start-2 col-end-3 w-full">{titleContent}</Box>
+        )}
+        {resolvedEndAccessory && (
+          <Box className="col-start-3 justify-self-end">
+            {resolvedEndAccessory}
+          </Box>
+        )}
+      </header>
+    );
+  },
+);
+
+PopoverHeader.displayName = 'PopoverHeader';

--- a/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.types.ts
+++ b/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.types.ts
@@ -17,7 +17,10 @@ import type { ButtonIconProps } from '../ButtonIcon';
  * closeButtonProps={{ ariaLabel: t('close') }}
  * ```
  */
-type PopoverHeaderButtonProps = Omit<ButtonIconProps, 'iconName' | 'size'> & {
+type PopoverHeaderButtonProps = Omit<
+  ButtonIconProps,
+  'iconName' | 'size' | 'onClick'
+> & {
   [key: `data-${string}`]: string | undefined;
 };
 

--- a/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.types.ts
+++ b/packages/design-system-react/src/components/PopoverHeader/PopoverHeader.types.ts
@@ -1,0 +1,67 @@
+import type { ComponentProps, ReactNode } from 'react';
+
+import type { ButtonIconProps } from '../ButtonIcon';
+
+/**
+ * Props accepted by the auto-rendered back / close `ButtonIcon`. The
+ * component owns `iconName` (ArrowLeft / Close) and `size`
+ * (ButtonIconSize.Sm), so consumers cannot override them. The `data-*` index
+ * signature lets test ids and other dataset attributes pass through
+ * `Partial`/`Omit` indirection.
+ *
+ * `ariaLabel` is preserved as **required** (it is required on
+ * `ButtonIconProps`). The component does not pull from any i18n context, so
+ * consumers must pass a localized label explicitly:
+ *
+ * ```tsx
+ * closeButtonProps={{ ariaLabel: t('close') }}
+ * ```
+ */
+type PopoverHeaderButtonProps = Omit<ButtonIconProps, 'iconName' | 'size'> & {
+  [key: `data-${string}`]: string | undefined;
+};
+
+/**
+ * Discriminated pair: `onBack` and `backButtonProps` are co-required. If
+ * `onBack` is set, the consumer must also provide `backButtonProps` with a
+ * (required) `ariaLabel`. This enforces the no-i18n-fallback contract at
+ * compile time without an internal English default.
+ */
+type PopoverHeaderBackProps =
+  | { onBack?: undefined; backButtonProps?: undefined }
+  | { onBack: () => void; backButtonProps: PopoverHeaderButtonProps };
+
+/**
+ * Discriminated pair: `onClose` and `closeButtonProps` are co-required. Same
+ * shape and rationale as `PopoverHeaderBackProps`.
+ */
+type PopoverHeaderCloseProps =
+  | { onClose?: undefined; closeButtonProps?: undefined }
+  | { onClose: () => void; closeButtonProps: PopoverHeaderButtonProps };
+
+export type PopoverHeaderProps = Omit<ComponentProps<'header'>, 'children'> &
+  PopoverHeaderBackProps &
+  PopoverHeaderCloseProps & {
+    /**
+     * Header title content. When a string, it is auto-wrapped in a
+     * `Text` with `TextVariant.HeadingSm`, `TextAlign.Center`, and
+     * `TextColor.Inherit` so the title picks up the popover surface color.
+     * When a `ReactNode`, it is rendered as-is.
+     */
+    children?: ReactNode;
+    /**
+     * Optional override for the start (left in LTR) slot. When provided, it
+     * replaces the auto-rendered back button — even if `onBack` is set.
+     */
+    startAccessory?: ReactNode;
+    /**
+     * Optional override for the end (right in LTR) slot. When provided, it
+     * replaces the auto-rendered close button — even if `onClose` is set.
+     */
+    endAccessory?: ReactNode;
+    /**
+     * Optional override for additional CSS classes applied to the
+     * PopoverHeader root. Merged with the component's defaults via `twMerge`.
+     */
+    className?: string;
+  };

--- a/packages/design-system-react/src/components/PopoverHeader/README.mdx
+++ b/packages/design-system-react/src/components/PopoverHeader/README.mdx
@@ -1,0 +1,202 @@
+import { Controls, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as PopoverHeaderStories from './PopoverHeader.stories';
+
+# PopoverHeader
+
+`PopoverHeader` is the top section of a popover. It renders a semantic `<header>` with a centered title and optional back/close buttons. The component owns the iconography and size of the built-in buttons (`ArrowLeft` / `Close` at `ButtonIconSize.Sm`); consumers configure the click handler and the (required) accessible label via `backButtonProps` / `closeButtonProps`. The title text and the auto-rendered icon buttons inherit color from the popover surface, so headers placed on inverse or semantic backgrounds pick up the right foreground color automatically.
+
+```tsx
+import { PopoverHeader } from '@metamask/design-system-react';
+
+<PopoverHeader
+  onClose={handleClose}
+  closeButtonProps={{ ariaLabel: t('close') }}
+>
+  {t('removeAccount')}
+</PopoverHeader>;
+```
+
+<Canvas of={PopoverHeaderStories.Default} />
+
+## Props
+
+### `children`
+
+Header title content. When a string, it is auto-wrapped in a `Text` component with `TextVariant.HeadingSm`, `TextAlign.Center`, and `TextColor.Inherit` so the title picks up the popover surface color. When a `ReactNode`, it is rendered as-is so consumers can supply custom title layouts.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={PopoverHeaderStories.StringTitle} />
+
+<Canvas of={PopoverHeaderStories.NodeTitle} />
+
+### `onBack` + `backButtonProps`
+
+When `onBack` is set, the component renders a back `ButtonIcon` in the start slot. `backButtonProps` is **co-required** (the type system enforces this): consumers must supply at least `ariaLabel`. The component owns `iconName` (`IconName.ArrowLeft`) and `size` (`ButtonIconSize.Sm`); they cannot be overridden via the prop bag. The auto-rendered button defaults to `text-inherit` so its icon picks up the popover surface color — pass `className` on the prop bag to override.
+
+`PopoverHeader` is i18n-agnostic — pass localized labels from your application's i18n layer (e.g. `t('back')`).
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>onBack: () =&gt; void</code>
+        <br />
+        <code>backButtonProps: Omit&lt;ButtonIconProps, 'iconName' | 'size'&gt;</code>
+      </td>
+      <td align="left">No (but co-required when set)</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `onClose` + `closeButtonProps`
+
+Same shape as `onBack` / `backButtonProps`. When `onClose` is set, a close `ButtonIcon` (`IconName.Close`, `ButtonIconSize.Sm`) renders in the end slot. `closeButtonProps.ariaLabel` is required.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>onClose: () =&gt; void</code>
+        <br />
+        <code>closeButtonProps: Omit&lt;ButtonIconProps, 'iconName' | 'size'&gt;</code>
+      </td>
+      <td align="left">No (but co-required when set)</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={PopoverHeaderStories.WithCloseButton} />
+
+<Canvas of={PopoverHeaderStories.WithBackAndCloseButtons} />
+
+### `startAccessory`
+
+Optional override for the start (left in LTR) slot. When provided, it replaces the auto-rendered back button — even if `onBack` is set.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={PopoverHeaderStories.StartAccessoryOverride} />
+
+### `endAccessory`
+
+Optional override for the end (right in LTR) slot. When provided, it replaces the auto-rendered close button — even if `onClose` is set.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={PopoverHeaderStories.EndAccessoryOverride} />
+
+### `className`
+
+Custom CSS classes applied to the root `<header>` element. Merged with the component's defaults via `twMerge`. PopoverHeader applies no padding by default — popover surfaces own their own spacing.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Component API
+
+<Controls of={PopoverHeaderStories.Default} />
+
+## Migration Guide
+
+Migrating from `ui/components/component-library/popover-header` in MetaMask Extension? See the [PopoverHeader Migration Guide](../../../MIGRATION.md#popoverheader-component) for prop mappings, before/after examples, and the i18n decoupling steps.
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/src/components/PopoverHeader/README.mdx
+++ b/packages/design-system-react/src/components/PopoverHeader/README.mdx
@@ -46,9 +46,7 @@ Header title content. When a string, it is auto-wrapped in a `Text` component wi
   </tbody>
 </table>
 
-<Canvas of={PopoverHeaderStories.StringTitle} />
-
-<Canvas of={PopoverHeaderStories.NodeTitle} />
+<Canvas of={PopoverHeaderStories.Children} />
 
 ### `onBack` + `backButtonProps`
 
@@ -106,9 +104,9 @@ Same shape as `onBack` / `backButtonProps`. When `onClose` is set, a close `Butt
   </tbody>
 </table>
 
-<Canvas of={PopoverHeaderStories.WithCloseButton} />
+<Canvas of={PopoverHeaderStories.OnClose} />
 
-<Canvas of={PopoverHeaderStories.WithBackAndCloseButtons} />
+<Canvas of={PopoverHeaderStories.OnBack} />
 
 ### `startAccessory`
 
@@ -135,7 +133,7 @@ Optional override for the start (left in LTR) slot. When provided, it replaces t
   </tbody>
 </table>
 
-<Canvas of={PopoverHeaderStories.StartAccessoryOverride} />
+<Canvas of={PopoverHeaderStories.StartAccessory} />
 
 ### `endAccessory`
 
@@ -162,7 +160,7 @@ Optional override for the end (right in LTR) slot. When provided, it replaces th
   </tbody>
 </table>
 
-<Canvas of={PopoverHeaderStories.EndAccessoryOverride} />
+<Canvas of={PopoverHeaderStories.EndAccessory} />
 
 ### `className`
 

--- a/packages/design-system-react/src/components/PopoverHeader/index.ts
+++ b/packages/design-system-react/src/components/PopoverHeader/index.ts
@@ -1,0 +1,2 @@
+export { PopoverHeader } from './PopoverHeader';
+export type { PopoverHeaderProps } from './PopoverHeader.types';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -121,6 +121,9 @@ export type { SkeletonProps } from './Skeleton';
 export { SensitiveText, SensitiveTextLength } from './SensitiveText';
 export type { SensitiveTextProps } from './SensitiveText';
 
+export { PopoverHeader } from './PopoverHeader';
+export type { PopoverHeaderProps } from './PopoverHeader';
+
 export { Text } from './Text';
 export {
   TextVariant,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrated `PopoverHeader` component.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-324

## **Manual testing steps**

1. Open stroybook
2. Check `PopoverHeader` component

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1046" height="379" alt="image" src="https://github.com/user-attachments/assets/ce667049-1be7-41d8-9ae6-b27f782dec0a" />

### **After**

<img width="1034" height="617" alt="image" src="https://github.com/user-attachments/assets/05d5d2de-5795-4b15-a007-4d5e65f3e3d0" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive change introducing a new `PopoverHeader` component with Storybook/tests and documentation updates; low risk aside from potential consumer churn when migrating due to the new co-required `*ButtonProps` typing for `onBack`/`onClose`.
> 
> **Overview**
> Adds a new `PopoverHeader` component to `@metamask/design-system-react` and exports it from the components barrel.
> 
> The new API preserves the back/title/close layout but *drops* legacy Box/polymorphic surfaces and i18n coupling: when `onBack`/`onClose` are provided, `backButtonProps`/`closeButtonProps` (with explicit `ariaLabel`) are now enforced via discriminated unions, and built-in icon/size are owned by the component.
> 
> Includes Storybook stories, a dedicated README, and unit tests covering layout, accessory precedence, attribute/ref forwarding, and default `text-inherit` color behavior, plus an updated `MIGRATION.md` section documenting the extension-to-design-system mapping and breaking changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc0506541a1e31dcc9165c249ff4ca70abfbce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->