### PR TITLE
fix: `ButtonSecondary` disabled-state outline in dark mode

### DIFF
--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
@@ -153,6 +153,8 @@ describe('ButtonSecondary', () => {
     );
     const btn = getByTestId('button-secondary');
     expectBorderColor(btn.props.style, 'border-default', twDark);
+
+    expect(btn).toBeDefined();
   });
 
   it('keeps border transparent on disabled default in light theme', () => {
@@ -163,6 +165,8 @@ describe('ButtonSecondary', () => {
     );
     const btn = getByTestId('button-secondary');
     expectBorderColor(btn.props.style, 'border-transparent');
+
+    expect(btn).toBeDefined();
   });
 
   it('toggles pressed styles (default)', () => {

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
@@ -1,5 +1,9 @@
 import { ButtonBaseSize } from '@metamask/design-system-shared';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Theme,
+  ThemeProvider,
+  useTailwind,
+} from '@metamask/design-system-twrnc-preset';
 import { renderHook } from '@testing-library/react-hooks';
 import { render } from '@testing-library/react-native';
 import React from 'react';
@@ -9,10 +13,17 @@ import { ButtonSecondary } from './ButtonSecondary';
 
 describe('ButtonSecondary', () => {
   let tw: ReturnType<typeof useTailwind>;
+  let twDark: ReturnType<typeof useTailwind>;
 
   beforeAll(() => {
     const { result } = renderHook(() => useTailwind());
     tw = result.current;
+    const { result: darkResult } = renderHook(() => useTailwind(), {
+      wrapper: ({ children }) => (
+        <ThemeProvider theme={Theme.Dark}>{children}</ThemeProvider>
+      ),
+    });
+    twDark = darkResult.current;
   });
 
   /**
@@ -48,6 +59,30 @@ describe('ButtonSecondary', () => {
       expect.arrayContaining([
         expect.objectContaining({
           backgroundColor: expected.backgroundColor,
+        }),
+      ]),
+    );
+  }
+
+  /**
+   * Expect border color to match the borderColor produced by a tailwind class
+   * resolved against the supplied tailwind instance (theme-aware).
+   *
+   * @param styleProp - The style prop to check
+   * @param tailwindClass - The tailwind class providing the expected borderColor
+   * @param twInstance - The tailwind instance to resolve the class against
+   */
+  function expectBorderColor(
+    styleProp: unknown,
+    tailwindClass: string,
+    twInstance: ReturnType<typeof useTailwind> = tw,
+  ) {
+    const expected = twInstance`${tailwindClass}`;
+    const allStyles = flattenStyles(styleProp);
+    expect(allStyles).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          borderColor: expected.borderColor,
         }),
       ]),
     );
@@ -106,6 +141,28 @@ describe('ButtonSecondary', () => {
     expectBackground(btn.props.style, 'bg-default');
 
     expect(btn).toBeDefined();
+  });
+
+  it('renders border-default on disabled default in dark theme', () => {
+    const { getByTestId } = render(
+      <ThemeProvider theme={Theme.Dark}>
+        <ButtonSecondary isDisabled testID="button-secondary">
+          Disabled
+        </ButtonSecondary>
+      </ThemeProvider>,
+    );
+    const btn = getByTestId('button-secondary');
+    expectBorderColor(btn.props.style, 'border-default', twDark);
+  });
+
+  it('keeps border transparent on disabled default in light theme', () => {
+    const { getByTestId } = render(
+      <ButtonSecondary isDisabled testID="button-secondary">
+        Disabled
+      </ButtonSecondary>,
+    );
+    const btn = getByTestId('button-secondary');
+    expectBorderColor(btn.props.style, 'border-transparent');
   });
 
   it('toggles pressed styles (default)', () => {

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.tsx
@@ -1,3 +1,4 @@
+import { Theme, useTheme } from '@metamask/design-system-twrnc-preset';
 import React, { useCallback } from 'react';
 
 import { ButtonBase } from '../../../ButtonBase';
@@ -15,12 +16,14 @@ export const ButtonSecondary = ({
   startIconProps,
   endIconProps,
   isDanger = false,
+  isDisabled = false,
   isInverse = false,
   isLoading = false,
   twClassName = '',
   style,
   ...props
 }: ButtonSecondaryProps) => {
+  const theme = useTheme();
   const getContainerClassName = useCallback(
     (pressed: boolean): string => {
       const classNameStr =
@@ -52,12 +55,15 @@ export const ButtonSecondary = ({
       } else {
         backgroundClass =
           pressed || isLoading ? 'bg-muted-pressed' : 'bg-muted';
-        borderClass = 'border-transparent';
+        borderClass =
+          isDisabled && theme === Theme.Dark
+            ? 'border-default'
+            : 'border-transparent';
       }
 
       return `${backgroundClass} ${borderClass} ${baseClasses}`;
     },
-    [isInverse, isDanger, isLoading, twClassName],
+    [isInverse, isDanger, isDisabled, isLoading, theme, twClassName],
   );
 
   const getTextClassName = useCallback(
@@ -95,6 +101,7 @@ export const ButtonSecondary = ({
         size: IconSize.Sm,
         ...endIconProps,
       }}
+      isDisabled={isDisabled}
       isLoading={isLoading}
       twClassName={getContainerClassName}
       textClassName={getTextClassName}


### PR DESCRIPTION
## **Description**

In dark mode, the disabled `ButtonSecondary` (default variant) blends into the page background and reads as floating text rather than a control. This adds a 1px `border-default` outline to the disabled state when the active theme is dark. Light mode, all non-disabled states, and the `isDanger` / `isInverse` / `isInverse + isDanger` sub-variants are unchanged.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-783

## **Manual testing steps**

1. Open Storybook (or any consumer rendering `ButtonSecondary`).
2. Switch the app theme to dark mode.
3. Render a `ButtonSecondary` with `isDisabled={true}` (e.g. the `isDisabled` story under `ButtonSecondary`).
4. Confirm the button now shows a 1px outline using the `border-default` token, distinct from the page background.
5. Switch to light mode and confirm the disabled `ButtonSecondary` is unchanged (no visible outline).
6. With dark mode active, confirm non-disabled (default, pressed, loading) states still render without an outline, and the `isDanger` / `isInverse` / `isInverse + isDanger` sub-variants render exactly as before.

## **Screenshots/Recordings**

**BEFORE**
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/922b0356-718f-463f-be02-87b5f6a755f8" />

**AFTER**
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/822b61a5-1326-4d30-a1db-c4b452f6ddb5" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling change limited to `ButtonSecondary`’s disabled default state in dark mode, with added unit tests to lock behavior. No behavioral, data, or security-sensitive logic is affected.
> 
> **Overview**
> Fixes the *disabled* default `ButtonSecondary` appearance in dark mode by applying a `border-default` outline when `isDisabled` and the active theme is `Theme.Dark` (light mode and other sub-variants keep their existing borders).
> 
> Updates tests to be theme-aware via `ThemeProvider`, adds a helper to assert `borderColor`, and covers both dark-mode outlined and light-mode transparent disabled borders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f6c455b77cec6785e31bac95c020f4eb0d8bd47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->