### PR TITLE
Release/39.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "38.0.0",
+  "version": "39.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- refactor: align Toast API with severity and accessory ([#1143](https://github.com/MetaMask/metamask-design-system/pull/1143))
+- feat(icons): add ListArrow icon ([#1161](https://github.com/MetaMask/metamask-design-system/pull/1161))
+- fix(icons): update musd.svg with combined path element ([#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))
+- feat(icons): add Musd and MusdFilled icons ([#1162](https://github.com/MetaMask/metamask-design-system/pull/1162))
+- feat(icons): update candlestick and add group, pie-chart, predictions icons ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157))
+- docs: `HeaderBase` migration (mobile) ([#1100](https://github.com/MetaMask/metamask-design-system/pull/1100))
+
 ## [0.23.0]
 
 ### Added

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,14 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.24.0]
 
-### Uncategorized
+### Added
 
-- refactor: align Toast API with severity and accessory ([#1143](https://github.com/MetaMask/metamask-design-system/pull/1143))
-- feat(icons): add ListArrow icon ([#1161](https://github.com/MetaMask/metamask-design-system/pull/1161))
-- fix(icons): update musd.svg with combined path element ([#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))
-- feat(icons): add Musd and MusdFilled icons ([#1162](https://github.com/MetaMask/metamask-design-system/pull/1162))
-- feat(icons): update candlestick and add group, pie-chart, predictions icons ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157))
-- docs: `HeaderBase` migration (mobile) ([#1100](https://github.com/MetaMask/metamask-design-system/pull/1100))
+- Added `ListArrow`, `Musd`, and `MusdFilled` icons; refreshed `Candlestick`; and added `Group`, `PieChart`, and `Predictions` icons (same names as in `@metamask/design-system-react`) ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157), [#1161](https://github.com/MetaMask/metamask-design-system/pull/1161), [#1162](https://github.com/MetaMask/metamask-design-system/pull/1162), [#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))
+
+### Changed
+
+- **BREAKING:** Tightened the `Toast` API shipped with `Toaster` in 0.23.0 ([#1143](https://github.com/MetaMask/metamask-design-system/pull/1143))
+  - **`toast.show`** → **`toast(...)`**; **`toast.hide`** → **`toast.dismiss()`**
+  - **`iconProps`** renamed to **`iconAlertProps`**
+  - **`ToastSeverity.Info`** removed; use **`Default`**, **`Success`**, **`Warning`**, or **`Danger`**
+  - **`hasNoTimeout`** is optional and defaults to auto-dismiss unless set to **`true`**
+  - Close control is always shown on the toast surface
+  - See [Migration Guide](./MIGRATION.md#from-version-0230-to-0x0)
+- Expanded `HeaderBase` migration guidance for apps moving off the mobile component library ([#1100](https://github.com/MetaMask/metamask-design-system/pull/1100))
 
 ## [0.23.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0]
+
 ### Uncategorized
 
 - refactor: align Toast API with severity and accessory ([#1143](https://github.com/MetaMask/metamask-design-system/pull/1143))
@@ -411,7 +413,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.23.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.24.0...HEAD
+[0.24.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.23.0...@metamask/design-system-react-native@0.24.0
 [0.23.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.22.0...@metamask/design-system-react-native@0.23.0
 [0.22.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.21.0...@metamask/design-system-react-native@0.22.0
 [0.21.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.20.0...@metamask/design-system-react-native@0.21.0

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0]
+
 ### Uncategorized
 
 - [4/N] feat: `ModalContent` migration (extension) ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))
@@ -305,7 +307,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.21.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.22.0...HEAD
+[0.22.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.21.0...@metamask/design-system-react@0.22.0
 [0.21.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.20.0...@metamask/design-system-react@0.21.0
 [0.20.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.19.0...@metamask/design-system-react@0.20.0
 [0.19.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.18.0...@metamask/design-system-react@0.19.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- [4/N] feat: `ModalContent` migration (extension) ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))
+- feat: `Skeleton` migration (extension) ([#1146](https://github.com/MetaMask/metamask-design-system/pull/1146))
+- feat: `HeaderBase` migration (extension) ([#1142](https://github.com/MetaMask/metamask-design-system/pull/1142))
+- feat(icons): add ListArrow icon ([#1161](https://github.com/MetaMask/metamask-design-system/pull/1161))
+- fix(icons): update musd.svg with combined path element ([#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))
+- feat(icons): add Musd and MusdFilled icons ([#1162](https://github.com/MetaMask/metamask-design-system/pull/1162))
+- feat(icons): update candlestick and add group, pie-chart, predictions icons ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157))
+- [3/N] feat: `Modal` migration (extension) ([#1136](https://github.com/MetaMask/metamask-design-system/pull/1136))
+
 ## [0.21.0]
 
 ### Added

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,16 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.0]
 
-### Uncategorized
+### Added
 
-- [4/N] feat: `ModalContent` migration (extension) ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))
-- feat: `Skeleton` migration (extension) ([#1146](https://github.com/MetaMask/metamask-design-system/pull/1146))
-- feat: `HeaderBase` migration (extension) ([#1142](https://github.com/MetaMask/metamask-design-system/pull/1142))
-- feat(icons): add ListArrow icon ([#1161](https://github.com/MetaMask/metamask-design-system/pull/1161))
-- fix(icons): update musd.svg with combined path element ([#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))
-- feat(icons): add Musd and MusdFilled icons ([#1162](https://github.com/MetaMask/metamask-design-system/pull/1162))
-- feat(icons): update candlestick and add group, pie-chart, predictions icons ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157))
-- [3/N] feat: `Modal` migration (extension) ([#1136](https://github.com/MetaMask/metamask-design-system/pull/1136))
+- Added `Modal` and `useModalContext` for composing modal dialogs with focus management and the same layout patterns used in the MetaMask extension migration ([#1136](https://github.com/MetaMask/metamask-design-system/pull/1136))
+- Added `ModalContent` (with `ModalContentSize` and `MODAL_CONTENT_IGNORE_OUTSIDE_CLICK_ATTR`) for sized modal bodies, entrance motion, and outside-click handling aligned with that migration ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))
+- Added `Skeleton` for loading placeholders ([#1146](https://github.com/MetaMask/metamask-design-system/pull/1146))
+- Added `HeaderBase` for flexible header layouts when migrating extension screens into the design system ([#1142](https://github.com/MetaMask/metamask-design-system/pull/1142))
+- Added `ListArrow`, `Musd`, and `MusdFilled` icons; refreshed `Candlestick`; and added `Group`, `PieChart`, and `Predictions` icons ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157), [#1161](https://github.com/MetaMask/metamask-design-system/pull/1161), [#1162](https://github.com/MetaMask/metamask-design-system/pull/1162), [#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))
 
 ## [0.21.0]
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",
@@ -78,7 +78,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-tailwind-preset": "^0.7.0",
+    "@metamask/design-system-tailwind-preset": "^0.8.0",
     "@metamask/design-tokens": "^8.1.0",
     "@metamask/utils": "^11.11.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0]
+
 ### Uncategorized
 
 - feat(icons): add ListArrow icon ([#1161](https://github.com/MetaMask/metamask-design-system/pull/1161))
@@ -181,7 +183,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.16.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.17.0...HEAD
+[0.17.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.16.0...@metamask/design-system-shared@0.17.0
 [0.16.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.15.0...@metamask/design-system-shared@0.16.0
 [0.15.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.14.0...@metamask/design-system-shared@0.15.0
 [0.14.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.13.0...@metamask/design-system-shared@0.14.0

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,12 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.17.0]
 
-### Uncategorized
+### Added
 
-- feat(icons): add ListArrow icon ([#1161](https://github.com/MetaMask/metamask-design-system/pull/1161))
-- fix(icons): update musd.svg with combined path element ([#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))
-- feat(icons): add Musd and MusdFilled icons ([#1162](https://github.com/MetaMask/metamask-design-system/pull/1162))
-- feat(icons): update candlestick and add group, pie-chart, predictions icons ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157))
+- Added `ListArrow`, `Musd`, and `MusdFilled` to the shared icon exports; refreshed `Candlestick`; and added `Group`, `PieChart`, and `Predictions` so React and React Native stay aligned on `IconName` ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157), [#1161](https://github.com/MetaMask/metamask-design-system/pull/1161), [#1162](https://github.com/MetaMask/metamask-design-system/pull/1162), [#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))
 
 ## [0.16.0]
 

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(icons): add ListArrow icon ([#1161](https://github.com/MetaMask/metamask-design-system/pull/1161))
+- fix(icons): update musd.svg with combined path element ([#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))
+- feat(icons): add Musd and MusdFilled icons ([#1162](https://github.com/MetaMask/metamask-design-system/pull/1162))
+- feat(icons): update candlestick and add group, pie-chart, predictions icons ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157))
+
 ## [0.16.0]
 
 ### Added

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- [4/N] feat: `ModalContent` migration (extension) ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))
+- feat: `Skeleton` migration (extension) ([#1146](https://github.com/MetaMask/metamask-design-system/pull/1146))
+
 ## [0.7.0]
 
 ### Added

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.0]
 
-### Uncategorized
+### Added
 
-- [4/N] feat: `ModalContent` migration (extension) ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))
-- feat: `Skeleton` migration (extension) ([#1146](https://github.com/MetaMask/metamask-design-system/pull/1146))
+- Added `animate-skeleton-pulse` (keyframes `skeleton-pulse`) for the design-system `Skeleton` loading bar ([#1146](https://github.com/MetaMask/metamask-design-system/pull/1146))
+- Added `animate-slide-up` (keyframes `slide-up`) for `ModalContent` dialog entrance motion ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))
 
 ## [0.7.0]
 

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0]
+
 ### Uncategorized
 
 - [4/N] feat: `ModalContent` migration (extension) ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))
@@ -77,7 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.7.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.8.0...HEAD
+[0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.7.0...@metamask/design-system-tailwind-preset@0.8.0
 [0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.6.1...@metamask/design-system-tailwind-preset@0.7.0
 [0.6.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.6.0...@metamask/design-system-tailwind-preset@0.6.1
 [0.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.5.0...@metamask/design-system-tailwind-preset@0.6.0

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-tailwind-preset",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Design System Tailwind CSS preset for MetaMask projects",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,7 +3378,7 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-tailwind-preset": ^0.7.0
+    "@metamask/design-system-tailwind-preset": ^0.8.0
     "@metamask/design-tokens": ^8.1.0
     "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0


### PR DESCRIPTION
## Release 39.0.0

This release ships Extension-aligned modal and loading primitives on web, new icons across shared + both platforms, matching Tailwind preset animations, and a **breaking** follow-up to the React Native `Toast` API introduced in 0.23.0.

### Package versions

- `@metamask/design-tokens`: **8.4.0**
- `@metamask/design-system-shared`: **0.17.0**
- `@metamask/design-system-react`: **0.22.0**
- `@metamask/design-system-react-native`: **0.24.0**
- `@metamask/design-system-tailwind-preset`: **0.8.0**
- `@metamask/design-system-twrnc-preset`: **0.4.2**

### Shared updates (0.17.0)

#### Icon additions ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157), [#1161](https://github.com/MetaMask/metamask-design-system/pull/1161), [#1162](https://github.com/MetaMask/metamask-design-system/pull/1162), [#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))

**What changed**

- Extended shared `IconName` with `ListArrow`, `Musd`, `MusdFilled`, refreshed `Candlestick`, and added `Group`, `PieChart`, and `Predictions`.

**Impact**

- React and React Native stay aligned on icon names and assets when consuming `@metamask/design-system-shared`.

### React web (0.22.0)

#### Added

- `Modal` and `useModalContext` for composing modal dialogs ([#1136](https://github.com/MetaMask/metamask-design-system/pull/1136))
- `ModalContent` (with `ModalContentSize` and `MODAL_CONTENT_IGNORE_OUTSIDE_CLICK_ATTR`) ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))
- `Skeleton` loading placeholders ([#1146](https://github.com/MetaMask/metamask-design-system/pull/1146))
- `HeaderBase` for flexible headers during Extension migration ([#1142](https://github.com/MetaMask/metamask-design-system/pull/1142))
- Icons: `ListArrow`, `Musd`, `MusdFilled`, `Candlestick` refresh, `Group`, `PieChart`, `Predictions` ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157), [#1161](https://github.com/MetaMask/metamask-design-system/pull/1161), [#1162](https://github.com/MetaMask/metamask-design-system/pull/1162), [#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))

### React Native (0.24.0)

#### Added

- Same icon set as web (shared asset alignment) ([#1157](https://github.com/MetaMask/metamask-design-system/pull/1157), [#1161](https://github.com/MetaMask/metamask-design-system/pull/1161), [#1162](https://github.com/MetaMask/metamask-design-system/pull/1162), [#1163](https://github.com/MetaMask/metamask-design-system/pull/1163))

#### Changed

- **BREAKING:** `Toast` API tightened after the 0.23.0 `Toaster` migration ([#1143](https://github.com/MetaMask/metamask-design-system/pull/1143)): use `toast(...)` / `toast.dismiss()`, rename `iconProps` → `iconAlertProps`, remove `ToastSeverity.Info`, optional `hasNoTimeout` with auto-dismiss default, close affordance always shown. See [React Native migration guide](./packages/design-system-react-native/MIGRATION.md#from-version-0230-to-0x0).
- Expanded `HeaderBase` migration guidance for Mobile ([#1100](https://github.com/MetaMask/metamask-design-system/pull/1100))

### Tailwind preset (0.8.0)

#### Added

- `animate-skeleton-pulse` / `skeleton-pulse` for design-system `Skeleton` ([#1146](https://github.com/MetaMask/metamask-design-system/pull/1146))
- `animate-slide-up` / `slide-up` for `ModalContent` entrance ([#1139](https://github.com/MetaMask/metamask-design-system/pull/1139))

### TWRNC preset (0.4.2)

#### Changed

- Broadened `react` peer range to `>=18.2.0` for RN 0.76 / React 19 stacks ([#844](https://github.com/MetaMask/metamask-design-system/pull/844))

### Breaking changes

#### Toast runtime API (React Native only)

**What changed**

- `toast.show` → `toast(...)`; `toast.hide` → `toast.dismiss()`
- `iconProps` → `iconAlertProps`
- `ToastSeverity.Info` removed
- `hasNoTimeout` optional (defaults to timed dismiss)
- Close control always on surface

**Migration**

```tsx
// Before (0.23.x patterns targeted by this follow-up)
toast.show({
  title: 'Saved',
  severity: ToastSeverity.Info,
  iconProps: { testID: 'toast-icon' },
});
toast.hide();

// After (0.24.0)
toast({
  title: 'Saved',
  severity: ToastSeverity.Default,
  iconAlertProps: { testID: 'toast-icon' },
});
toast.dismiss();
```

**Impact**

- Apps already on `<Toaster />` from 0.23.0 must adjust call sites that still used `toast.show` / `toast.hide`, `ToastSeverity.Info`, or `iconProps`.

See [Toast version bump section](./packages/design-system-react-native/MIGRATION.md#from-version-0230-to-0x0) (update the `0.x.0` placeholder heading/TOC to **0.24.0** when you finalize the migration anchor).

---

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: minor (0.16.0 → 0.17.0) — shared icon set additions and asset fixes
  - [x] design-system-react: minor (0.21.0 → 0.22.0) — extension migration components and icons
  - [x] design-system-react-native: minor (0.23.0 → 0.24.0) — **breaking Toast follow-up (#1143)**, icons, `Musd` fix
  - [x] design-system-tailwind-preset: minor (0.7.0 → 0.8.0) — `animate-slide-up` and `animate-skeleton-pulse` for ModalContent / Skeleton
  - [x] design-system-twrnc-preset: patch (0.4.1 → 0.4.2) — wider `react` peer range
- [x] Breaking changes documented with migration guidance (React Native Toast — see MIGRATION.md link above)
- [x] Migration guides updated with before/after examples (Toast **0.23 → 0.24**)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples (**React Native Toast** — [0.23.0 → 0.24.0](./packages/design-system-react-native/MIGRATION.md#from-version-0230-to-0240))
- [ ] All unreleased changes are accounted for in changelogs


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a release/version bump, but it changes published package versions and updates peer dependency requirements, which can affect downstream installs. React Native release notes include a breaking `Toast` API change that consumers must account for when upgrading.
> 
> **Overview**
> Bumps the monorepo release to `39.0.0` and increments package versions for `@metamask/design-system-react` (`0.22.0`), `@metamask/design-system-react-native` (`0.24.0`), `@metamask/design-system-shared` (`0.17.0`), and `@metamask/design-system-tailwind-preset` (`0.8.0`), updating corresponding changelogs and compare links.
> 
> Updates `@metamask/design-system-react` to require `@metamask/design-system-tailwind-preset@^0.8.0` (and aligns `yarn.lock`). Changelogs capture the release contents, including new modal/skeleton/header additions on web, icon set updates across packages, and a **breaking** React Native `Toast` API tightening for `Toaster`/`toast(...)` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e3ea636f7e8b4d605d38a96c4e15521ce18659d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->