### PR TITLE
feat: `TextField` migration (extension)

### DIFF
--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -29,6 +29,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [PopoverHeader Component](#popoverheader-component)
   - [SensitiveText Component](#sensitivetext-component)
   - [Skeleton Component](#skeleton-component)
+  - [TextField Component](#textfield-component)
 - [Version Updates](#version-updates)
   - [From version 0.22.0 to 0.x.0](#from-version-0220-to-0x0)
   - [From version 0.17.0 to 0.18.0](#from-version-0170-to-0180)
@@ -2488,6 +2489,68 @@ Codemod-friendly: every `isLoading=` token in the extension's existing call site
 
 - `Skeleton` always renders a `<div>` and forwards arbitrary HTML attributes (`id`, `role`, `data-*`, `aria-*`, `ref`) to it.
 - The container, animated overlay, and (when present) hidden-children wrapper are all `aria-hidden="true"` and `pointer-events-none` by default. The skeleton takes no part in the accessibility tree.
+
+### TextField Component
+
+The `TextField` is now available from the design system. The new component drops the polymorphic `Box`/`InputComponent` pattern in favor of a concrete `forwardRef<HTMLDivElement>` container that composes the design-system `Input`. State props are renamed to match the system-wide `is*` convention, and styling moves from SCSS (`mm-text-field`) to Tailwind utilities.
+
+#### Import Path
+
+| Extension Pattern                                         | Design System Migration                                         |
+| --------------------------------------------------------- | --------------------------------------------------------------- |
+| `import { TextField } from '../../component-library'`     | `import { TextField } from '@metamask/design-system-react'`     |
+| `import { TextFieldSize } from '../../component-library'` | `import { TextFieldSize } from '@metamask/design-system-react'` |
+| `import { TextFieldType } from '../../component-library'` | `import { TextFieldType } from '@metamask/design-system-react'` |
+
+#### Enums → Const Objects
+
+`TextFieldSize` and `TextFieldType` are now const objects with derived string union types (per ADR-0003). Member access (`TextFieldSize.Md`) and underlying string values (`'sm'`, `'md'`, `'lg'`, `'text'`, `'number'`, `'password'`, `'search'`) are unchanged, so most call sites need no edits.
+
+#### State Props
+
+| Extension Prop | Design System Prop | Notes   |
+| -------------- | ------------------ | ------- |
+| `disabled`     | `isDisabled`       | renamed |
+| `readOnly`     | `isReadOnly`       | renamed |
+| `error`        | `isError`          | renamed |
+
+```tsx
+// Before (Extension)
+<TextField disabled readOnly error value={value} onChange={onChange} />
+
+// After (Design System)
+<TextField isDisabled isReadOnly isError value={value} onChange={onChange} />
+```
+
+#### Removed Props
+
+| Extension Prop                                                | Design System Migration                                                                                                                                 |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `as` / polymorphic `C`                                        | Removed. The container is always a `<div>`. Wrap with a custom element if you need a different root.                                                    |
+| `InputComponent`                                              | Replaced by the shared `inputElement` slot. Pass a fully-rendered element instead of a component reference.                                             |
+| `testId`                                                      | Pass `data-testid` directly on `TextField` (root). For the inner input, use `getByRole('textbox')` in tests or compose your own via `inputElement`.     |
+| `defaultValue`                                                | Removed. The design-system `Input` is controlled-only; manage state with `value`/`onChange` (or use `inputElement` for an uncontrolled custom input).   |
+| Box style-utility props (`paddingLeft`, `borderRadius`, etc.) | Use `className` with Tailwind utilities, or compose with `Box`. The container's default chrome (border, radius, padding) is fixed by the design system. |
+
+```tsx
+// Before (Extension): custom InputComponent reference
+<TextField InputComponent={CustomInput} value={value} />
+
+// After (Design System): pass a rendered element via inputElement
+<TextField
+  value={value}
+  inputElement={<CustomInput value={value} onChange={onChange} />}
+/>
+```
+
+#### Ref
+
+- `ref` on `TextField` targets the root container (`HTMLDivElement`).
+- Use `inputRef` to reach the inner `<input>`. Both object refs and callback refs are supported.
+
+#### Styling
+
+The new `TextField` uses Tailwind utilities (focus/error/disabled borders driven by design tokens) instead of the `mm-text-field` SCSS module. Custom container styles should be passed via `className`; the legacy `mm-text-field--*` classes are no longer applied.
 
 ## Version Updates
 

--- a/packages/design-system-react/src/components/TextField/README.mdx
+++ b/packages/design-system-react/src/components/TextField/README.mdx
@@ -1,0 +1,82 @@
+import { Controls, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as TextFieldStories from './TextField.stories';
+
+# TextField
+
+TextField is a controlled text input with a styled container, optional start/end accessories, configurable size, and error/disabled/read-only states. Use it when you need a labeled, accessory-capable input. For a plain borderless input (typically composed inside a custom container), use `Input`.
+
+```tsx
+import { TextField, TextFieldSize, TextFieldType } from '@metamask/design-system-react';
+
+<TextField
+  placeholder="Enter value"
+  value=""
+  size={TextFieldSize.Md}
+  type={TextFieldType.Text}
+/>;
+```
+
+<Canvas of={TextFieldStories.Default} />
+
+## Props
+
+### `size`
+
+Controls the height of the container.
+
+<Canvas of={TextFieldStories.Size} />
+
+### `type`
+
+Sets the native `type` attribute on the inner input.
+
+<Canvas of={TextFieldStories.Type} />
+
+### `startAccessory`
+
+Content rendered before the input.
+
+<Canvas of={TextFieldStories.StartAccessory} />
+
+### `endAccessory`
+
+Content rendered after the input.
+
+<Canvas of={TextFieldStories.EndAccessory} />
+
+### `isError`
+
+Renders the error border treatment and sets `aria-invalid` on the inner input.
+
+<Canvas of={TextFieldStories.IsError} />
+
+### `isDisabled`
+
+Disables the inner input and applies the disabled container treatment. Click events on the container are ignored.
+
+<Canvas of={TextFieldStories.IsDisabled} />
+
+### `isReadOnly`
+
+Marks the inner input as read-only. The user can focus but not edit the value.
+
+<Canvas of={TextFieldStories.IsReadOnly} />
+
+### `truncate`
+
+When `true` (default) the inner input truncates overflowing text with an ellipsis.
+
+<Canvas of={TextFieldStories.Truncate} />
+
+### `inputElement`
+
+Replaces the default `Input` with a custom element when you need a different inner control.
+
+### `inputProps` / `inputRef`
+
+`inputProps` forwards extra attributes to the inner `Input`. `inputRef` exposes a ref to the underlying `<input>`; the component `ref` targets the root container.
+
+## Controls
+
+<Controls of={TextFieldStories.Default} />

--- a/packages/design-system-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.stories.tsx
@@ -63,7 +63,24 @@ export const Default: Story = {
     placeholder: 'Sample placeholder',
     value: '',
   },
-  render: (args) => <ControlledTextField {...args} />,
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? '');
+
+    useEffect(() => {
+      setValue(args.value ?? '');
+    }, [args.value]);
+
+    return (
+      <TextField
+        {...args}
+        value={value}
+        onChange={(event) => {
+          setValue(event.target.value);
+          args.onChange?.(event);
+        }}
+      />
+    );
+  },
 };
 
 export const Size: Story = {

--- a/packages/design-system-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.stories.tsx
@@ -50,7 +50,6 @@ const meta: Meta<TextFieldProps> = {
     truncate: { control: 'boolean' },
     placeholder: { control: 'text' },
     value: { control: 'text' },
-    className: { control: 'text' },
   },
 };
 

--- a/packages/design-system-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React, { useEffect, useState } from 'react';
 
+import { Text } from '../Text';
 import README from './README.mdx';
 import { TextField } from './TextField';
 import { TextFieldSize, TextFieldType } from './TextField.types';
@@ -105,7 +106,7 @@ export const StartAccessory: Story = {
   render: () => (
     <ControlledTextField
       placeholder="0.00"
-      startAccessory={<span>$</span>}
+      startAccessory={<Text>$</Text>}
       value=""
     />
   ),
@@ -115,7 +116,7 @@ export const EndAccessory: Story = {
   render: () => (
     <ControlledTextField
       placeholder="Amount"
-      endAccessory={<span>USD</span>}
+      endAccessory={<Text>USD</Text>}
       value=""
     />
   ),
@@ -146,8 +147,13 @@ export const IsReadOnly: Story = {
 export const Truncate: Story = {
   render: () => (
     <div className="flex w-48 flex-col gap-4">
-      <TextField truncate value="A very long value that should be truncated" />
       <TextField
+        inputProps={{ 'aria-label': 'Truncated value' }}
+        truncate
+        value="A very long value that should be truncated"
+      />
+      <TextField
+        inputProps={{ 'aria-label': 'Non-truncated value' }}
         truncate={false}
         value="A very long value that should not be truncated"
       />

--- a/packages/design-system-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.stories.tsx
@@ -1,3 +1,4 @@
+import { TextFieldSize, TextFieldType } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React, { useEffect, useState } from 'react';
 
@@ -5,7 +6,6 @@ import { Text } from '../Text';
 
 import README from './README.mdx';
 import { TextField } from './TextField';
-import { TextFieldSize, TextFieldType } from './TextField.types';
 import type { TextFieldProps } from './TextField.types';
 
 function ControlledTextField(props: TextFieldProps) {

--- a/packages/design-system-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.stories.tsx
@@ -1,4 +1,3 @@
-import { TextFieldSize, TextFieldType } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React, { useEffect, useState } from 'react';
 
@@ -6,6 +5,7 @@ import { Text } from '../Text';
 
 import README from './README.mdx';
 import { TextField } from './TextField';
+import { TextFieldSize, TextFieldType } from './TextField.types';
 import type { TextFieldProps } from './TextField.types';
 
 function ControlledTextField(props: TextFieldProps) {

--- a/packages/design-system-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.stories.tsx
@@ -1,0 +1,156 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React, { useEffect, useState } from 'react';
+
+import README from './README.mdx';
+import { TextField } from './TextField';
+import { TextFieldSize, TextFieldType } from './TextField.types';
+import type { TextFieldProps } from './TextField.types';
+
+function ControlledTextField(props: TextFieldProps) {
+  const [value, setValue] = useState(props.value ?? '');
+
+  useEffect(() => {
+    setValue(props.value ?? '');
+  }, [props.value]);
+
+  return (
+    <TextField
+      {...props}
+      value={value}
+      onChange={(event) => {
+        setValue(event.target.value);
+        props.onChange?.(event);
+      }}
+    />
+  );
+}
+
+const meta: Meta<TextFieldProps> = {
+  title: 'React Components/TextField',
+  component: TextField,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: Object.values(TextFieldSize),
+    },
+    type: {
+      control: 'select',
+      options: Object.values(TextFieldType),
+    },
+    isDisabled: { control: 'boolean' },
+    isReadOnly: { control: 'boolean' },
+    isError: { control: 'boolean' },
+    truncate: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    value: { control: 'text' },
+    className: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<TextFieldProps>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Sample placeholder',
+    value: '',
+  },
+  render: (args) => <ControlledTextField {...args} />,
+};
+
+export const Size: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <ControlledTextField placeholder="Sm" size={TextFieldSize.Sm} value="" />
+      <ControlledTextField placeholder="Md" size={TextFieldSize.Md} value="" />
+      <ControlledTextField placeholder="Lg" size={TextFieldSize.Lg} value="" />
+    </div>
+  ),
+};
+
+export const Type: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <ControlledTextField
+        placeholder="Text"
+        type={TextFieldType.Text}
+        value=""
+      />
+      <ControlledTextField
+        placeholder="Number"
+        type={TextFieldType.Number}
+        value=""
+      />
+      <ControlledTextField
+        placeholder="Password"
+        type={TextFieldType.Password}
+        value=""
+      />
+      <ControlledTextField
+        placeholder="Search"
+        type={TextFieldType.Search}
+        value=""
+      />
+    </div>
+  ),
+};
+
+export const StartAccessory: Story = {
+  render: () => (
+    <ControlledTextField
+      placeholder="0.00"
+      startAccessory={<span>$</span>}
+      value=""
+    />
+  ),
+};
+
+export const EndAccessory: Story = {
+  render: () => (
+    <ControlledTextField
+      placeholder="Amount"
+      endAccessory={<span>USD</span>}
+      value=""
+    />
+  ),
+};
+
+export const IsError: Story = {
+  render: () => (
+    <ControlledTextField isError placeholder="Error" value="Invalid value" />
+  ),
+};
+
+export const IsDisabled: Story = {
+  render: () => (
+    <ControlledTextField
+      isDisabled
+      placeholder="Disabled"
+      value="Not editable"
+    />
+  ),
+};
+
+export const IsReadOnly: Story = {
+  render: () => (
+    <TextField isReadOnly placeholder="Read only" value="Read-only value" />
+  ),
+};
+
+export const Truncate: Story = {
+  render: () => (
+    <div className="flex w-48 flex-col gap-4">
+      <TextField truncate value="A very long value that should be truncated" />
+      <TextField
+        truncate={false}
+        value="A very long value that should not be truncated"
+      />
+    </div>
+  ),
+};

--- a/packages/design-system-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React, { useEffect, useState } from 'react';
 
 import { Text } from '../Text';
+
 import README from './README.mdx';
 import { TextField } from './TextField';
 import { TextFieldSize, TextFieldType } from './TextField.types';

--- a/packages/design-system-react/src/components/TextField/TextField.test.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.test.tsx
@@ -152,10 +152,12 @@ describe('TextField', () => {
       const input = screen.getByRole('textbox');
 
       fireEvent.focus(input);
-      expect(root).toHaveClass('border-primary-default');
+      expect(root).toHaveClass('border-default');
+      expect(root).not.toHaveClass('border-muted');
 
       fireEvent.blur(input);
-      expect(root).not.toHaveClass('border-primary-default');
+      expect(root).toHaveClass('border-muted');
+      expect(root).not.toHaveClass('border-default');
     });
 
     it('clears focused state when isDisabled becomes true', () => {
@@ -163,9 +165,7 @@ describe('TextField', () => {
         <TextField data-testid={ROOT_TEST_ID} onChange={noop} value="" />,
       );
       fireEvent.focus(screen.getByRole('textbox'));
-      expect(screen.getByTestId(ROOT_TEST_ID)).toHaveClass(
-        'border-primary-default',
-      );
+      expect(screen.getByTestId(ROOT_TEST_ID)).toHaveClass('border-default');
 
       rerender(
         <TextField
@@ -177,7 +177,7 @@ describe('TextField', () => {
       );
 
       expect(screen.getByTestId(ROOT_TEST_ID)).not.toHaveClass(
-        'border-primary-default',
+        'border-default',
       );
     });
   });

--- a/packages/design-system-react/src/components/TextField/TextField.test.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.test.tsx
@@ -1,8 +1,8 @@
-import { TextFieldSize, TextFieldType } from '@metamask/design-system-shared';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 
 import { TextField } from './TextField';
+import { TextFieldSize, TextFieldType } from './TextField.types';
 
 const ROOT_TEST_ID = 'textfield';
 const noop = () => undefined;

--- a/packages/design-system-react/src/components/TextField/TextField.test.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.test.tsx
@@ -1,8 +1,8 @@
+import { TextFieldSize, TextFieldType } from '@metamask/design-system-shared';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 
 import { TextField } from './TextField';
-import { TextFieldSize, TextFieldType } from './TextField.types';
 
 const ROOT_TEST_ID = 'textfield';
 const noop = () => undefined;

--- a/packages/design-system-react/src/components/TextField/TextField.test.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.test.tsx
@@ -1,0 +1,324 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { createRef } from 'react';
+
+import { TextField } from './TextField';
+import { TextFieldSize, TextFieldType } from './TextField.types';
+
+const ROOT_TEST_ID = 'textfield';
+const noop = () => undefined;
+
+describe('TextField', () => {
+  describe('rendering', () => {
+    it('renders with default props', () => {
+      render(<TextField data-testid={ROOT_TEST_ID} onChange={noop} value="" />);
+
+      expect(screen.getByTestId(ROOT_TEST_ID)).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('renders placeholder and value on inner input', () => {
+      render(
+        <TextField
+          placeholder="Enter value"
+          value="hello"
+          onChange={() => undefined}
+        />,
+      );
+
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'placeholder',
+        'Enter value',
+      );
+      expect(screen.getByRole('textbox')).toHaveValue('hello');
+    });
+
+    it('renders start and end accessories', () => {
+      render(
+        <TextField
+          data-testid={ROOT_TEST_ID}
+          onChange={noop}
+          value=""
+          startAccessory={<span data-testid="start">$</span>}
+          endAccessory={<span data-testid="end">USD</span>}
+        />,
+      );
+
+      expect(screen.getByTestId('start')).toBeInTheDocument();
+      expect(screen.getByTestId('end')).toBeInTheDocument();
+    });
+
+    it('renders a custom inputElement when provided', () => {
+      render(
+        <TextField
+          value=""
+          inputElement={<input data-testid="custom-input" />}
+        />,
+      );
+
+      expect(screen.getByTestId('custom-input')).toBeInTheDocument();
+      expect(screen.queryByRole('textbox')).toBe(
+        screen.getByTestId('custom-input'),
+      );
+    });
+  });
+
+  describe('size', () => {
+    const cases: { size: TextFieldSize; heightClass: string }[] = [
+      { size: TextFieldSize.Sm, heightClass: 'h-8' },
+      { size: TextFieldSize.Md, heightClass: 'h-10' },
+      { size: TextFieldSize.Lg, heightClass: 'h-12' },
+    ];
+
+    cases.forEach(({ size, heightClass }) => {
+      it(`applies the ${heightClass} height for size ${size}`, () => {
+        render(
+          <TextField
+            data-testid={ROOT_TEST_ID}
+            size={size}
+            onChange={noop}
+            value=""
+          />,
+        );
+
+        expect(screen.getByTestId(ROOT_TEST_ID)).toHaveClass(heightClass);
+      });
+    });
+  });
+
+  describe('type', () => {
+    it('forwards type to the inner input', () => {
+      render(
+        <TextField
+          data-testid={ROOT_TEST_ID}
+          type={TextFieldType.Password}
+          onChange={noop}
+          value=""
+        />,
+      );
+
+      expect(
+        screen.getByTestId(ROOT_TEST_ID).querySelector('input'),
+      ).toHaveAttribute('type', 'password');
+    });
+  });
+
+  describe('state', () => {
+    it('applies the error border when isError is true', () => {
+      render(
+        <TextField
+          data-testid={ROOT_TEST_ID}
+          isError
+          onChange={noop}
+          value=""
+        />,
+      );
+
+      expect(screen.getByTestId(ROOT_TEST_ID)).toHaveClass(
+        'border-error-default',
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      );
+    });
+
+    it('applies the disabled state when isDisabled is true', () => {
+      render(
+        <TextField
+          data-testid={ROOT_TEST_ID}
+          isDisabled
+          onChange={noop}
+          value=""
+        />,
+      );
+
+      expect(screen.getByTestId(ROOT_TEST_ID)).toHaveClass(
+        'cursor-not-allowed',
+        'opacity-50',
+      );
+      expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+
+    it('marks the inner input as readonly when isReadOnly is true', () => {
+      render(<TextField isReadOnly value="locked" />);
+
+      expect(screen.getByRole('textbox')).toHaveAttribute('readonly');
+    });
+
+    it('applies the focused border on focus and removes it on blur', () => {
+      render(<TextField data-testid={ROOT_TEST_ID} onChange={noop} value="" />);
+
+      const root = screen.getByTestId(ROOT_TEST_ID);
+      const input = screen.getByRole('textbox');
+
+      fireEvent.focus(input);
+      expect(root).toHaveClass('border-primary-default');
+
+      fireEvent.blur(input);
+      expect(root).not.toHaveClass('border-primary-default');
+    });
+
+    it('clears focused state when isDisabled becomes true', () => {
+      const { rerender } = render(
+        <TextField data-testid={ROOT_TEST_ID} onChange={noop} value="" />,
+      );
+      fireEvent.focus(screen.getByRole('textbox'));
+      expect(screen.getByTestId(ROOT_TEST_ID)).toHaveClass(
+        'border-primary-default',
+      );
+
+      rerender(
+        <TextField
+          data-testid={ROOT_TEST_ID}
+          isDisabled
+          onChange={noop}
+          value=""
+        />,
+      );
+
+      expect(screen.getByTestId(ROOT_TEST_ID)).not.toHaveClass(
+        'border-primary-default',
+      );
+    });
+  });
+
+  describe('truncate', () => {
+    it('applies the truncate class on the inner input by default', () => {
+      render(<TextField onChange={noop} value="" />);
+
+      expect(screen.getByRole('textbox')).toHaveClass('truncate');
+    });
+
+    it('omits the truncate class when truncate is false', () => {
+      render(<TextField truncate={false} onChange={noop} value="" />);
+
+      expect(screen.getByRole('textbox')).not.toHaveClass('truncate');
+    });
+  });
+
+  describe('events', () => {
+    it('calls onChange when the inner input changes', () => {
+      const onChange = jest.fn();
+      render(<TextField onChange={onChange} value="" />);
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'next' },
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('focuses the inner input when the container is clicked', () => {
+      render(<TextField data-testid={ROOT_TEST_ID} onChange={noop} value="" />);
+
+      fireEvent.click(screen.getByTestId(ROOT_TEST_ID));
+
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
+    it('calls onClick when the container is clicked and not disabled', () => {
+      const onClick = jest.fn();
+      render(
+        <TextField
+          data-testid={ROOT_TEST_ID}
+          onClick={onClick}
+          onChange={noop}
+          value=""
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId(ROOT_TEST_ID));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not focus or call onClick when isDisabled', () => {
+      const onClick = jest.fn();
+      render(
+        <TextField
+          data-testid={ROOT_TEST_ID}
+          isDisabled
+          onClick={onClick}
+          onChange={noop}
+          value=""
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId(ROOT_TEST_ID));
+
+      expect(onClick).not.toHaveBeenCalled();
+      expect(screen.getByRole('textbox')).not.toHaveFocus();
+    });
+
+    it('calls onFocus and onBlur', () => {
+      const onFocus = jest.fn();
+      const onBlur = jest.fn();
+      render(
+        <TextField
+          onBlur={onBlur}
+          onFocus={onFocus}
+          onChange={noop}
+          value=""
+        />,
+      );
+
+      fireEvent.focus(screen.getByRole('textbox'));
+      expect(onFocus).toHaveBeenCalledTimes(1);
+
+      fireEvent.blur(screen.getByRole('textbox'));
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('refs', () => {
+    it('forwards ref to the root element', () => {
+      const ref = createRef<HTMLDivElement>();
+      render(<TextField ref={ref} onChange={noop} value="" />);
+
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it('forwards inputRef to the inner input (object ref)', () => {
+      const inputRef = createRef<HTMLInputElement>();
+      render(<TextField inputRef={inputRef} onChange={noop} value="" />);
+
+      expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
+    });
+
+    it('forwards inputRef to the inner input (callback ref)', () => {
+      const inputRef = jest.fn();
+      render(<TextField inputRef={inputRef} onChange={noop} value="" />);
+
+      expect(inputRef).toHaveBeenCalledWith(expect.any(HTMLInputElement));
+    });
+  });
+
+  describe('inputProps', () => {
+    it('merges inputProps.className with the inner input default classes', () => {
+      render(
+        <TextField
+          inputProps={{ className: 'mt-2' }}
+          onChange={noop}
+          value=""
+        />,
+      );
+
+      expect(screen.getByRole('textbox')).toHaveClass('mt-2', 'flex-1');
+    });
+  });
+
+  describe('className', () => {
+    it('merges custom className onto the root container', () => {
+      render(
+        <TextField
+          data-testid={ROOT_TEST_ID}
+          className="ring-2"
+          onChange={noop}
+          value=""
+        />,
+      );
+
+      expect(screen.getByTestId(ROOT_TEST_ID)).toHaveClass('ring-2');
+    });
+  });
+});

--- a/packages/design-system-react/src/components/TextField/TextField.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.tsx
@@ -109,7 +109,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
       endAccessory ? 'pr-4' : 'pr-0',
       isDisabled && 'cursor-not-allowed border-muted opacity-50',
       !isDisabled && isError && 'border-error-default',
-      !isDisabled && !isError && isFocused && 'border-primary-default',
+      !isDisabled && !isError && isFocused && 'border-default',
       !isDisabled && !isError && !isFocused && 'border-muted',
       className,
     );

--- a/packages/design-system-react/src/components/TextField/TextField.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.tsx
@@ -1,0 +1,162 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import { twMerge } from '../../utils/tw-merge';
+import { Input } from '../Input';
+
+import { TextFieldSize, TextFieldType } from './TextField.types';
+import type { TextFieldProps } from './TextField.types';
+
+const SIZE_CLASS: Record<TextFieldSize, string> = {
+  [TextFieldSize.Sm]: 'h-8',
+  [TextFieldSize.Md]: 'h-10',
+  [TextFieldSize.Lg]: 'h-12',
+};
+
+export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
+  (
+    {
+      autoFocus = false,
+      className,
+      id,
+      inputElement,
+      inputProps,
+      inputRef,
+      isDisabled = false,
+      isError = false,
+      isReadOnly = false,
+      maxLength,
+      name,
+      onBlur,
+      onChange,
+      onClick,
+      onFocus,
+      placeholder,
+      required,
+      size = TextFieldSize.Md,
+      startAccessory,
+      endAccessory,
+      style,
+      truncate = true,
+      type = TextFieldType.Text,
+      value,
+      ...rest
+    },
+    ref,
+  ) => {
+    const internalInputRef = useRef<HTMLInputElement | null>(null);
+    const [isFocused, setIsFocused] = useState(autoFocus);
+
+    useEffect(() => {
+      if (isDisabled) {
+        setIsFocused(false);
+      }
+    }, [isDisabled]);
+
+    const handleClick = useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        if (isDisabled) {
+          return;
+        }
+        internalInputRef.current?.focus();
+        onClick?.(event);
+      },
+      [isDisabled, onClick],
+    );
+
+    const handleFocus = useCallback(
+      (event: React.FocusEvent<HTMLInputElement>) => {
+        setIsFocused(true);
+        onFocus?.(event);
+      },
+      [onFocus],
+    );
+
+    const handleBlur = useCallback(
+      (event: React.FocusEvent<HTMLInputElement>) => {
+        setIsFocused(false);
+        onBlur?.(event);
+      },
+      [onBlur],
+    );
+
+    const handleInputRef = useCallback(
+      (node: HTMLInputElement | null) => {
+        internalInputRef.current = node;
+        if (typeof inputRef === 'function') {
+          inputRef(node);
+        } else if (inputRef && 'current' in inputRef) {
+          (
+            inputRef as React.MutableRefObject<HTMLInputElement | null>
+          ).current = node;
+        }
+      },
+      [inputRef],
+    );
+
+    const { className: inputClassNameFromProps, ...inputRest } =
+      inputProps ?? {};
+
+    const containerClassName = twMerge(
+      'inline-flex items-center rounded-lg border bg-default transition-colors',
+      SIZE_CLASS[size],
+      startAccessory ? 'pl-4' : 'pl-0',
+      endAccessory ? 'pr-4' : 'pr-0',
+      isDisabled && 'cursor-not-allowed border-muted opacity-50',
+      !isDisabled && isError && 'border-error-default',
+      !isDisabled && !isError && isFocused && 'border-primary-default',
+      !isDisabled && !isError && !isFocused && 'border-muted',
+      className,
+    );
+
+    const innerInputClassName = twMerge(
+      'm-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0',
+      startAccessory ? 'pl-2' : 'pl-4',
+      endAccessory ? 'pr-2' : 'pr-4',
+      truncate && 'truncate',
+      inputClassNameFromProps,
+    );
+
+    return (
+      <div
+        ref={ref}
+        className={containerClassName}
+        style={style}
+        onClick={handleClick}
+        {...rest}
+      >
+        {startAccessory}
+        {inputElement ?? (
+          <Input
+            {...inputRest}
+            ref={handleInputRef}
+            id={id}
+            name={name}
+            type={type}
+            value={value}
+            placeholder={placeholder}
+            autoFocus={autoFocus}
+            isDisabled={isDisabled}
+            isReadOnly={isReadOnly}
+            isStateStylesDisabled
+            maxLength={maxLength}
+            required={required}
+            aria-invalid={isError || undefined}
+            onChange={onChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            className={innerInputClassName}
+          />
+        )}
+        {endAccessory}
+      </div>
+    );
+  },
+);
+
+TextField.displayName = 'TextField';

--- a/packages/design-system-react/src/components/TextField/TextField.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.tsx
@@ -1,3 +1,4 @@
+import { TextFieldSize, TextFieldType } from '@metamask/design-system-shared';
 import React, {
   forwardRef,
   useCallback,
@@ -9,7 +10,6 @@ import React, {
 import { twMerge } from '../../utils/tw-merge';
 import { Input } from '../Input';
 
-import { TextFieldSize, TextFieldType } from './TextField.types';
 import type { TextFieldProps } from './TextField.types';
 
 const SIZE_CLASS: Record<TextFieldSize, string> = {

--- a/packages/design-system-react/src/components/TextField/TextField.tsx
+++ b/packages/design-system-react/src/components/TextField/TextField.tsx
@@ -1,4 +1,3 @@
-import { TextFieldSize, TextFieldType } from '@metamask/design-system-shared';
 import React, {
   forwardRef,
   useCallback,
@@ -10,6 +9,7 @@ import React, {
 import { twMerge } from '../../utils/tw-merge';
 import { Input } from '../Input';
 
+import { TextFieldSize, TextFieldType } from './TextField.types';
 import type { TextFieldProps } from './TextField.types';
 
 const SIZE_CLASS: Record<TextFieldSize, string> = {

--- a/packages/design-system-react/src/components/TextField/TextField.types.ts
+++ b/packages/design-system-react/src/components/TextField/TextField.types.ts
@@ -3,6 +3,32 @@ import type { ComponentPropsWithoutRef, Ref } from 'react';
 
 import type { InputProps } from '../Input/Input.types';
 
+/**
+ * TextField size variants (web-only, ADR-0003).
+ *
+ * The React Native `TextField` ships a fixed height and intentionally does not
+ * expose a size prop, so this const object lives in the web package only.
+ */
+export const TextFieldSize = {
+  Sm: 'sm',
+  Md: 'md',
+  Lg: 'lg',
+} as const;
+export type TextFieldSize = (typeof TextFieldSize)[keyof typeof TextFieldSize];
+
+/**
+ * Native input `type` attribute values supported by the web TextField
+ * (ADR-0003). React Native consumers use `inputProps.keyboardType` /
+ * `inputProps.secureTextEntry` instead, so this is web-only.
+ */
+export const TextFieldType = {
+  Text: 'text',
+  Number: 'number',
+  Password: 'password',
+  Search: 'search',
+} as const;
+export type TextFieldType = (typeof TextFieldType)[keyof typeof TextFieldType];
+
 type TextFieldInputProps = Omit<
   InputProps,
   | 'autoFocus'
@@ -26,6 +52,40 @@ export type TextFieldProps = Omit<
   'onBlur' | 'onChange' | 'onFocus' | 'onClick'
 > &
   TextFieldPropsShared & {
+    /**
+     * The size of the text field. Controls the height.
+     *
+     * @default TextFieldSize.Md
+     */
+    size?: TextFieldSize;
+    /**
+     * The native input `type` attribute.
+     *
+     * @default TextFieldType.Text
+     */
+    type?: TextFieldType;
+    /**
+     * If true, truncates overflowing input text with an ellipsis.
+     *
+     * @default true
+     */
+    truncate?: boolean;
+    /**
+     * Max number of characters to allow.
+     */
+    maxLength?: number;
+    /**
+     * Name attribute of the inner `input` element.
+     */
+    name?: string;
+    /**
+     * `id` of the inner `input` element.
+     */
+    id?: string;
+    /**
+     * If true, the inner input is marked as required.
+     */
+    required?: boolean;
     /**
      * Additional props for the inner `Input`. Do not pass `value`,
      * `placeholder`, `isDisabled`, `isReadOnly`, `onFocus`, `onBlur`,

--- a/packages/design-system-react/src/components/TextField/TextField.types.ts
+++ b/packages/design-system-react/src/components/TextField/TextField.types.ts
@@ -3,21 +3,6 @@ import type { ComponentPropsWithoutRef, Ref } from 'react';
 
 import type { InputProps } from '../Input/Input.types';
 
-export const TextFieldSize = {
-  Sm: 'sm',
-  Md: 'md',
-  Lg: 'lg',
-} as const;
-export type TextFieldSize = (typeof TextFieldSize)[keyof typeof TextFieldSize];
-
-export const TextFieldType = {
-  Text: 'text',
-  Number: 'number',
-  Password: 'password',
-  Search: 'search',
-} as const;
-export type TextFieldType = (typeof TextFieldType)[keyof typeof TextFieldType];
-
 type TextFieldInputProps = Omit<
   InputProps,
   | 'autoFocus'
@@ -41,44 +26,6 @@ export type TextFieldProps = Omit<
   'onBlur' | 'onChange' | 'onFocus' | 'onClick'
 > &
   TextFieldPropsShared & {
-    /**
-     * The size of the text field. Controls the height.
-     *
-     * @default TextFieldSize.Md
-     */
-    size?: TextFieldSize;
-    /**
-     * The native input `type` attribute.
-     *
-     * @default TextFieldType.Text
-     */
-    type?: TextFieldType;
-    /**
-     * If true, truncates overflowing input text with an ellipsis.
-     *
-     * @default true
-     */
-    truncate?: boolean;
-    /**
-     * Max number of characters to allow.
-     */
-    maxLength?: number;
-    /**
-     * Name attribute of the inner `input` element.
-     */
-    name?: string;
-    /**
-     * `id` of the inner `input` element.
-     */
-    id?: string;
-    /**
-     * If true, the inner input is marked as required.
-     */
-    required?: boolean;
-    /**
-     * Hint shown when value is empty.
-     */
-    placeholder?: string;
     /**
      * Additional props for the inner `Input`. Do not pass `value`,
      * `placeholder`, `isDisabled`, `isReadOnly`, `onFocus`, `onBlur`,

--- a/packages/design-system-react/src/components/TextField/TextField.types.ts
+++ b/packages/design-system-react/src/components/TextField/TextField.types.ts
@@ -1,0 +1,112 @@
+import type { TextFieldPropsShared } from '@metamask/design-system-shared';
+import type { ComponentPropsWithoutRef, Ref } from 'react';
+
+import type { InputProps } from '../Input/Input.types';
+
+export const TextFieldSize = {
+  Sm: 'sm',
+  Md: 'md',
+  Lg: 'lg',
+} as const;
+export type TextFieldSize = (typeof TextFieldSize)[keyof typeof TextFieldSize];
+
+export const TextFieldType = {
+  Text: 'text',
+  Number: 'number',
+  Password: 'password',
+  Search: 'search',
+} as const;
+export type TextFieldType = (typeof TextFieldType)[keyof typeof TextFieldType];
+
+type TextFieldInputProps = Omit<
+  InputProps,
+  | 'autoFocus'
+  | 'isDisabled'
+  | 'isReadOnly'
+  | 'isStateStylesDisabled'
+  | 'onBlur'
+  | 'onChange'
+  | 'onFocus'
+  | 'placeholder'
+  | 'value'
+>;
+
+export type TextFieldProps = Omit<
+  ComponentPropsWithoutRef<'div'>,
+  'onBlur' | 'onChange' | 'onFocus' | 'onClick'
+> &
+  TextFieldPropsShared & {
+    /**
+     * The size of the text field. Controls the height.
+     *
+     * @default TextFieldSize.Md
+     */
+    size?: TextFieldSize;
+    /**
+     * The native input `type` attribute.
+     *
+     * @default TextFieldType.Text
+     */
+    type?: TextFieldType;
+    /**
+     * If true, truncates overflowing input text with an ellipsis.
+     *
+     * @default true
+     */
+    truncate?: boolean;
+    /**
+     * Max number of characters to allow.
+     */
+    maxLength?: number;
+    /**
+     * Name attribute of the inner `input` element.
+     */
+    name?: string;
+    /**
+     * `id` of the inner `input` element.
+     */
+    id?: string;
+    /**
+     * If true, the inner input is marked as required.
+     */
+    required?: boolean;
+    /**
+     * Hint shown when value is empty.
+     */
+    placeholder?: string;
+    /**
+     * Additional props for the inner `Input`. Do not pass `value`,
+     * `placeholder`, `isDisabled`, `isReadOnly`, `onFocus`, `onBlur`, or
+     * `onChange` here; use the TextField-level props above.
+     */
+    inputProps?: TextFieldInputProps;
+    /**
+     * Ref to the inner `input` element. The component `ref` targets the
+     * root `div`.
+     */
+    inputRef?: Ref<HTMLInputElement>;
+    /**
+     * Called when the inner input value changes.
+     */
+    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    /**
+     * Called when the inner input receives focus.
+     */
+    onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
+    /**
+     * Called when the inner input loses focus.
+     */
+    onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+    /**
+     * Called when the root container is clicked. Focuses the inner input.
+     */
+    onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+    /**
+     * Optional additional CSS classes for the root container.
+     */
+    className?: string;
+    /**
+     * Optional inline styles for the root container.
+     */
+    style?: React.CSSProperties;
+  };

--- a/packages/design-system-react/src/components/TextField/TextField.types.ts
+++ b/packages/design-system-react/src/components/TextField/TextField.types.ts
@@ -21,13 +21,18 @@ export type TextFieldType = (typeof TextFieldType)[keyof typeof TextFieldType];
 type TextFieldInputProps = Omit<
   InputProps,
   | 'autoFocus'
+  | 'id'
   | 'isDisabled'
   | 'isReadOnly'
   | 'isStateStylesDisabled'
+  | 'maxLength'
+  | 'name'
   | 'onBlur'
   | 'onChange'
   | 'onFocus'
   | 'placeholder'
+  | 'required'
+  | 'type'
   | 'value'
 >;
 
@@ -76,8 +81,9 @@ export type TextFieldProps = Omit<
     placeholder?: string;
     /**
      * Additional props for the inner `Input`. Do not pass `value`,
-     * `placeholder`, `isDisabled`, `isReadOnly`, `onFocus`, `onBlur`, or
-     * `onChange` here; use the TextField-level props above.
+     * `placeholder`, `isDisabled`, `isReadOnly`, `onFocus`, `onBlur`,
+     * `onChange`, `id`, `name`, `type`, `maxLength`, or `required` here;
+     * use the TextField-level props above.
      */
     inputProps?: TextFieldInputProps;
     /**

--- a/packages/design-system-react/src/components/TextField/index.ts
+++ b/packages/design-system-react/src/components/TextField/index.ts
@@ -1,0 +1,3 @@
+export { TextField } from './TextField';
+export { TextFieldSize, TextFieldType } from './TextField.types';
+export type { TextFieldProps } from './TextField.types';

--- a/packages/design-system-react/src/components/TextField/index.ts
+++ b/packages/design-system-react/src/components/TextField/index.ts
@@ -1,3 +1,3 @@
+export { TextFieldSize, TextFieldType } from '@metamask/design-system-shared';
 export { TextField } from './TextField';
-export { TextFieldSize, TextFieldType } from './TextField.types';
 export type { TextFieldProps } from './TextField.types';

--- a/packages/design-system-react/src/components/TextField/index.ts
+++ b/packages/design-system-react/src/components/TextField/index.ts
@@ -1,3 +1,3 @@
-export { TextFieldSize, TextFieldType } from '@metamask/design-system-shared';
 export { TextField } from './TextField';
+export { TextFieldSize, TextFieldType } from './TextField.types';
 export type { TextFieldProps } from './TextField.types';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -145,6 +145,9 @@ export type { TextProps } from './Text';
 export { TextButton, TextButtonSize } from './TextButton';
 export type { TextButtonProps } from './TextButton';
 
+export { TextField, TextFieldSize, TextFieldType } from './TextField';
+export type { TextFieldProps } from './TextField';
+
 export { BannerAlert, BannerAlertSeverity } from './BannerAlert';
 export type { BannerAlertProps } from './BannerAlert';
 

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -145,8 +145,12 @@ export {
   type TextPropsShared,
 } from './types/Text';
 
-// TextField types (ADR-0004)
-export { type TextFieldPropsShared } from './types/TextField';
+// TextField types (ADR-0003 + ADR-0004)
+export {
+  TextFieldSize,
+  TextFieldType,
+  type TextFieldPropsShared,
+} from './types/TextField';
 
 // TextArea types (ADR-0004)
 export { type TextAreaPropsShared } from './types/TextArea';

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -145,12 +145,8 @@ export {
   type TextPropsShared,
 } from './types/Text';
 
-// TextField types (ADR-0003 + ADR-0004)
-export {
-  TextFieldSize,
-  TextFieldType,
-  type TextFieldPropsShared,
-} from './types/TextField';
+// TextField types (ADR-0004)
+export { type TextFieldPropsShared } from './types/TextField';
 
 // TextArea types (ADR-0004)
 export { type TextAreaPropsShared } from './types/TextArea';

--- a/packages/design-system-shared/src/types/TextField/TextField.types.ts
+++ b/packages/design-system-shared/src/types/TextField/TextField.types.ts
@@ -3,27 +3,6 @@ import type { ReactNode } from 'react';
 import type { InputPropsShared } from '../Input/Input.types';
 
 /**
- * TextField size variants (ADR-0003).
- */
-export const TextFieldSize = {
-  Sm: 'sm',
-  Md: 'md',
-  Lg: 'lg',
-} as const;
-export type TextFieldSize = (typeof TextFieldSize)[keyof typeof TextFieldSize];
-
-/**
- * Native input `type` attribute values supported by TextField (ADR-0003).
- */
-export const TextFieldType = {
-  Text: 'text',
-  Number: 'number',
-  Password: 'password',
-  Search: 'search',
-} as const;
-export type TextFieldType = (typeof TextFieldType)[keyof typeof TextFieldType];
-
-/**
  * TextField shared props (ADR-0004).
  *
  * Layers controlled text-field chrome (accessories, custom input slot, error
@@ -35,40 +14,6 @@ export type TextFieldPropsShared = Omit<
   InputPropsShared,
   'isStateStylesDisabled' | 'textVariant'
 > & {
-  /**
-   * The size of the text field. Controls the height.
-   *
-   * @default TextFieldSize.Md
-   */
-  size?: TextFieldSize;
-  /**
-   * The native input `type` attribute.
-   *
-   * @default TextFieldType.Text
-   */
-  type?: TextFieldType;
-  /**
-   * If true, truncates overflowing input text with an ellipsis.
-   *
-   * @default true
-   */
-  truncate?: boolean;
-  /**
-   * Max number of characters to allow.
-   */
-  maxLength?: number;
-  /**
-   * Name attribute of the inner `input` element.
-   */
-  name?: string;
-  /**
-   * `id` of the inner `input` element.
-   */
-  id?: string;
-  /**
-   * If true, the inner input is marked as required.
-   */
-  required?: boolean;
   /**
    * When true, the field shows an error state (for example border treatment).
    *

--- a/packages/design-system-shared/src/types/TextField/TextField.types.ts
+++ b/packages/design-system-shared/src/types/TextField/TextField.types.ts
@@ -3,17 +3,72 @@ import type { ReactNode } from 'react';
 import type { InputPropsShared } from '../Input/Input.types';
 
 /**
+ * TextField size variants (ADR-0003).
+ */
+export const TextFieldSize = {
+  Sm: 'sm',
+  Md: 'md',
+  Lg: 'lg',
+} as const;
+export type TextFieldSize = (typeof TextFieldSize)[keyof typeof TextFieldSize];
+
+/**
+ * Native input `type` attribute values supported by TextField (ADR-0003).
+ */
+export const TextFieldType = {
+  Text: 'text',
+  Number: 'number',
+  Password: 'password',
+  Search: 'search',
+} as const;
+export type TextFieldType = (typeof TextFieldType)[keyof typeof TextFieldType];
+
+/**
  * TextField shared props (ADR-0004).
  *
  * Layers controlled text-field chrome (accessories, custom input slot, error
  * state, etc.) on top of the shared `InputPropsShared` contract. Styling,
- * `testID`, native-only `inputProps`, and typed focus/blur handlers stay on
- * the platform layer.
+ * `testID`, native-only `inputProps`, refs, and typed focus/blur handlers
+ * stay on the platform layer.
  */
 export type TextFieldPropsShared = Omit<
   InputPropsShared,
   'isStateStylesDisabled' | 'textVariant'
 > & {
+  /**
+   * The size of the text field. Controls the height.
+   *
+   * @default TextFieldSize.Md
+   */
+  size?: TextFieldSize;
+  /**
+   * The native input `type` attribute.
+   *
+   * @default TextFieldType.Text
+   */
+  type?: TextFieldType;
+  /**
+   * If true, truncates overflowing input text with an ellipsis.
+   *
+   * @default true
+   */
+  truncate?: boolean;
+  /**
+   * Max number of characters to allow.
+   */
+  maxLength?: number;
+  /**
+   * Name attribute of the inner `input` element.
+   */
+  name?: string;
+  /**
+   * `id` of the inner `input` element.
+   */
+  id?: string;
+  /**
+   * If true, the inner input is marked as required.
+   */
+  required?: boolean;
   /**
    * When true, the field shows an error state (for example border treatment).
    *

--- a/packages/design-system-shared/src/types/TextField/index.ts
+++ b/packages/design-system-shared/src/types/TextField/index.ts
@@ -1,5 +1,1 @@
-export {
-  TextFieldSize,
-  TextFieldType,
-  type TextFieldPropsShared,
-} from './TextField.types';
+export { type TextFieldPropsShared } from './TextField.types';

--- a/packages/design-system-shared/src/types/TextField/index.ts
+++ b/packages/design-system-shared/src/types/TextField/index.ts
@@ -1,1 +1,5 @@
-export type { TextFieldPropsShared } from './TextField.types';
+export {
+  TextFieldSize,
+  TextFieldType,
+  type TextFieldPropsShared,
+} from './TextField.types';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Added `TextField` component to DSR. 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-316

## **Manual testing steps**

1. Open Storybook app
2. Check `TextField` example

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1077" height="434" alt="image" src="https://github.com/user-attachments/assets/2ff2b6df-e7c0-408a-86ed-d31c5f968334" />

### **After**

<img width="1076" height="580" alt="image" src="https://github.com/user-attachments/assets/cee5ddf4-c3b9-492f-a6a2-41ed7625a67a" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New UI component with tests and documentation only; no changes to auth, data handling, or existing consumer runtime behavior until extensions adopt the new import.
> 
> **Overview**
> Adds **`TextField`** to `@metamask/design-system-react` as the web implementation of the extension migration (DSYS-316): a **`forwardRef`** root `<div>` that wraps design-system **`Input`**, with Tailwind-based chrome (sizes, focus/error/disabled borders), optional **start/end accessories**, and **`inputElement`** / **`inputRef`** / **`inputProps`** for customization.
> 
> Exports **`TextField`**, **`TextFieldSize`**, **`TextFieldType`**, and **`TextFieldProps`** from the package barrel; web-only size/type const objects extend shared **`TextFieldPropsShared`**. Includes Storybook docs, stories, and unit tests. **`MIGRATION.md`** documents extension → design-system moves (`disabled`/`readOnly`/`error` → **`is*`**, **`InputComponent`** → **`inputElement`**, controlled-only, no polymorphic Box).
> 
> Shared package: comment tweak on **`TextFieldPropsShared`** and **`export { type ... }`** on the TextField types index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbe0b8ae311f5d93ec3c3b3adabb816bf69c81fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->