### PR TITLE
Align severity vocabulary across components: Error→Danger, Default→Neutral

### DIFF
--- a/packages/design-system-react-native/src/components/AvatarIcon/AvatarIcon.constants.ts
+++ b/packages/design-system-react-native/src/components/AvatarIcon/AvatarIcon.constants.ts
@@ -13,7 +13,7 @@ export const TWCLASSMAP_AVATARICON_SEVERITY_BACKGROUNDCOLOR: Record<
   [AvatarIconSeverity.Neutral]: 'bg-muted',
   [AvatarIconSeverity.Info]: 'bg-info-muted',
   [AvatarIconSeverity.Success]: 'bg-success-muted',
-  [AvatarIconSeverity.Error]: 'bg-error-muted',
+  [AvatarIconSeverity.Danger]: 'bg-error-muted',
   [AvatarIconSeverity.Warning]: 'bg-warning-muted',
 };
 export const MAP_AVATARICON_SIZE_ICONSIZE: Record<AvatarIconSize, IconSize> = {
@@ -30,6 +30,6 @@ export const MAP_AVATARICON_SEVERITY_ICONCOLOR: Record<
   [AvatarIconSeverity.Neutral]: IconColor.IconAlternative,
   [AvatarIconSeverity.Info]: IconColor.InfoDefault,
   [AvatarIconSeverity.Success]: IconColor.SuccessDefault,
-  [AvatarIconSeverity.Error]: IconColor.ErrorDefault,
+  [AvatarIconSeverity.Danger]: IconColor.ErrorDefault,
   [AvatarIconSeverity.Warning]: IconColor.WarningDefault,
 };

--- a/packages/design-system-react-native/src/components/AvatarIcon/AvatarIcon.figma.tsx
+++ b/packages/design-system-react-native/src/components/AvatarIcon/AvatarIcon.figma.tsx
@@ -33,7 +33,7 @@ figma.connect(
         neutral: AvatarIconSeverity.Neutral,
         info: AvatarIconSeverity.Info,
         success: AvatarIconSeverity.Success,
-        error: AvatarIconSeverity.Error,
+        error: AvatarIconSeverity.Danger,
         warning: AvatarIconSeverity.Warning,
       }),
     },

--- a/packages/design-system-react-native/src/components/AvatarIcon/README.md
+++ b/packages/design-system-react-native/src/components/AvatarIcon/README.md
@@ -39,7 +39,7 @@ Available severities:
 - `AvatarIconSeverity.Neutral`
 - `AvatarIconSeverity.Info`
 - `AvatarIconSeverity.Success`
-- `AvatarIconSeverity.Error`
+- `AvatarIconSeverity.Danger`
 - `AvatarIconSeverity.Warning`
 
 ```tsx

--- a/packages/design-system-react-native/src/components/IconAlert/IconAlert.constants.ts
+++ b/packages/design-system-react-native/src/components/IconAlert/IconAlert.constants.ts
@@ -20,7 +20,7 @@ export const ICON_ALERT_SEVERITY_MAP: Record<
     name: IconName.Danger,
     color: IconColor.WarningDefault,
   },
-  [IconAlertSeverity.Error]: {
+  [IconAlertSeverity.Danger]: {
     name: IconName.Error,
     color: IconColor.ErrorDefault,
   },

--- a/packages/design-system-react-native/src/components/IconAlert/README.md
+++ b/packages/design-system-react-native/src/components/IconAlert/README.md
@@ -22,7 +22,7 @@ Available severities:
 - `IconAlertSeverity.Info` — `IconName.Info`, `IconColor.PrimaryDefault`
 - `IconAlertSeverity.Success` — `IconName.Confirmation`, `IconColor.SuccessDefault`
 - `IconAlertSeverity.Warning` — `IconName.Danger`, `IconColor.WarningDefault`
-- `IconAlertSeverity.Error` — `IconName.Error`, `IconColor.ErrorDefault`
+- `IconAlertSeverity.Danger` — `IconName.Error`, `IconColor.ErrorDefault`
 
 | TYPE                | REQUIRED | DEFAULT |
 | ------------------- | -------- | ------- |
@@ -34,7 +34,7 @@ import { IconAlert, IconAlertSeverity } from '@metamask/design-system-react-nati
 <IconAlert severity={IconAlertSeverity.Info} />
 <IconAlert severity={IconAlertSeverity.Success} />
 <IconAlert severity={IconAlertSeverity.Warning} />
-<IconAlert severity={IconAlertSeverity.Error} />
+<IconAlert severity={IconAlertSeverity.Danger} />
 ```
 
 ### `size`

