### PR TITLE
refactor: simplify BannerBase close handling

### DIFF
--- a/.cursor/rules/release-workflow.md
+++ b/.cursor/rules/release-workflow.md
@@ -15,8 +15,10 @@ AI-first workflow for creating release PRs with proper version bumps, changelogs
 - ✅ **Release often** for non-breaking changes
 - ✅ **Isolate large breaking changes** to single releases (design tokens, major component API changes)
 - ✅ **Use `yarn create-release-branch`** (documented in @docs/contributing.md)
+- ✅ **Edit package `CHANGELOG.md` files only on release branches** created by `yarn create-release-branch`
 - ✅ **Run `yarn constraints --fix && yarn && yarn dedupe`** after release spec
 - ❌ **NO manual peer dependency updates** - handled automatically by yarn workspaces (causes errors)
+- ❌ **NO package `CHANGELOG.md` edits in normal feature/fix PRs** - document breaking changes in `MIGRATION.md` instead and let the release branch collect changelog entries
 
 ### Changelog Quality
 

--- a/docs/package-migration-process-guide.md
+++ b/docs/package-migration-process-guide.md
@@ -175,10 +175,12 @@ This document outlines the process for migrating a MetaMask library into the met
 - Create a separate issue for resolving the marked errors as soon as the migration is completed.
   - e.g. https://github.com/MetaMask/core/issues/1823
 
-### 5. Record changes made to any metamask design system package in its CHANGELOG, under the `## [Unreleased]` heading
+### 5. Document breaking changes in `MIGRATION.md`; reserve `CHANGELOG.md` for release branches
 