--- a/packages/design-system-react-native/src/components/Tag/README.md
+++ b/packages/design-system-react-native/src/components/Tag/README.md
@@ -20,7 +20,7 @@ Available values:
 
 - `TagSeverity.Neutral`
 - `TagSeverity.Success`
-- `TagSeverity.Error`
+- `TagSeverity.Danger`
 - `TagSeverity.Warning`
 - `TagSeverity.Info`
 
@@ -33,7 +33,7 @@ import { Tag } from '@metamask/design-system-react-native';
 import { TagSeverity } from '@metamask/design-system-shared';
 
 <Tag severity={TagSeverity.Success}>Success</Tag>
-<Tag severity={TagSeverity.Error}>Error</Tag>
+<Tag severity={TagSeverity.Danger}>Danger</Tag>
 ```
 
 ### `children`

--- a/packages/design-system-react-native/src/components/Tag/Tag.constants.ts
+++ b/packages/design-system-react-native/src/components/Tag/Tag.constants.ts
@@ -11,7 +11,7 @@ export const MAP_TAG_SEVERITY_BACKGROUND: Record<
 > = {
   [TagSeverity.Neutral]: BoxBackgroundColor.BackgroundMuted,
   [TagSeverity.Success]: BoxBackgroundColor.SuccessMuted,
-  [TagSeverity.Error]: BoxBackgroundColor.ErrorMuted,
+  [TagSeverity.Danger]: BoxBackgroundColor.ErrorMuted,
   [TagSeverity.Warning]: BoxBackgroundColor.WarningMuted,
   [TagSeverity.Info]: BoxBackgroundColor.InfoMuted,
 };
@@ -19,7 +19,7 @@ export const MAP_TAG_SEVERITY_BACKGROUND: Record<
 export const MAP_TAG_SEVERITY_TEXT_COLOR: Record<TagSeverity, TextColor> = {
   [TagSeverity.Neutral]: TextColor.TextDefault,
   [TagSeverity.Success]: TextColor.SuccessDefault,
-  [TagSeverity.Error]: TextColor.ErrorDefault,
+  [TagSeverity.Danger]: TextColor.ErrorDefault,
   [TagSeverity.Warning]: TextColor.WarningDefault,
   [TagSeverity.Info]: TextColor.InfoDefault,
 };
@@ -27,7 +27,7 @@ export const MAP_TAG_SEVERITY_TEXT_COLOR: Record<TagSeverity, TextColor> = {
 export const MAP_TAG_SEVERITY_ICON_COLOR: Record<TagSeverity, IconColor> = {
   [TagSeverity.Neutral]: IconColor.IconDefault,
   [TagSeverity.Success]: IconColor.SuccessDefault,
-  [TagSeverity.Error]: IconColor.ErrorDefault,
+  [TagSeverity.Danger]: IconColor.ErrorDefault,
   [TagSeverity.Warning]: IconColor.WarningDefault,
   [TagSeverity.Info]: IconColor.InfoDefault,
 };

--- a/packages/design-system-react-native/src/components/Tag/Tag.figma.tsx
+++ b/packages/design-system-react-native/src/components/Tag/Tag.figma.tsx
@@ -28,7 +28,7 @@ figma.connect(
     props: {
       severity: figma.enum('severity', {
         neutral: TagSeverity.Neutral,
-        error: TagSeverity.Error,
+        error: TagSeverity.Danger,
         info: TagSeverity.Info,
         success: TagSeverity.Success,
         warning: TagSeverity.Warning,

--- a/packages/design-system-react-native/src/components/Tag/Tag.stories.tsx
+++ b/packages/design-system-react-native/src/components/Tag/Tag.stories.tsx
@@ -48,8 +48,8 @@ export const Severity: Story = {
       <Tag severity={TagSeverity.Success} twClassName="mt-2">
         Success
       </Tag>
-      <Tag severity={TagSeverity.Error} twClassName="mt-2">
-        Error
+      <Tag severity={TagSeverity.Danger} twClassName="mt-2">
+        Danger
       </Tag>
       <Tag severity={TagSeverity.Warning} twClassName="mt-2">
         Warning

--- a/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.constants.ts
+++ b/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.constants.ts
@@ -20,7 +20,7 @@ export const TWCLASSMAP_AVATARICON_SEVERITY_BACKGROUNDCOLOR: Record<
   [AvatarIconSeverity.Neutral]: 'bg-muted',
   [AvatarIconSeverity.Info]: 'bg-info-muted',
   [AvatarIconSeverity.Success]: 'bg-success-muted',
-  [AvatarIconSeverity.Error]: 'bg-error-muted',
+  [AvatarIconSeverity.Danger]: 'bg-error-muted',
   [AvatarIconSeverity.Warning]: 'bg-warning-muted',
 };
 
@@ -31,6 +31,6 @@ export const MAP_AVATARICON_SEVERITY_ICONCOLOR: Record<
   [AvatarIconSeverity.Neutral]: IconColor.IconAlternative,
   [AvatarIconSeverity.Info]: IconColor.InfoDefault,
   [AvatarIconSeverity.Success]: IconColor.SuccessDefault,
-  [AvatarIconSeverity.Error]: IconColor.ErrorDefault,
+  [AvatarIconSeverity.Danger]: IconColor.ErrorDefault,
   [AvatarIconSeverity.Warning]: IconColor.WarningDefault,
 };

--- a/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.figma.tsx
+++ b/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.figma.tsx
@@ -33,7 +33,7 @@ figma.connect(
         neutral: AvatarIconSeverity.Neutral,
         info: AvatarIconSeverity.Info,
         success: AvatarIconSeverity.Success,
-        error: AvatarIconSeverity.Error,
+        error: AvatarIconSeverity.Danger,
         warning: AvatarIconSeverity.Warning,
       }),
     },

--- a/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.stories.tsx
+++ b/packages/design-system-react/src/components/AvatarIcon/AvatarIcon.stories.tsx
@@ -40,7 +40,7 @@ const meta: Meta<typeof AvatarIcon> = {
       options: Object.keys(AvatarIconSeverity),
       mapping: AvatarIconSeverity,
       description:
-        'Optional prop to control the severity of the avatar. Defaults to AvatarIconSeverity.Default',
+        'Optional prop to control the severity of the avatar. Defaults to AvatarIconSeverity.Neutral',
     },
     className: {
       control: 'text',
@@ -105,7 +105,7 @@ export const Severity: Story = {
       />
       <AvatarIcon
         iconName={IconName.Danger}
-        severity={AvatarIconSeverity.Error}
+        severity={AvatarIconSeverity.Danger}
       />
     </div>
   ),

--- a/packages/design-system-react/src/components/AvatarIcon/README.mdx
+++ b/packages/design-system-react/src/components/AvatarIcon/README.mdx
@@ -90,7 +90,7 @@ Available severities:
 - `AvatarIconSeverity.Info` - info styling for informational content
 - `AvatarIconSeverity.Success` - success styling for positive actions/states
 - `AvatarIconSeverity.Warning` - warning styling for cautionary content
-- `AvatarIconSeverity.Error` - error styling for critical issues
+- `AvatarIconSeverity.Danger` - danger styling for critical issues
 
 <table>
   <thead>

--- a/packages/design-system-shared/src/types/AvatarIcon/AvatarIcon.types.ts
+++ b/packages/design-system-shared/src/types/AvatarIcon/AvatarIcon.types.ts
@@ -21,9 +21,9 @@ export const AvatarIconSeverity = {
    */
   Success: 'success',
   /**
-   * Represents an error severity
+   * Represents a danger severity
    */
-  Error: 'error',
+  Danger: 'danger',
   /**
    * Represents a warning severity
    */
@@ -53,7 +53,7 @@ export type AvatarIconPropsShared = {
    * - AvatarIconSeverity.Neutral
    * - AvatarIconSeverity.Info
    * - AvatarIconSeverity.Success
-   * - AvatarIconSeverity.Error
+   * - AvatarIconSeverity.Danger
    * - AvatarIconSeverity.Warning
    *
    * @default AvatarIconSeverity.Neutral

--- a/packages/design-system-shared/src/types/IconAlert/IconAlert.types.ts
+++ b/packages/design-system-shared/src/types/IconAlert/IconAlert.types.ts
@@ -15,9 +15,9 @@ export const IconAlertSeverity = {
    */
   Warning: 'warning',
   /**
-   * Critical error severity
+   * Critical danger severity
    */
-  Error: 'error',
+  Danger: 'danger',
 } as const;
 export type IconAlertSeverity =
   (typeof IconAlertSeverity)[keyof typeof IconAlertSeverity];

--- a/packages/design-system-shared/src/types/Tag/Tag.types.ts
+++ b/packages/design-system-shared/src/types/Tag/Tag.types.ts
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react';
 export const TagSeverity = {
   Neutral: 'neutral',
   Success: 'success',
-  Error: 'error',
+  Danger: 'danger',
   Warning: 'warning',
   Info: 'info',
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Standardizes severity naming across the design system component APIs per team guidance:

- Error → Danger
- Default → Neutral (where a neutral state exists)

This aligns public props, shared types, stories, and docs. Token names (e.g., ErrorDefault) remain unchanged.

Changes by area:
- Shared types: AvatarIconSeverity, IconAlertSeverity, TagSeverity now use Danger instead of Error
- React (web): AvatarIcon constants, stories updated; Figma mapping now maps the Figma “error” variant to the new Danger severity
- React Native: AvatarIcon, IconAlert, Tag updated (constants, stories); Figma mapping for Tag/AvatarIcon maps Figma “error” to Danger
- Docs: READMEs updated to reference Danger/Neutral

Build, test, and lint all pass via root scripts (`yarn build`, `yarn test`, `yarn lint`).

## Related issues
Fixes: N/A (requested in internal thread)

## Manual testing steps
1. Run `yarn storybook` and verify AvatarIcon (web) shows the Danger option and renders correctly
2. In RN storybook, verify AvatarIcon, IconAlert, and Tag now expose Danger instead of Error
3. Confirm that background/icon colors remain consistent for the Danger state
4. Search the codebase for `*.Error` usages of these severities to verify no remaining references

## Screenshots/Recordings
N/A (visual semantics unchanged; only API naming updated)

### Before
- Components exposed `Error` severity in several APIs; some docs referenced `Default`

### After
- Components expose `Danger`; docs reference `Neutral` as the non-emphasis state

## Pre-merge author checklist
- [x] I’ve followed MetaMask Contributor Docs
- [x] I’ve completed the PR template to the best of my ability
- [x] I’ve updated stories and docs; tests still pass
- [x] Lint and build pass

## Pre-merge reviewer checklist
- [ ] I’ve manually tested updated stories
- [ ] I confirm the naming matches our agreed vocabulary (Danger/Neutral)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C0354T27M5M/p1778083989797669?thread_ts=1778083989.797669&cid=C0354T27M5M)

<div><a href="https://cursor.com/agents/bc-d049d763-4367-5cf0-8acd-d55bb68eccf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d049d763-4367-5cf0-8acd-d55bb68eccf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