-- CHANGELOG entries should be recorded in the migration target's downstream packages for version bumps to the migration target's current release.
-- [Example PR](https://github.com/MetaMask/core/pull/2003/files): this step can be performed either as a part of Phase C, or in a separate, subsequent PR.
+- In normal migration or feature PRs, document consumer-facing breaking changes in the relevant package `MIGRATION.md`.
+- Do not manually update package `CHANGELOG.md` files in these PRs.
+- Package changelog entries should only be added on release branches created by `yarn create-release-branch`.
+- [Example PR](https://github.com/MetaMask/core/pull/2003/files): release-facing changelog work can happen as part of the release flow or in a separate follow-up release PR.
 
 ### 6. Finalize merge
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -27,7 +27,8 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TabEmptyState Component](#tabemptystate-component)
   - [Toast Component](#toast-component)
 - [Version Updates](#version-updates)
-  - [From version 0.23.0 to 0.x.0](#from-version-0230-to-0x0)
+  - [From version 0.24.0 to 0.x.0](#from-version-0240-to-0x0)
+  - [From version 0.23.0 to 0.24.0](#from-version-0230-to-0240)
   - [From version 0.22.0 to 0.23.0](#from-version-0220-to-0230)
   - [From version 0.21.0 to 0.22.0](#from-version-0210-to-0220)
   - [From version 0.19.0 to 0.20.0](#from-version-0190-to-0200)
@@ -42,9 +43,9 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Version Updates
 
-<!-- TODO: Replace 0.x.0 with the actual next released version when these unreleased follow-ups ship. -->
+<!-- TODO: Replace 0.x.0 with the actual next released version when this BannerBase follow-up ships. -->
 
-### From version 0.23.0 to 0.x.0
+### From version 0.24.0 to 0.x.0
 
 #### BannerBase: `onClose` is now the only close-button behavior API
 
@@ -63,6 +64,12 @@ This guide provides detailed instructions for migrating your project from one ve
 **Impact:**
 
 - Existing **`@metamask/design-system-react-native`** consumers that relied on **`closeButtonProps.onPress`** or on rendering a close button without **`onClose`** must update those call sites.
+
+<!-- Backward-compatible anchor for the 0.24.0 changelog entry that shipped with the old placeholder link. -->
+
+<a id="from-version-0230-to-0x0"></a>
+
+### From version 0.23.0 to 0.24.0
 
 #### Toast: tighten the runtime API and align the surface with the shipped design
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -42,9 +42,27 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Version Updates
 
-<!-- TODO: Replace 0.x.0 with the actual next released version when this Toast follow-up ships. -->
+<!-- TODO: Replace 0.x.0 with the actual next released version when these unreleased follow-ups ship. -->
 
 ### From version 0.23.0 to 0.x.0
+
+#### BannerBase: `onClose` is now the only close-button behavior API
+
+**What changed:**
+
+- **`closeButtonProps.onPress`** is removed from the public **`BannerBase`** API.
+- The close button now renders **only** when **`onClose`** is provided.
+- **`closeButtonProps`** is now customization-only for the rendered close **`ButtonIcon`**.
+
+**Migration:**
+
+- Move any close-button behavior from **`closeButtonProps.onPress`** to **`onClose`**.
+- Keep **`closeButtonProps`** only for non-behavioral customization such as **`testID`**, accessibility props, and styling hooks.
+- If you previously passed only **`closeButtonProps`** to force-render a close button, also provide **`onClose`** now.
+
+**Impact:**
+
+- Existing **`@metamask/design-system-react-native`** consumers that relied on **`closeButtonProps.onPress`** or on rendering a close button without **`onClose`** must update those call sites.
 
 #### Toast: tighten the runtime API and align the surface with the shipped design
 
@@ -2155,21 +2173,21 @@ Mobile `BannerBase` maps to `BannerBase` in the design system, but the action-bu
 
 ##### Renamed Props
 
-| Legacy Mobile API                            | MMDS API                                     |
-| -------------------------------------------- | -------------------------------------------- |
-| `actionButtonProps.onPress`                  | `actionButtonOnPress`                        |
-| `actionButtonProps.label`                    | `actionButtonLabel`                          |
-| `closeButtonProps.onPress` (still supported) | `closeButtonProps.onPress` (still supported) |
+| Legacy Mobile API           | MMDS API              |
+| --------------------------- | --------------------- |
+| `actionButtonProps.onPress` | `actionButtonOnPress` |
+| `actionButtonProps.label`   | `actionButtonLabel`   |
+| `closeButtonProps.onPress`  | **`onClose`**         |
 
 ##### Type and Callback Signature Changes
 
-| Legacy Mobile API                                       | MMDS API                                                                                                                            | Notes                                                                        |
-| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `actionButtonProps?: ButtonProps`                       | `actionButtonProps?: Omit<Partial<ButtonProps>, 'children' \| 'onPress' \| 'variant'>`                                              | MMDS prevents setting action handler and variant through `actionButtonProps` |
-| `actionButtonProps` controls rendering of action button | `actionButtonOnPress` controls rendering of action button                                                                           | Action button is shown only when `actionButtonOnPress` is provided           |
-| `title?: string \| React.ReactNode`                     | `title?: ReactNode`                                                                                                                 | Equivalent content support                                                   |
-| `description?: string \| React.ReactNode`               | `description?: ReactNode`                                                                                                           | Equivalent content support                                                   |
-| `closeButtonProps?: ButtonIconProps`                    | `closeButtonProps?: Omit<Partial<ButtonIconProps>, 'iconName' \| 'onPress'> & { onPress?: (event: GestureResponderEvent) => void }` | `iconName` remains fixed to close icon                                       |
+| Legacy Mobile API                                       | MMDS API                                                                               | Notes                                                                        |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `actionButtonProps?: ButtonProps`                       | `actionButtonProps?: Omit<Partial<ButtonProps>, 'children' \| 'onPress' \| 'variant'>` | MMDS prevents setting action handler and variant through `actionButtonProps` |
+| `actionButtonProps` controls rendering of action button | `actionButtonOnPress` controls rendering of action button                              | Action button is shown only when `actionButtonOnPress` is provided           |
+| `title?: string \| React.ReactNode`                     | `title?: ReactNode`                                                                    | Equivalent content support                                                   |
+| `description?: string \| React.ReactNode`               | `description?: ReactNode`                                                              | Equivalent content support                                                   |
+| `closeButtonProps?: ButtonIconProps`                    | `closeButtonProps?: Omit<Partial<ButtonIconProps>, 'iconName' \| 'onPress'>`           | `iconName` remains fixed to close icon; use `onClose` for behavior           |
 
 ##### Default and Behavior Changes
 
@@ -2177,7 +2195,7 @@ Mobile `BannerBase` maps to `BannerBase` in the design system, but the action-bu
 | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
 | Action button shown when `actionButtonProps` exists                      | Action button shown when `actionButtonOnPress` exists                                                              |
 | Action button defaults to `size={ButtonSize.Auto}`                       | Action button defaults to `size={ButtonSize.Md}`                                                                   |
-| Close button press fallback uses `noop` when callbacks are missing       | Close button callback is omitted when callbacks are missing                                                        |
+| Close button press fallback uses `noop` when callbacks are missing       | Close button is rendered only when `onClose` is provided                                                           |
 | Close button icon default color is `IconColor.Default`                   | MMDS `BannerBase` delegates icon color to `ButtonIcon` defaults unless explicitly overridden in `closeButtonProps` |
 | Close button accessibility label had no explicit default in `BannerBase` | Default close label is `'Close banner'` (override with `closeButtonProps.accessibilityLabel`)                      |
 

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.stories.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.stories.tsx
@@ -41,7 +41,8 @@ const meta: Meta<BannerBaseProps> = {
     },
     closeButtonProps: {
       control: 'object',
-      description: 'Optional props for the close button',
+      description:
+        'Optional non-behavioral props for the close button when onClose is provided',
     },
     startAccessory: {
       control: false,

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
@@ -110,4 +110,25 @@ describe('BannerBase', () => {
 
     expect(queryByTestId(closeButtonTestId)).toBeNull();
   });
+
+  it('ignores leaked closeButtonProps.onPress and still calls onClose', () => {
+    const onClose = jest.fn();
+    const leakedOnPress = jest.fn();
+    const { getByTestId } = render(
+      <BannerBase
+        onClose={onClose}
+        closeButtonProps={
+          {
+            testID: closeButtonTestId,
+            onPress: leakedOnPress,
+          } as never
+        }
+      />,
+    );
+
+    fireEvent.press(getByTestId(closeButtonTestId));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(leakedOnPress).not.toHaveBeenCalled();
+  });
 });

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
@@ -110,25 +110,4 @@ describe('BannerBase', () => {
 
     expect(queryByTestId(closeButtonTestId)).toBeNull();
   });
-
-  it('ignores leaked closeButtonProps.onPress and still calls onClose', () => {
-    const onClose = jest.fn();
-    const leakedOnPress = jest.fn();
-    const { getByTestId } = render(
-      <BannerBase
-        onClose={onClose}
-        closeButtonProps={
-          {
-            testID: closeButtonTestId,
-            onPress: leakedOnPress,
-          } as never
-        }
-      />,
-    );
-
-    fireEvent.press(getByTestId(closeButtonTestId));
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-    expect(leakedOnPress).not.toHaveBeenCalled();
-  });
 });

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
@@ -97,12 +97,10 @@ describe('BannerBase', () => {
     );
   });
 
-  it('renders close button and triggers closeButtonProps.onPress when onClose is not provided', () => {
-    const onCloseButtonPress = jest.fn();
-    const { getByTestId } = render(
+  it('does not render close button when only closeButtonProps are provided', () => {
+    const { queryByTestId } = render(
       <BannerBase
         closeButtonProps={{
-          onPress: onCloseButtonPress,
           accessibilityLabel: 'Dismiss banner',
           testID: closeButtonTestId,
           twClassName: 'p-2',
@@ -110,10 +108,6 @@ describe('BannerBase', () => {
       />,
     );
 
-    expect(getByTestId(closeButtonTestId).props.accessibilityLabel).toBe(
-      'Dismiss banner',
-    );
-    fireEvent.press(getByTestId(closeButtonTestId));
-    expect(onCloseButtonPress).toHaveBeenCalledTimes(1);
+    expect(queryByTestId(closeButtonTestId)).toBeNull();
   });
 });

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -9,7 +9,6 @@ import {
   TextVariant,
 } from '@metamask/design-system-shared';
 import React from 'react';
-import { GestureResponderEvent } from 'react-native';
 
 import { Box } from '../Box';
 import { Button } from '../Button';
@@ -44,24 +43,12 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
 
   const {
     accessibilityLabel: closeButtonAccessibilityLabel = 'Close banner',
-    onPress: closeButtonPropsOnPress,
     twClassName: closeButtonTwClassName,
     ...resolvedCloseButtonProps
   } = closeButtonProps ?? {};
 
-  const shouldShowCloseButton = Boolean(onClose || closeButtonProps);
+  const shouldShowCloseButton = Boolean(onClose);
   const shouldShowActionButton = Boolean(actionButtonOnPress);
-
-  const handleClosePress =
-    onClose || closeButtonPropsOnPress
-      ? (event: GestureResponderEvent) => {
-          if (onClose) {
-            onClose();
-            return;
-          }
-          closeButtonPropsOnPress?.(event);
-        }
-      : undefined;
 
   const mergedCloseButtonTwClassName = closeButtonTwClassName
     ? `ml-3 ${closeButtonTwClassName}`
@@ -133,7 +120,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
           iconName={IconName.Close}
           size={ButtonIconSize.Sm}
           accessibilityLabel={closeButtonAccessibilityLabel}
-          onPress={handleClosePress}
+          onPress={onClose}
           {...resolvedCloseButtonProps}
         />
       )}

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -43,7 +43,6 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
 
   const {
     accessibilityLabel: closeButtonAccessibilityLabel = 'Close banner',
-    onPress: _ignoredCloseButtonOnPress,
     twClassName: closeButtonTwClassName,
     ...resolvedCloseButtonProps
   } = closeButtonProps ?? {};

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -43,6 +43,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
 
   const {
     accessibilityLabel: closeButtonAccessibilityLabel = 'Close banner',
+    onPress: _ignoredCloseButtonOnPress,
     twClassName: closeButtonTwClassName,
     ...resolvedCloseButtonProps
   } = closeButtonProps ?? {};

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.types.ts
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.types.ts
@@ -14,12 +14,7 @@ type BannerBaseActionButtonProps = Omit<
 type BannerBaseCloseButtonProps = Omit<
   Partial<ButtonIconProps>,
   'iconName' | 'onPress'
-> & {
-  /**
-   * Optional press handler for the close button.
-   */
-  onPress?: (event: GestureResponderEvent) => void;
-};
+>;
 
 type BannerBasePropsBase = BannerBasePropsShared &
   Omit<BoxProps, 'children'> & {
@@ -42,7 +37,7 @@ type BannerBasePropsBase = BannerBasePropsShared &
     onClose?: () => void;
     /**
      * Optional props for the close `ButtonIcon`.
-     * Providing this also shows a close button.
+     * Only used when `onClose` is provided.
      */
     closeButtonProps?: BannerBaseCloseButtonProps;
   };

--- a/packages/design-system-react-native/src/components/BannerBase/README.md
+++ b/packages/design-system-react-native/src/components/BannerBase/README.md
@@ -95,12 +95,12 @@ When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass 
 
 ### `onClose`
 
-Optional close callback. If passed, a close button is shown. Use `closeButtonProps` to pass additional props to the close `ButtonIcon`, including `testID` when needed for testing.
+Optional close callback. If passed, a close button is shown. Use `closeButtonProps` to pass additional non-behavioral props to the close `ButtonIcon`, including `testID`, accessibility props, and styling hooks when needed for testing.
 
-| PROP               | TYPE                                                                                                             | REQUIRED | DEFAULT     |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| `onClose`          | `() => void`                                                                                                     | No       | `undefined` |
-| `closeButtonProps` | `Omit<Partial<ButtonIconProps>, 'iconName' \| 'onPress'> & { onPress?: (event: GestureResponderEvent) => void }` | No       | `undefined` |
+| PROP               | TYPE                                                      | REQUIRED | DEFAULT     |
+| ------------------ | --------------------------------------------------------- | -------- | ----------- |
+| `onClose`          | `() => void`                                              | No       | `undefined` |
+| `closeButtonProps` | `Omit<Partial<ButtonIconProps>, 'iconName' \| 'onPress'>` | No       | `undefined` |
 
 ```tsx
 <BannerBase

--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -25,6 +25,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [ModalOverlay Component](#modaloverlay-component)
   - [Skeleton Component](#skeleton-component)
 - [Version Updates](#version-updates)
+  - [From version 0.21.0 to 0.x.0](#from-version-0210-to-0x0)
   - [From version 0.17.0 to 0.18.0](#from-version-0170-to-0180)
   - [From version 0.16.0 to 0.17.0](#from-version-0160-to-0170)
   - [From version 0.12.0 to 0.13.0](#from-version-0120-to-0130)
@@ -887,20 +888,20 @@ No direct prop renames were introduced for extension-to-MMDS `BannerBase`.
 
 ##### Type and Callback Signature Changes
 
-| Legacy Extension API                                     | MMDS API                                                                                                                          | Notes                                                 |
-| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `title?: string`                                         | `title?: ReactNode`                                                                                                               | MMDS now accepts full React node content              |
-| `description?: string`                                   | `description?: ReactNode`                                                                                                         | MMDS now accepts full React node content              |
-| `actionButtonProps?: Partial<ButtonLinkProps<'button'>>` | `actionButtonProps?: Omit<Partial<ButtonProps>, 'children' \| 'onClick' \| 'variant'>`                                            | MMDS action button is a `Button`, not a `ButtonLink`  |
-| `onClose?: (e: React.MouseEvent<HTMLElement>) => void`   | `onClose?: MouseEventHandler<HTMLButtonElement>`                                                                                  | Close callback target is now the close button element |
-| `closeButtonProps?: Partial<ButtonIconProps<'button'>>`  | `closeButtonProps?: Omit<Partial<ButtonIconProps>, 'iconName' \| 'onClick'> & { onClick?: MouseEventHandler<HTMLButtonElement> }` | `iconName` remains fixed to close icon                |
+| Legacy Extension API                                     | MMDS API                                                                               | Notes                                                              |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `title?: string`                                         | `title?: ReactNode`                                                                    | MMDS now accepts full React node content                           |
+| `description?: string`                                   | `description?: ReactNode`                                                              | MMDS now accepts full React node content                           |
+| `actionButtonProps?: Partial<ButtonLinkProps<'button'>>` | `actionButtonProps?: Omit<Partial<ButtonProps>, 'children' \| 'onClick' \| 'variant'>` | MMDS action button is a `Button`, not a `ButtonLink`               |
+| `onClose?: (e: React.MouseEvent<HTMLElement>) => void`   | `onClose?: MouseEventHandler<HTMLButtonElement>`                                       | Close callback target is now the close button element              |
+| `closeButtonProps?: Partial<ButtonIconProps<'button'>>`  | `closeButtonProps?: Omit<Partial<ButtonIconProps>, 'iconName' \| 'onClick'>`           | `iconName` remains fixed to close icon; use `onClose` for behavior |
 
 ##### Default and Behavior Changes
 
 | Legacy Extension Behavior                                                  | MMDS Behavior                                                                                      |
 | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | Action button defaults to `ButtonLink` semantics and `ButtonLinkSize.Auto` | Action button is `Button` with default `ButtonSize.Md`                                             |
-| Close button renders only when `onClose` is provided                       | Close button renders when `onClose` **or** `closeButtonProps` is provided                          |
+| Close button renders only when `onClose` is provided                       | Close button renders only when `onClose` is provided                                               |
 | Close button `ariaLabel` defaults to translated `t('close')`               | Close button `ariaLabel` defaults to `'Close banner'` (override with `closeButtonProps.ariaLabel`) |
 | String/number `children` are wrapped in extension `Text` defaults          | String/number `children` are wrapped in MMDS `Text` with `TextVariant.BodyMd`                      |
 
@@ -2041,6 +2042,28 @@ Codemod-friendly: every `isLoading=` token in the extension's existing call site
 - The container, animated overlay, and (when present) hidden-children wrapper are all `aria-hidden="true"` and `pointer-events-none` by default. The skeleton takes no part in the accessibility tree.
 
 ## Version Updates
+
+<!-- TODO: Replace 0.x.0 with the actual next released version when this BannerBase follow-up ships. -->
+
+## From version 0.21.0 to 0.x.0
+
+### BannerBase: `onClose` is now the only close-button behavior API
+
+**What changed:**
+
+- **`closeButtonProps.onClick`** is removed from the public **`BannerBase`** API.
+- The close button now renders **only** when **`onClose`** is provided.
+- **`closeButtonProps`** is now customization-only for the rendered close **`ButtonIcon`**.
+
+**Migration:**
+
+- Move any close-button behavior from **`closeButtonProps.onClick`** to **`onClose`**.
+- Keep **`closeButtonProps`** only for non-behavioral customization such as **`data-testid`**, accessibility props, and styling hooks.
+- If you previously passed only **`closeButtonProps`** to force-render a close button, also provide **`onClose`** now.
+
+**Impact:**
+
+- Existing **`@metamask/design-system-react`** consumers that relied on **`closeButtonProps.onClick`** or on rendering a close button without **`onClose`** must update those call sites.
 
 This section covers version-to-version breaking changes within `@metamask/design-system-react`.
 

--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -25,7 +25,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [ModalOverlay Component](#modaloverlay-component)
   - [Skeleton Component](#skeleton-component)
 - [Version Updates](#version-updates)
-  - [From version 0.21.0 to 0.x.0](#from-version-0210-to-0x0)
+  - [From version 0.22.0 to 0.x.0](#from-version-0220-to-0x0)
   - [From version 0.17.0 to 0.18.0](#from-version-0170-to-0180)
   - [From version 0.16.0 to 0.17.0](#from-version-0160-to-0170)
   - [From version 0.12.0 to 0.13.0](#from-version-0120-to-0130)
@@ -2045,7 +2045,7 @@ Codemod-friendly: every `isLoading=` token in the extension's existing call site
 
 <!-- TODO: Replace 0.x.0 with the actual next released version when this BannerBase follow-up ships. -->
 
-## From version 0.21.0 to 0.x.0
+## From version 0.22.0 to 0.x.0
 
 ### BannerBase: `onClose` is now the only close-button behavior API
 

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.stories.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.stories.tsx
@@ -47,7 +47,8 @@ const meta: Meta<BannerBaseProps> = {
     },
     closeButtonProps: {
       control: 'object',
-      description: 'Optional props for the close button',
+      description:
+        'Optional non-behavioral props for the close button when onClose is provided',
     },
     startAccessory: {
       control: false,

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
@@ -92,17 +92,18 @@ describe('BannerBase', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('renders close button and triggers closeButtonProps.onClick when onClose is not provided', () => {
-    const onCloseButtonClick = jest.fn();
-    render(<BannerBase closeButtonProps={{ onClick: onCloseButtonClick }} />);
+  it('does not render close button when only closeButtonProps are provided', () => {
+    render(
+      <BannerBase closeButtonProps={{ 'data-testid': closeButtonTestId }} />,
+    );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close banner' }));
-    expect(onCloseButtonClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId(closeButtonTestId)).not.toBeInTheDocument();
   });
 
   it('merges structural and custom close button className values', () => {
     render(
       <BannerBase
+        onClose={() => undefined}
         closeButtonProps={{
           className: 'rotate-45',
           'data-testid': closeButtonTestId,

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
@@ -48,12 +48,11 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
 
     const {
       ariaLabel: closeButtonAriaLabel = 'Close banner',
-      onClick: closeButtonPropsOnClick,
       className: closeButtonClassName,
       ...resolvedCloseButtonProps
     } = closeButtonProps ?? {};
 
-    const shouldShowCloseButton = Boolean(onClose || closeButtonProps);
+    const shouldShowCloseButton = Boolean(onClose);
     const shouldShowActionButton = Boolean(actionButtonOnClick);
 
     return (
@@ -123,7 +122,7 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
             iconName={IconName.Close}
             size={ButtonIconSize.Sm}
             ariaLabel={closeButtonAriaLabel}
-            onClick={onClose ?? closeButtonPropsOnClick}
+            onClick={onClose}
             {...resolvedCloseButtonProps}
           />
         )}

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.types.ts
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.types.ts
@@ -19,10 +19,6 @@ type BannerBaseCloseButtonProps = Omit<
    * Optional test id for the close button element.
    */
   'data-testid'?: string;
-  /**
-   * Optional click handler for the close button.
-   */
-  onClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
 type BannerBasePropsBase = BannerBasePropsShared &
@@ -46,7 +42,7 @@ type BannerBasePropsBase = BannerBasePropsShared &
     onClose?: MouseEventHandler<HTMLButtonElement>;
     /**
      * Optional props for the close `ButtonIcon`.
-     * Providing this also shows a close button.
+     * Only used when `onClose` is provided.
      */
     closeButtonProps?: BannerBaseCloseButtonProps;
   };

--- a/packages/design-system-react/src/components/BannerBase/README.mdx
+++ b/packages/design-system-react/src/components/BannerBase/README.mdx
@@ -203,7 +203,7 @@ When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass 
 
 ### `onClose`
 
-Optional close callback. If passed, a close button is shown. Use `closeButtonProps` to pass additional props to the close `ButtonIcon`, including `data-testid` when needed for testing.
+Optional close callback. If passed, a close button is shown. Use `closeButtonProps` to pass additional non-behavioral props to the close `ButtonIcon`, including `data-testid`, accessibility props, and styling hooks when needed for testing.
 
 <table>
   <thead>
@@ -232,10 +232,7 @@ Optional close callback. If passed, a close button is shown. Use `closeButtonPro
         <code>closeButtonProps</code>
       </td>
       <td align="left">
-        <code>
-          Omit&lt;Partial&lt;ButtonIconProps&gt;, 'iconName' | 'onClick'&gt;
-          &amp; {'{'} onClick?: MouseEventHandler&lt;HTMLButtonElement&gt; {'}'}
-        </code>
+        <code>Omit&lt;Partial&lt;ButtonIconProps&gt;, 'iconName' | 'onClick'&gt;</code>
       </td>
       <td align="left">No</td>
       <td align="left">


### PR DESCRIPTION
## **Description**

This PR simplifies `BannerBase` close handling in `@metamask/design-system-react-native` so `onClose` is the only behavioral close API. `closeButtonProps` is now customization-only, and the close button only renders when `onClose` is provided.

It also updates the related migration and usage docs so reviewers and downstream consumers have the current contract documented in one place.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn build`
2. Run `yarn test`
3. Run `yarn lint`
4. In the `BannerBase` stories/docs, confirm `closeButtonProps` is described as non-behavioral and that `onClose` is required to render the close button.

## **Screenshots/Recordings**

Not applicable. This PR changes component API behavior and documentation only.

### **Before**

Not applicable.

### **After**

Not applicable.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a breaking behavior/type change in `BannerBase` (web + RN): close buttons no longer render or handle events via `closeButtonProps`, which can break downstream consumers and tests until updated.
> 
> **Overview**
> **`BannerBase` close handling is simplified across React and React Native.** The close button now renders *only* when `onClose` is provided, and `closeButtonProps` is reduced to customization-only (removing `closeButtonProps.onClick` / `closeButtonProps.onPress` from the public types and wiring).
> 
> Tests, Storybook arg descriptions, and component READMEs are updated to reflect the new contract, and both packages’ `MIGRATION.md` add explicit breaking-change guidance. Release/migration process docs are also updated to clarify that package `CHANGELOG.md` edits should happen only on release branches, with breaking changes documented in `MIGRATION.md` during feature/migration PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6f48d20d23030e72cf77caa0f0b1d7f746dd4f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

