### PR TITLE
feat: Added SelectButton, SegmentButton, and SegmentGroup to DSRN

### DIFF
--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.tsx
@@ -1,6 +1,6 @@
+import type { BoxSpacing } from '@metamask/design-system-shared';
 import {
   ButtonBaseSize,
-  type BoxSpacing,
   FontWeight,
   TextColor,
 } from '@metamask/design-system-shared';

--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.tsx
@@ -1,4 +1,3 @@
-import type { BoxSpacing } from '@metamask/design-system-shared';
 import {
   ButtonBaseSize,
   FontWeight,
@@ -163,18 +162,8 @@ export const ButtonBase = ({
       {({ pressed }) => {
         const { twClassName: loadingWrapperTw, ...restLoadingWrapper } =
           loadingWrapperProps ?? {};
-        const {
-          twClassName: contentWrapperTw,
-          gap: contentWrapperGap,
-          ...restContentWrapper
-        } = contentWrapperProps ?? {};
-
-        let contentRowGap: BoxSpacing = 0;
-        if (contentWrapperGap !== undefined) {
-          contentRowGap = contentWrapperGap;
-        } else if (hasAccessories) {
-          contentRowGap = 1;
-        }
+        const { twClassName: contentWrapperTw, ...restContentWrapper } =
+          contentWrapperProps ?? {};
 
         return (
           <>
@@ -209,7 +198,7 @@ export const ButtonBase = ({
             <BoxRow
               {...restContentWrapper}
               twClassName={`${contentWrapperTw ?? ''} ${isLoading ? 'opacity-0' : ''}`}
-              gap={contentRowGap}
+              gap={hasAccessories ? 1 : 0}
               startAccessory={
                 finalStartIconName ? (
                   <Icon

--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.tsx
@@ -1,5 +1,6 @@
 import {
   ButtonBaseSize,
+  type BoxSpacing,
   FontWeight,
   TextColor,
 } from '@metamask/design-system-shared';
@@ -162,8 +163,18 @@ export const ButtonBase = ({
       {({ pressed }) => {
         const { twClassName: loadingWrapperTw, ...restLoadingWrapper } =
           loadingWrapperProps ?? {};
-        const { twClassName: contentWrapperTw, ...restContentWrapper } =
-          contentWrapperProps ?? {};
+        const {
+          twClassName: contentWrapperTw,
+          gap: contentWrapperGap,
+          ...restContentWrapper
+        } = contentWrapperProps ?? {};
+
+        let contentRowGap: BoxSpacing = 0;
+        if (contentWrapperGap !== undefined) {
+          contentRowGap = contentWrapperGap;
+        } else if (hasAccessories) {
+          contentRowGap = 1;
+        }
 
         return (
           <>
@@ -198,7 +209,7 @@ export const ButtonBase = ({
             <BoxRow
               {...restContentWrapper}
               twClassName={`${contentWrapperTw ?? ''} ${isLoading ? 'opacity-0' : ''}`}
-              gap={hasAccessories ? 1 : 0}
+              gap={contentRowGap}
               startAccessory={
                 finalStartIconName ? (
                   <Icon

--- a/packages/design-system-react-native/src/components/SegmentButton/README.md
+++ b/packages/design-system-react-native/src/components/SegmentButton/README.md
@@ -160,7 +160,7 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 
 ### Other `ButtonBase` props
 
-`SegmentButton` accepts the rest of **`ButtonBase`** props (for example **`size`**, **`isLoading`**, **`isDisabled`**, **`startIconName`**, **`startAccessory`**, **`textProps`**, **`startIconProps`**, **`endIconProps`**). Shared segment fields live in **`SegmentButtonPropsShared`** in **`@metamask/design-system-shared`**.
+`SegmentButton` accepts the rest of **`ButtonBase`** props (for example **`size`**, **`isLoading`**, **`isDisabled`**, **`startIconName`**, **`startAccessory`**, **`textProps`**, **`startIconProps`**, **`endIconProps`**). The full props contract is **`SegmentButtonProps`** from **`@metamask/design-system-react-native`**.
 
 ## References
 

--- a/packages/design-system-react-native/src/components/SegmentButton/README.md
+++ b/packages/design-system-react-native/src/components/SegmentButton/README.md
@@ -1,0 +1,167 @@
+# SegmentButton
+
+SegmentButton is one segment in a segmented control: a pressable row with optional leading and trailing icons, loading state, and sizing consistent with other buttons. Use it inside **`SegmentGroup`** when the parent owns a single selected **`value`**, or on its own when you drive selection with **`isSelected`**.
+
+```tsx
+import { SegmentButton } from '@metamask/design-system-react-native';
+
+<SegmentButton onPress={() => {}}>Option A</SegmentButton>;
+```
+
+## Props
+
+### `children`
+
+Visible label or custom content for the segment.
+
+| TYPE        | REQUIRED | DEFAULT |
+| ----------- | -------- | ------- |
+| `ReactNode` | Yes      | N/A     |
+
+```tsx
+import { SegmentButton } from '@metamask/design-system-react-native';
+
+<SegmentButton onPress={() => {}}>All</SegmentButton>;
+```
+
+### `onPress`
+
+Called when the segment is pressed. Use with **`SegmentGroup`** so the parent updates group **`value`** from **`onChange`**, or toggle local state when using **`isSelected`** alone.
+
+| TYPE         | REQUIRED | DEFAULT     |
+| ------------ | -------- | ----------- |
+| `() => void` | No       | `undefined` |
+
+```tsx
+import { SegmentButton } from '@metamask/design-system-react-native';
+
+<SegmentButton onPress={() => console.log('pressed')}>Save</SegmentButton>;
+```
+
+### `variant`
+
+Controls selected vs unselected styling for each segment.
+
+Available values:
+
+- `SegmentButtonVariant.Primary` — selected segment uses the primary inverse treatment; unselected uses a transparent row with alternative label and icon colors.
+- `SegmentButtonVariant.Secondary` — selected segment uses a muted filled treatment; unselected matches the transparent-row alternative treatment.
+
+| TYPE                   | REQUIRED | DEFAULT                        |
+| ---------------------- | -------- | ------------------------------ |
+| `SegmentButtonVariant` | No       | `SegmentButtonVariant.Primary` |
+
+```tsx
+import {
+  SegmentButton,
+  SegmentButtonVariant,
+} from '@metamask/design-system-react-native';
+
+<SegmentButton
+  variant={SegmentButtonVariant.Secondary}
+  isSelected
+  onPress={() => {}}
+>
+  1D
+</SegmentButton>;
+```
+
+### `isSelected`
+
+When `true`, the segment uses the selected look for the current **`variant`**. Ignored when the button has **`value`** set and sits under **`SegmentGroup`** (the group’s **`value`** decides selection).
+
+| TYPE      | REQUIRED | DEFAULT |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
+```tsx
+import { SegmentButton } from '@metamask/design-system-react-native';
+
+<SegmentButton isSelected onPress={() => {}}>
+  Active
+</SegmentButton>;
+```
+
+### `value`
+
+Stable segment id when used under **`SegmentGroup`**. Must match the group’s **`value`** for this segment to appear selected. Distinct from visible **`children`**.
+
+| TYPE     | REQUIRED | DEFAULT     |
+| -------- | -------- | ----------- |
+| `string` | No       | `undefined` |
+
+```tsx
+import { useState } from 'react';
+import {
+  SegmentButton,
+  SegmentGroup,
+} from '@metamask/design-system-react-native';
+
+export const Example = () => {
+  const [value, setValue] = useState('all');
+
+  return (
+    <SegmentGroup value={value} onChange={setValue}>
+      <SegmentButton value="all" onPress={() => {}}>
+        All
+      </SegmentButton>
+      <SegmentButton value="tokens" onPress={() => {}}>
+        Tokens
+      </SegmentButton>
+    </SegmentGroup>
+  );
+};
+```
+
+### `twClassName`
+
+Use the `twClassName` prop to add Tailwind CSS classes to the root pressable. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+| TYPE                                       | REQUIRED | DEFAULT     |
+| ------------------------------------------ | -------- | ----------- |
+| `string \| ((pressed: boolean) => string)` | No       | `undefined` |
+
+```tsx
+import { SegmentButton } from '@metamask/design-system-react-native';
+
+<SegmentButton onPress={() => {}} twClassName="min-w-16">
+  Wide
+</SegmentButton>;
+```
+
+### `style`
+
+Use the `style` prop to customize the root with React Native styles. For consistent styling, prefer using `twClassName` with Tailwind classes when possible. Use `style` with `tw.style()` for conditionals or dynamic values.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `StyleProp<ViewStyle>` | No       | `undefined` |
+
+```tsx
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { SegmentButton } from '@metamask/design-system-react-native';
+
+export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
+  const tw = useTailwind();
+
+  return (
+    <SegmentButton
+      onPress={() => {}}
+      style={tw.style(isActive && 'opacity-80')}
+    >
+      Filter
+    </SegmentButton>
+  );
+};
+```
+
+### Other `ButtonBase` props
+
+`SegmentButton` accepts the rest of **`ButtonBase`** props (for example **`size`**, **`isLoading`**, **`isDisabled`**, **`startIconName`**, **`startAccessory`**, **`textProps`**, **`startIconProps`**, **`endIconProps`**). Shared segment fields live in **`SegmentButtonPropsShared`** in **`@metamask/design-system-shared`**.
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.stories.tsx
+++ b/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.stories.tsx
@@ -1,0 +1,151 @@
+import { SegmentButtonVariant } from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import type { ViewProps } from 'react-native';
+import { View } from 'react-native';
+
+import { Icon, IconName, IconSize } from '../Icon';
+
+import { SegmentButton } from './SegmentButton';
+import type { SegmentButtonProps } from './SegmentButton.types';
+
+const noopPress = () => undefined;
+
+const meta: Meta<SegmentButtonProps> = {
+  title: 'Components/SegmentButton',
+  component: SegmentButton,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: Object.values(SegmentButtonVariant),
+    },
+    isSelected: {
+      control: 'boolean',
+    },
+    isDisabled: {
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+
+const SegmentButtonStoryWrapper: React.FC<ViewProps> = ({
+  children,
+  ...props
+}) => {
+  const tw = useTailwind();
+  return (
+    <View {...props} style={[tw`flex-row flex-wrap gap-2 p-4`, props.style]}>
+      {children}
+    </View>
+  );
+};
+
+type Story = StoryObj<SegmentButtonProps>;
+
+export const Default: Story = {
+  args: {
+    children: 'Segment',
+    variant: SegmentButtonVariant.Primary,
+    isSelected: true,
+    isDisabled: false,
+    isLoading: false,
+    onPress: noopPress,
+  },
+  render: (args: SegmentButtonProps) => (
+    <SegmentButtonStoryWrapper>
+      <SegmentButton {...args} />
+    </SegmentButtonStoryWrapper>
+  ),
+};
+
+export const Variant: Story = {
+  render: () => (
+    <SegmentButtonStoryWrapper>
+      <SegmentButton
+        variant={SegmentButtonVariant.Primary}
+        isSelected
+        children="Primary selected"
+        onPress={noopPress}
+      />
+      <SegmentButton
+        variant={SegmentButtonVariant.Primary}
+        isSelected={false}
+        children="Primary unselected"
+        onPress={noopPress}
+      />
+      <SegmentButton
+        variant={SegmentButtonVariant.Secondary}
+        isSelected
+        children="Secondary selected"
+        onPress={noopPress}
+      />
+      <SegmentButton
+        variant={SegmentButtonVariant.Secondary}
+        isSelected={false}
+        children="Secondary unselected"
+        onPress={noopPress}
+      />
+    </SegmentButtonStoryWrapper>
+  ),
+};
+
+export const IsSelected: Story = {
+  render: () => (
+    <SegmentButtonStoryWrapper>
+      <SegmentButton
+        variant={SegmentButtonVariant.Primary}
+        isSelected
+        children="Selected"
+        onPress={noopPress}
+      />
+      <SegmentButton
+        variant={SegmentButtonVariant.Primary}
+        isSelected={false}
+        children="Unselected"
+        onPress={noopPress}
+      />
+    </SegmentButtonStoryWrapper>
+  ),
+};
+
+export const IsDisabled: Story = {
+  render: () => (
+    <SegmentButtonStoryWrapper>
+      <SegmentButton
+        variant={SegmentButtonVariant.Primary}
+        children="Enabled"
+        onPress={noopPress}
+      />
+      <SegmentButton
+        variant={SegmentButtonVariant.Primary}
+        isDisabled
+        children="Disabled"
+        onPress={noopPress}
+      />
+    </SegmentButtonStoryWrapper>
+  ),
+};
+
+export const StartAccessory: Story = {
+  render: () => (
+    <SegmentButtonStoryWrapper>
+      <SegmentButton
+        variant={SegmentButtonVariant.Secondary}
+        isSelected={false}
+        startIconName={IconName.Search}
+        startIconProps={{ testID: 'segment-start-icon' }}
+        children="With icon"
+        onPress={noopPress}
+      />
+      <SegmentButton
+        variant={SegmentButtonVariant.Primary}
+        isSelected={false}
+        startAccessory={<Icon name={IconName.Wallet} size={IconSize.Sm} />}
+        children="Custom start"
+        onPress={noopPress}
+      />
+    </SegmentButtonStoryWrapper>
+  ),
+};

--- a/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.test.tsx
+++ b/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.test.tsx
@@ -1,0 +1,434 @@
+import {
+  SegmentButtonVariant,
+  TextColor,
+} from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { renderHook } from '@testing-library/react-hooks';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import { IconColor, IconName, IconSize } from '../../types';
+import { TWCLASSMAP_ICON_SIZE_DIMENSION } from '../Icon/Icon.constants';
+import { SegmentGroup } from '../SegmentGroup/SegmentGroup';
+
+import { SegmentButton } from './SegmentButton';
+
+const ROOT_TEST_ID = 'segment-button';
+
+const noopPress = () => undefined;
+
+describe('SegmentButton', () => {
+  let tw: ReturnType<typeof useTailwind>;
+
+  beforeAll(() => {
+    const { result } = renderHook(() => useTailwind());
+    tw = result.current;
+  });
+
+  describe('when rendering children', () => {
+    it('renders string children as label text', () => {
+      const { getByText } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          children="Label"
+        />,
+      );
+
+      expect(getByText('Label')).toHaveTextContent('Label');
+    });
+
+    it('renders JSX children as label text', () => {
+      const { getByText } = render(
+        <SegmentButton testID={ROOT_TEST_ID} onPress={noopPress}>
+          Child label
+        </SegmentButton>,
+      );
+
+      expect(getByText('Child label')).toHaveTextContent('Child label');
+    });
+  });
+
+  it('exposes testID on the root pressable', () => {
+    const { getByTestId } = render(
+      <SegmentButton
+        testID="custom-segment"
+        onPress={noopPress}
+        children="A"
+      />,
+    );
+
+    expect(getByTestId('custom-segment')).toBeOnTheScreen();
+  });
+
+  describe('container and label appearance by variant', () => {
+    it('uses icon default background when primary variant is selected', () => {
+      const { getByTestId } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SegmentButtonVariant.Primary}
+          isSelected
+          children="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-icon-default`);
+    });
+
+    it('uses transparent background when primary variant is unselected', () => {
+      const { getByTestId } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SegmentButtonVariant.Primary}
+          isSelected={false}
+          children="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-transparent`);
+    });
+
+    it('uses muted background when secondary variant is selected', () => {
+      const { getByTestId } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SegmentButtonVariant.Secondary}
+          isSelected
+          children="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-muted`);
+    });
+
+    it('uses transparent background when secondary variant is unselected', () => {
+      const { getByTestId } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SegmentButtonVariant.Secondary}
+          isSelected={false}
+          children="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-transparent`);
+    });
+
+    it('applies alternative text color when primary variant is unselected', () => {
+      const { getByText } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SegmentButtonVariant.Primary}
+          isSelected={false}
+          children="Label"
+        />,
+      );
+
+      expect(getByText('Label')).toHaveStyle(
+        tw.style(TextColor.TextAlternative),
+      );
+    });
+
+    it('applies alternative text color when secondary variant is unselected', () => {
+      const { getByText } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SegmentButtonVariant.Secondary}
+          isSelected={false}
+          children="Label"
+        />,
+      );
+
+      expect(getByText('Label')).toHaveStyle(
+        tw.style(TextColor.TextAlternative),
+      );
+    });
+
+    it('applies alternative icon color to start icon when primary variant is unselected', () => {
+      const { getByTestId } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SegmentButtonVariant.Primary}
+          isSelected={false}
+          startIconName={IconName.Search}
+          startIconProps={{ testID: 'segment-icon' }}
+          children="Label"
+        />,
+      );
+
+      expect(getByTestId('segment-icon')).toHaveStyle(
+        tw.style(
+          IconColor.IconAlternative,
+          TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Sm],
+        ),
+      );
+    });
+
+    it('applies alternative icon color to start icon when secondary variant is unselected', () => {
+      const { getByTestId } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SegmentButtonVariant.Secondary}
+          isSelected={false}
+          startIconName={IconName.Search}
+          startIconProps={{ testID: 'segment-icon' }}
+          children="Label"
+        />,
+      );
+
+      expect(getByTestId('segment-icon')).toHaveStyle(
+        tw.style(
+          IconColor.IconAlternative,
+          TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Sm],
+        ),
+      );
+    });
+
+    it('applies alternative icon color to end icon when primary variant is unselected', () => {
+      const { getByTestId } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SegmentButtonVariant.Primary}
+          isSelected={false}
+          endIconName={IconName.Search}
+          endIconProps={{ testID: 'segment-end-icon' }}
+          children="Label"
+        />,
+      );
+
+      expect(getByTestId('segment-end-icon')).toHaveStyle(
+        tw.style(
+          IconColor.IconAlternative,
+          TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Sm],
+        ),
+      );
+    });
+  });
+
+  describe('when disabled', () => {
+    it('applies reduced opacity to the root', () => {
+      const { getByTestId } = render(
+        <SegmentButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          isDisabled
+          children="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`opacity-50`);
+    });
+  });
+
+  it('calls twClassName with pressed state when primary variant is selected', () => {
+    const twClassName = jest.fn((pressed: boolean) =>
+      pressed ? 'opacity-80' : 'opacity-100',
+    );
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Primary}
+        isSelected
+        twClassName={twClassName}
+        children="Label"
+      />,
+    );
+
+    const root = getByTestId(ROOT_TEST_ID);
+    fireEvent(root, 'pressIn');
+    expect(twClassName).toHaveBeenCalledWith(true);
+    fireEvent(root, 'pressOut');
+    expect(twClassName).toHaveBeenCalledWith(false);
+  });
+
+  it('calls twClassName with pressed state when secondary variant is selected', () => {
+    const twClassName = jest.fn((pressed: boolean) =>
+      pressed ? 'opacity-75' : 'opacity-100',
+    );
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Secondary}
+        isSelected
+        twClassName={twClassName}
+        children="Label"
+      />,
+    );
+
+    const root = getByTestId(ROOT_TEST_ID);
+    fireEvent(root, 'pressIn');
+    expect(twClassName).toHaveBeenCalledWith(true);
+    fireEvent(root, 'pressOut');
+    expect(twClassName).toHaveBeenCalledWith(false);
+  });
+
+  it('merges function twClassName for primary unselected container', () => {
+    const twClassName = jest.fn(() => 'mt-1');
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Primary}
+        isSelected={false}
+        twClassName={twClassName}
+        children="Label"
+      />,
+    );
+
+    expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`mt-1`);
+    expect(twClassName).toHaveBeenCalled();
+  });
+
+  it('merges function twClassName for secondary unselected container', () => {
+    const twClassName = jest.fn(() => 'mt-2');
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Secondary}
+        isSelected={false}
+        twClassName={twClassName}
+        children="Label"
+      />,
+    );
+
+    expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`mt-2`);
+    expect(twClassName).toHaveBeenCalled();
+  });
+
+  it('uses pressed background when primary selected receives pressIn', () => {
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Primary}
+        isSelected
+        children="Label"
+      />,
+    );
+
+    const root = getByTestId(ROOT_TEST_ID);
+    fireEvent(root, 'pressIn');
+    expect(root).toHaveStyle(tw`bg-icon-default-pressed`);
+  });
+
+  it('uses pressed border when primary unselected receives pressIn', () => {
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Primary}
+        isSelected={false}
+        children="Label"
+      />,
+    );
+
+    const root = getByTestId(ROOT_TEST_ID);
+    fireEvent(root, 'pressIn');
+    expect(root).toHaveStyle(tw`border-background-pressed`);
+  });
+
+  it('uses pressed border when secondary unselected receives pressIn', () => {
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Secondary}
+        isSelected={false}
+        children="Label"
+      />,
+    );
+
+    const root = getByTestId(ROOT_TEST_ID);
+    fireEvent(root, 'pressIn');
+    expect(root).toHaveStyle(tw`border-background-pressed`);
+  });
+
+  it('uses pressed background on root when primary selected is loading', () => {
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Primary}
+        isSelected
+        isLoading
+        children="Label"
+      />,
+    );
+
+    expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-icon-default-pressed`);
+  });
+
+  it('uses pressed loading container when primary unselected is loading', () => {
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Primary}
+        isSelected={false}
+        isLoading
+        children="Label"
+      />,
+    );
+
+    expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-pressed`);
+    expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
+      tw`border-background-pressed`,
+    );
+  });
+
+  it('uses pressed loading container when secondary unselected is loading', () => {
+    const { getByTestId } = render(
+      <SegmentButton
+        testID={ROOT_TEST_ID}
+        onPress={noopPress}
+        variant={SegmentButtonVariant.Secondary}
+        isSelected={false}
+        isLoading
+        children="Label"
+      />,
+    );
+
+    expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-pressed`);
+    expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
+      tw`border-background-pressed`,
+    );
+  });
+
+  describe('when used inside SegmentGroup', () => {
+    it('derives selected visual from group value instead of isSelected', () => {
+      const { getByTestId } = render(
+        <SegmentGroup value="b" onChange={noopPress} testID="group">
+          <SegmentButton
+            value="a"
+            children="A"
+            testID="seg-a"
+            isSelected
+            onPress={noopPress}
+          />
+          <SegmentButton
+            value="b"
+            children="B"
+            testID="seg-b"
+            isSelected={false}
+            onPress={noopPress}
+          />
+        </SegmentGroup>,
+      );
+
+      expect(getByTestId('seg-a')).toHaveStyle(tw`bg-transparent`);
+      expect(getByTestId('seg-b')).toHaveStyle(tw`bg-icon-default`);
+    });
+  });
+});

--- a/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.test.tsx
+++ b/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.test.tsx
@@ -323,7 +323,7 @@ describe('SegmentButton', () => {
     expect(root).toHaveStyle(tw`bg-icon-default-pressed`);
   });
 
-  it('uses pressed border when primary unselected receives pressIn', () => {
+  it('uses pressed background when primary unselected receives pressIn', () => {
     const { getByTestId } = render(
       <SegmentButton
         testID={ROOT_TEST_ID}
@@ -336,10 +336,10 @@ describe('SegmentButton', () => {
 
     const root = getByTestId(ROOT_TEST_ID);
     fireEvent(root, 'pressIn');
-    expect(root).toHaveStyle(tw`border-background-pressed`);
+    expect(root).toHaveStyle(tw`bg-pressed`);
   });
 
-  it('uses pressed border when secondary unselected receives pressIn', () => {
+  it('uses pressed background when secondary unselected receives pressIn', () => {
     const { getByTestId } = render(
       <SegmentButton
         testID={ROOT_TEST_ID}
@@ -352,7 +352,7 @@ describe('SegmentButton', () => {
 
     const root = getByTestId(ROOT_TEST_ID);
     fireEvent(root, 'pressIn');
-    expect(root).toHaveStyle(tw`border-background-pressed`);
+    expect(root).toHaveStyle(tw`bg-pressed`);
   });
 
   it('uses pressed background on root when primary selected is loading', () => {
@@ -383,9 +383,6 @@ describe('SegmentButton', () => {
     );
 
     expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-pressed`);
-    expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
-      tw`border-background-pressed`,
-    );
   });
 
   it('uses pressed loading container when secondary unselected is loading', () => {
@@ -401,9 +398,6 @@ describe('SegmentButton', () => {
     );
 
     expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-pressed`);
-    expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
-      tw`border-background-pressed`,
-    );
   });
 
   describe('when used inside SegmentGroup', () => {

--- a/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.tsx
+++ b/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.tsx
@@ -107,11 +107,7 @@ export const SegmentButton = ({
           }`;
         }
 
-        return `${pressed || isLoading ? 'bg-pressed' : 'bg-transparent'} ${
-          pressed || isLoading
-            ? 'border-background-pressed'
-            : 'border-transparent'
-        } border-0 ${
+        return `${pressed || isLoading ? 'bg-pressed' : 'bg-transparent'} border-0 ${
           typeof twClassName === 'function' ? twClassName(pressed) : twClassName
         }`;
       }}

--- a/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.tsx
+++ b/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.tsx
@@ -1,0 +1,125 @@
+import {
+  ButtonBaseSize,
+  SegmentButtonVariant,
+  SegmentGroupContext,
+} from '@metamask/design-system-shared';
+import React, { useContext } from 'react';
+import type { GestureResponderEvent } from 'react-native';
+
+import { ButtonBase } from '../ButtonBase';
+import { IconColor } from '../Icon';
+import { TextColor } from '../Text';
+
+import type { SegmentButtonProps } from './SegmentButton.types';
+
+export const SegmentButton = ({
+  children,
+  textProps,
+  startIconProps,
+  endIconProps,
+  value,
+  isSelected = false,
+  variant,
+  isLoading = false,
+  size = ButtonBaseSize.Sm,
+  twClassName = '',
+  style,
+  onPress,
+  ...buttonBaseRest
+}: SegmentButtonProps) => {
+  const segmentGroup = useContext(SegmentGroupContext);
+  const usesGroupSelection = segmentGroup !== null && value !== undefined;
+
+  const effectiveVariant =
+    variant ?? segmentGroup?.variant ?? SegmentButtonVariant.Primary;
+
+  const effectiveIsSelected = usesGroupSelection
+    ? segmentGroup.value === value
+    : isSelected;
+
+  const getTextAndIconClassName = () => {
+    if (
+      effectiveVariant === SegmentButtonVariant.Primary &&
+      effectiveIsSelected
+    ) {
+      return 'text-primary-inverse';
+    }
+    if (
+      effectiveVariant === SegmentButtonVariant.Secondary &&
+      effectiveIsSelected
+    ) {
+      return 'text-default';
+    }
+    return '';
+  };
+
+  const handlePress = (event: GestureResponderEvent) => {
+    if (
+      usesGroupSelection &&
+      segmentGroup !== null &&
+      value !== undefined &&
+      segmentGroup.value !== value
+    ) {
+      segmentGroup.onChange(value);
+    }
+    onPress?.(event);
+  };
+
+  return (
+    <ButtonBase
+      {...buttonBaseRest}
+      size={size}
+      isLoading={isLoading}
+      children={children}
+      onPress={handlePress}
+      textProps={{
+        ...(!effectiveIsSelected ? { color: TextColor.TextAlternative } : {}),
+        ...textProps,
+      }}
+      startIconProps={{
+        ...(!effectiveIsSelected ? { color: IconColor.IconAlternative } : {}),
+        ...startIconProps,
+      }}
+      endIconProps={{
+        ...(!effectiveIsSelected ? { color: IconColor.IconAlternative } : {}),
+        ...endIconProps,
+      }}
+      twClassName={(pressed) => {
+        if (
+          effectiveVariant === SegmentButtonVariant.Primary &&
+          effectiveIsSelected
+        ) {
+          return `${pressed || isLoading ? 'bg-icon-default-pressed' : 'bg-icon-default'} ${
+            typeof twClassName === 'function'
+              ? twClassName(pressed)
+              : twClassName
+          }`;
+        }
+
+        if (
+          effectiveVariant === SegmentButtonVariant.Secondary &&
+          effectiveIsSelected
+        ) {
+          return `${pressed || isLoading ? 'bg-muted-pressed' : 'bg-muted'} ${
+            typeof twClassName === 'function'
+              ? twClassName(pressed)
+              : twClassName
+          }`;
+        }
+
+        return `${pressed || isLoading ? 'bg-pressed' : 'bg-transparent'} ${
+          pressed || isLoading
+            ? 'border-background-pressed'
+            : 'border-transparent'
+        } border-0 ${
+          typeof twClassName === 'function' ? twClassName(pressed) : twClassName
+        }`;
+      }}
+      textClassName={getTextAndIconClassName}
+      iconClassName={getTextAndIconClassName}
+      style={style}
+    />
+  );
+};
+
+SegmentButton.displayName = 'SegmentButton';

--- a/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.types.ts
+++ b/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.types.ts
@@ -1,0 +1,11 @@
+import type { SegmentButtonPropsShared } from '@metamask/design-system-shared';
+
+import type { ButtonBaseProps } from '../ButtonBase/ButtonBase.types';
+
+/**
+ * SegmentButton component props.
+ */
+export type SegmentButtonProps = SegmentButtonPropsShared &
+  Omit<ButtonBaseProps, 'onPress'> & {
+    onPress?: ButtonBaseProps['onPress'];
+  };

--- a/packages/design-system-react-native/src/components/SegmentButton/index.ts
+++ b/packages/design-system-react-native/src/components/SegmentButton/index.ts
@@ -1,0 +1,3 @@
+export { SegmentButtonVariant } from '@metamask/design-system-shared';
+export { SegmentButton } from './SegmentButton';
+export type { SegmentButtonProps } from './SegmentButton.types';

--- a/packages/design-system-react-native/src/components/SegmentGroup/README.md
+++ b/packages/design-system-react-native/src/components/SegmentGroup/README.md
@@ -1,0 +1,213 @@
+# SegmentGroup
+
+SegmentGroup is a controlled horizontal strip for segment controls: it scrolls when content overflows and coordinates which **`SegmentButton`** is selected. Use it when the parent owns a single string **`value`** and updates it from **`onChange`**. You can place other controls (such as **`SelectButton`**) in the same row; they are not wired to group selection unless you connect them yourself.
+
+```tsx
+import { useState } from 'react';
+import {
+  SegmentButton,
+  SegmentGroup,
+} from '@metamask/design-system-react-native';
+
+export const Example = () => {
+  const [value, setValue] = useState('all');
+
+  return (
+    <SegmentGroup value={value} onChange={setValue}>
+      <SegmentButton value="all" onPress={() => {}}>
+        All
+      </SegmentButton>
+      <SegmentButton value="tokens" onPress={() => {}}>
+        Tokens
+      </SegmentButton>
+      <SegmentButton value="nfts" onPress={() => {}}>
+        NFTs
+      </SegmentButton>
+    </SegmentGroup>
+  );
+};
+```
+
+## Props
+
+Shared fields are defined as **`SegmentGroupPropsShared`** in **`@metamask/design-system-shared`**. The React Native type adds **`ScrollView`** props except **`horizontal`** and **`showsHorizontalScrollIndicator`** (fixed by the component), plus optional **`twClassName`** on the scroll content row.
+
+### `value`
+
+The selected segment id. Must match the **`value`** prop of the active **`SegmentButton`**.
+
+| TYPE     | REQUIRED | DEFAULT |
+| -------- | -------- | ------- |
+| `string` | Yes      | N/A     |
+
+### `onChange`
+
+Called with the next segment id when the user selects a participating **`SegmentButton`**.
+
+| TYPE                      | REQUIRED | DEFAULT |
+| ------------------------- | -------- | ------- |
+| `(value: string) => void` | Yes      | N/A     |
+
+```tsx
+import { useState } from 'react';
+import {
+  SegmentButton,
+  SegmentGroup,
+} from '@metamask/design-system-react-native';
+
+export const Controlled = () => {
+  const [value, setValue] = useState('a');
+
+  return (
+    <SegmentGroup value={value} onChange={setValue}>
+      <SegmentButton value="a" onPress={() => {}}>
+        A
+      </SegmentButton>
+      <SegmentButton value="b" onPress={() => {}}>
+        B
+      </SegmentButton>
+    </SegmentGroup>
+  );
+};
+```
+
+### `variant`
+
+Default **`SegmentButtonVariant`** for child segments that omit their own **`variant`**.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `SegmentButtonVariant` | No       | `undefined` |
+
+```tsx
+import { useState } from 'react';
+import {
+  SegmentButton,
+  SegmentButtonVariant,
+  SegmentGroup,
+} from '@metamask/design-system-react-native';
+
+export const WithGroupVariant = () => {
+  const [value, setValue] = useState('1d');
+
+  return (
+    <SegmentGroup
+      value={value}
+      onChange={setValue}
+      variant={SegmentButtonVariant.Secondary}
+    >
+      <SegmentButton value="1d" onPress={() => {}}>
+        1D
+      </SegmentButton>
+      <SegmentButton value="1w" onPress={() => {}}>
+        1W
+      </SegmentButton>
+    </SegmentGroup>
+  );
+};
+```
+
+### `twClassName`
+
+Optional Tailwind classes merged into the scroll content row after the default horizontal layout (**`gap-3`** between children, row alignment). These classes will be merged with the default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+| TYPE     | REQUIRED | DEFAULT     |
+| -------- | -------- | ----------- |
+| `string` | No       | `undefined` |
+
+```tsx
+import { useState } from 'react';
+import {
+  SegmentButton,
+  SegmentGroup,
+} from '@metamask/design-system-react-native';
+
+export const CustomRowSpacing = () => {
+  const [value, setValue] = useState('all');
+
+  return (
+    <SegmentGroup value={value} onChange={setValue} twClassName="gap-2">
+      <SegmentButton value="all" onPress={() => {}}>
+        All
+      </SegmentButton>
+      <SegmentButton value="tokens" onPress={() => {}}>
+        Tokens
+      </SegmentButton>
+    </SegmentGroup>
+  );
+};
+```
+
+### `style`
+
+Use the **`style`** prop on the root **`ScrollView`** for viewport layout (for example width). For the inner row, prefer **`twClassName`** or **`contentContainerStyle`**.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `StyleProp<ViewStyle>` | No       | `undefined` |
+
+```tsx
+import { useState } from 'react';
+import {
+  SegmentButton,
+  SegmentGroup,
+} from '@metamask/design-system-react-native';
+
+export const FullWidthStrip = () => {
+  const [value, setValue] = useState('all');
+
+  return (
+    <SegmentGroup
+      value={value}
+      onChange={setValue}
+      style={{ alignSelf: 'stretch' }}
+    >
+      <SegmentButton value="all" onPress={() => {}}>
+        All
+      </SegmentButton>
+      <SegmentButton value="tokens" onPress={() => {}}>
+        Tokens
+      </SegmentButton>
+    </SegmentGroup>
+  );
+};
+```
+
+### `contentContainerStyle`
+
+Merged after the default content container styles (horizontal row, centered items, gap). Use for extra padding or spacing on the segment row.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `StyleProp<ViewStyle>` | No       | `undefined` |
+
+```tsx
+import { useState } from 'react';
+import {
+  SegmentButton,
+  SegmentGroup,
+} from '@metamask/design-system-react-native';
+
+export const PaddedRow = () => {
+  const [value, setValue] = useState('all');
+
+  return (
+    <SegmentGroup
+      value={value}
+      onChange={setValue}
+      contentContainerStyle={{ paddingVertical: 8 }}
+    >
+      <SegmentButton value="all" onPress={() => {}}>
+        All
+      </SegmentButton>
+    </SegmentGroup>
+  );
+};
+```
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react-native/src/components/SegmentGroup/README.md
+++ b/packages/design-system-react-native/src/components/SegmentGroup/README.md
@@ -30,7 +30,7 @@ export const Example = () => {
 
 ## Props
 
-Shared fields are defined as **`SegmentGroupPropsShared`** in **`@metamask/design-system-shared`**. The React Native type adds **`ScrollView`** props except **`horizontal`** and **`showsHorizontalScrollIndicator`** (fixed by the component), plus optional **`twClassName`** on the scroll content row.
+The props contract is **`SegmentGroupProps`** from **`@metamask/design-system-react-native`**. It extends **`ScrollView`** props except **`horizontal`** and **`showsHorizontalScrollIndicator`** (fixed by the component), plus optional **`twClassName`** on the scroll content row.
 
 ### `value`
 

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.stories.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.stories.tsx
@@ -8,9 +8,6 @@ import React, { useEffect, useState } from 'react';
 import type { ViewProps } from 'react-native';
 import { View } from 'react-native';
 
-import { AvatarNetworkSize } from '../../types';
-import { AvatarNetwork } from '../AvatarNetwork';
-import { SAMPLE_AVATARNETWORK_URIS } from '../AvatarNetwork/AvatarNetwork.dev';
 import { SegmentButton } from '../SegmentButton';
 import { SelectButton } from '../SelectButton';
 
@@ -18,16 +15,6 @@ import { SegmentGroup } from './SegmentGroup';
 import type { SegmentGroupProps } from './SegmentGroup.types';
 
 const noopPress = () => undefined;
-
-const NETWORK_SEGMENT_DEMO = [
-  { value: 'arbitrum', networkName: 'Arbitrum' },
-  { value: 'avalanche', networkName: 'Avalanche' },
-  { value: 'bnb', networkName: 'BNB' },
-  { value: 'ethereum', networkName: 'Ethereum' },
-  { value: 'linea', networkName: 'Linea' },
-  { value: 'optimism', networkName: 'Optimism' },
-  { value: 'polygon', networkName: 'Polygon' },
-] as const;
 
 const meta: Meta<SegmentGroupProps> = {
   title: 'Components/SegmentGroup',
@@ -133,95 +120,6 @@ export const Variant: Story = {
             onPress={noopPress}
             placeholder="Range"
           />
-        </SegmentGroup>
-      </SegmentGroupStoryWrapper>
-    );
-  },
-};
-
-export const WithFilterControls: Story = {
-  render: () => {
-    const [value, setValue] = useState('all');
-
-    return (
-      <SegmentGroupStoryWrapper>
-        <SegmentGroup value={value} onChange={setValue}>
-          <SegmentButton value="all" onPress={noopPress}>
-            All
-          </SegmentButton>
-          <SegmentButton value="tokens" onPress={noopPress}>
-            Tokens
-          </SegmentButton>
-          <SegmentButton value="nfts" onPress={noopPress}>
-            NFTs
-          </SegmentButton>
-          <SelectButton
-            endArrowDirection={SelectButtonEndArrow.Down}
-            onPress={noopPress}
-            placeholder="Filter"
-          />
-        </SegmentGroup>
-      </SegmentGroupStoryWrapper>
-    );
-  },
-};
-
-export const WithChartControls: Story = {
-  render: () => {
-    const [value, setValue] = useState('1d');
-
-    return (
-      <SegmentGroupStoryWrapper>
-        <SegmentGroup
-          value={value}
-          onChange={setValue}
-          variant={SegmentButtonVariant.Secondary}
-        >
-          <SegmentButton value="1d" onPress={noopPress}>
-            1D
-          </SegmentButton>
-          <SegmentButton value="1w" onPress={noopPress}>
-            1W
-          </SegmentButton>
-          <SegmentButton value="1m" onPress={noopPress}>
-            1M
-          </SegmentButton>
-          <SelectButton
-            variant={SelectButtonVariant.Tertiary}
-            endArrowDirection={SelectButtonEndArrow.Down}
-            onPress={noopPress}
-            placeholder="Range"
-          />
-        </SegmentGroup>
-      </SegmentGroupStoryWrapper>
-    );
-  },
-};
-
-export const WithNetworkControls: Story = {
-  render: () => {
-    const [value, setValue] = useState('ethereum');
-
-    return (
-      <SegmentGroupStoryWrapper>
-        <SegmentGroup value={value} onChange={setValue}>
-          {NETWORK_SEGMENT_DEMO.map((option, index) => (
-            <SegmentButton
-              key={option.value}
-              value={option.value}
-              onPress={noopPress}
-              startAccessory={
-                <AvatarNetwork
-                  src={SAMPLE_AVATARNETWORK_URIS[index]}
-                  name={option.networkName}
-                  size={AvatarNetworkSize.Xs}
-                  twClassName="mr-1"
-                />
-              }
-            >
-              {option.networkName}
-            </SegmentButton>
-          ))}
         </SegmentGroup>
       </SegmentGroupStoryWrapper>
     );

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.stories.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.stories.tsx
@@ -4,7 +4,7 @@ import {
   SegmentButtonVariant,
 } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { ViewProps } from 'react-native';
 import { View } from 'react-native';
 
@@ -52,6 +52,10 @@ type Story = StoryObj<SegmentGroupProps>;
 
 const ControlledSegmentGroup = (args: Partial<SegmentGroupProps>) => {
   const [value, setValue] = useState(args.value ?? 'all');
+
+  useEffect(() => {
+    setValue(args.value ?? 'all');
+  }, [args.value]);
 
   return (
     <SegmentGroupStoryWrapper>

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.stories.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.stories.tsx
@@ -1,0 +1,225 @@
+import {
+  SelectButtonEndArrow,
+  SelectButtonVariant,
+  SegmentButtonVariant,
+} from '@metamask/design-system-shared';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import React, { useState } from 'react';
+import type { ViewProps } from 'react-native';
+import { View } from 'react-native';
+
+import { AvatarNetworkSize } from '../../types';
+import { AvatarNetwork } from '../AvatarNetwork';
+import { SAMPLE_AVATARNETWORK_URIS } from '../AvatarNetwork/AvatarNetwork.dev';
+import { SegmentButton } from '../SegmentButton';
+import { SelectButton } from '../SelectButton';
+
+import { SegmentGroup } from './SegmentGroup';
+import type { SegmentGroupProps } from './SegmentGroup.types';
+
+const noopPress = () => undefined;
+
+const NETWORK_SEGMENT_DEMO = [
+  { value: 'arbitrum', networkName: 'Arbitrum' },
+  { value: 'avalanche', networkName: 'Avalanche' },
+  { value: 'bnb', networkName: 'BNB' },
+  { value: 'ethereum', networkName: 'Ethereum' },
+  { value: 'linea', networkName: 'Linea' },
+  { value: 'optimism', networkName: 'Optimism' },
+  { value: 'polygon', networkName: 'Polygon' },
+] as const;
+
+const meta: Meta<SegmentGroupProps> = {
+  title: 'Components/SegmentGroup',
+  component: SegmentGroup,
+  argTypes: {
+    value: { control: 'text' },
+  },
+};
+
+export default meta;
+
+const SegmentGroupStoryWrapper: React.FC<ViewProps> = ({
+  children,
+  ...props
+}) => (
+  <View {...props} style={[{ padding: 16 }, props.style]}>
+    {children}
+  </View>
+);
+
+type Story = StoryObj<SegmentGroupProps>;
+
+const ControlledSegmentGroup = (args: Partial<SegmentGroupProps>) => {
+  const [value, setValue] = useState(args.value ?? 'all');
+
+  return (
+    <SegmentGroupStoryWrapper>
+      <SegmentGroup {...args} value={value} onChange={setValue}>
+        <SegmentButton value="all" onPress={noopPress}>
+          All
+        </SegmentButton>
+        <SegmentButton value="tokens" onPress={noopPress}>
+          Tokens
+        </SegmentButton>
+        <SegmentButton value="nfts" onPress={noopPress}>
+          NFTs
+        </SegmentButton>
+        <SelectButton
+          endArrowDirection={SelectButtonEndArrow.Down}
+          onPress={noopPress}
+          placeholder="Filter"
+        />
+      </SegmentGroup>
+    </SegmentGroupStoryWrapper>
+  );
+};
+
+export const Default: Story = {
+  args: {
+    value: 'all',
+  },
+  render: (args: SegmentGroupProps) => <ControlledSegmentGroup {...args} />,
+};
+
+export const Variant: Story = {
+  render: () => {
+    const [filterValue, setFilterValue] = useState('all');
+    const [chartValue, setChartValue] = useState('1d');
+
+    return (
+      <SegmentGroupStoryWrapper style={{ gap: 24 }}>
+        <SegmentGroup
+          value={filterValue}
+          onChange={setFilterValue}
+          variant={SegmentButtonVariant.Primary}
+        >
+          <SegmentButton value="all" onPress={noopPress}>
+            All
+          </SegmentButton>
+          <SegmentButton value="tokens" onPress={noopPress}>
+            Tokens
+          </SegmentButton>
+          <SegmentButton value="nfts" onPress={noopPress}>
+            NFTs
+          </SegmentButton>
+          <SelectButton
+            endArrowDirection={SelectButtonEndArrow.Down}
+            onPress={noopPress}
+            placeholder="Filter"
+          />
+        </SegmentGroup>
+        <SegmentGroup
+          value={chartValue}
+          onChange={setChartValue}
+          variant={SegmentButtonVariant.Secondary}
+        >
+          <SegmentButton value="1d" onPress={noopPress}>
+            1D
+          </SegmentButton>
+          <SegmentButton value="1w" onPress={noopPress}>
+            1W
+          </SegmentButton>
+          <SegmentButton value="1m" onPress={noopPress}>
+            1M
+          </SegmentButton>
+          <SelectButton
+            variant={SelectButtonVariant.Tertiary}
+            endArrowDirection={SelectButtonEndArrow.Down}
+            onPress={noopPress}
+            placeholder="Range"
+          />
+        </SegmentGroup>
+      </SegmentGroupStoryWrapper>
+    );
+  },
+};
+
+export const WithFilterControls: Story = {
+  render: () => {
+    const [value, setValue] = useState('all');
+
+    return (
+      <SegmentGroupStoryWrapper>
+        <SegmentGroup value={value} onChange={setValue}>
+          <SegmentButton value="all" onPress={noopPress}>
+            All
+          </SegmentButton>
+          <SegmentButton value="tokens" onPress={noopPress}>
+            Tokens
+          </SegmentButton>
+          <SegmentButton value="nfts" onPress={noopPress}>
+            NFTs
+          </SegmentButton>
+          <SelectButton
+            endArrowDirection={SelectButtonEndArrow.Down}
+            onPress={noopPress}
+            placeholder="Filter"
+          />
+        </SegmentGroup>
+      </SegmentGroupStoryWrapper>
+    );
+  },
+};
+
+export const WithChartControls: Story = {
+  render: () => {
+    const [value, setValue] = useState('1d');
+
+    return (
+      <SegmentGroupStoryWrapper>
+        <SegmentGroup
+          value={value}
+          onChange={setValue}
+          variant={SegmentButtonVariant.Secondary}
+        >
+          <SegmentButton value="1d" onPress={noopPress}>
+            1D
+          </SegmentButton>
+          <SegmentButton value="1w" onPress={noopPress}>
+            1W
+          </SegmentButton>
+          <SegmentButton value="1m" onPress={noopPress}>
+            1M
+          </SegmentButton>
+          <SelectButton
+            variant={SelectButtonVariant.Tertiary}
+            endArrowDirection={SelectButtonEndArrow.Down}
+            onPress={noopPress}
+            placeholder="Range"
+          />
+        </SegmentGroup>
+      </SegmentGroupStoryWrapper>
+    );
+  },
+};
+
+export const WithNetworkControls: Story = {
+  render: () => {
+    const [value, setValue] = useState('ethereum');
+
+    return (
+      <SegmentGroupStoryWrapper>
+        <SegmentGroup value={value} onChange={setValue}>
+          {NETWORK_SEGMENT_DEMO.map((option, index) => (
+            <SegmentButton
+              key={option.value}
+              value={option.value}
+              onPress={noopPress}
+              startAccessory={
+                <AvatarNetwork
+                  src={SAMPLE_AVATARNETWORK_URIS[index]}
+                  name={option.networkName}
+                  size={AvatarNetworkSize.Xs}
+                  twClassName="mr-1"
+                />
+              }
+            >
+              {option.networkName}
+            </SegmentButton>
+          ))}
+        </SegmentGroup>
+      </SegmentGroupStoryWrapper>
+    );
+  },
+};

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.test.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.test.tsx
@@ -1,0 +1,233 @@
+import {
+  BoxAlignItems,
+  BoxFlexDirection,
+  SelectButtonEndArrow,
+  SegmentButtonVariant,
+} from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { renderHook } from '@testing-library/react-hooks';
+import { fireEvent, render } from '@testing-library/react-native';
+import React, { useState } from 'react';
+import { StyleSheet } from 'react-native';
+
+import { TWCLASSMAP_BOX_GAP } from '../Box/Box.constants';
+import { SegmentButton } from '../SegmentButton';
+import { SelectButton } from '../SelectButton';
+
+import { SegmentGroup } from './SegmentGroup';
+
+const GROUP_TEST_ID = 'segment-group';
+
+const noopPress = () => undefined;
+
+describe('SegmentGroup', () => {
+  let tw: ReturnType<typeof useTailwind>;
+
+  beforeAll(() => {
+    const { result } = renderHook(() => useTailwind());
+    tw = result.current;
+  });
+
+  it('renders children', () => {
+    const { getByText } = render(
+      <SegmentGroup value="a" onChange={noopPress} testID={GROUP_TEST_ID}>
+        <SegmentButton value="a" onPress={noopPress}>
+          A
+        </SegmentButton>
+      </SegmentGroup>,
+    );
+
+    expect(getByText('A')).toBeOnTheScreen();
+  });
+
+  it('merges default row layout into contentContainerStyle', () => {
+    const { getByTestId } = render(
+      <SegmentGroup value="a" onChange={noopPress} testID={GROUP_TEST_ID}>
+        <SegmentButton value="a" onPress={noopPress}>
+          A
+        </SegmentButton>
+      </SegmentGroup>,
+    );
+
+    const scroll = getByTestId(GROUP_TEST_ID);
+    expect(scroll.props.horizontal).toBe(true);
+    expect(scroll.props.showsHorizontalScrollIndicator).toBe(false);
+
+    const expectedContent = tw.style(
+      'flex',
+      BoxFlexDirection.Row,
+      BoxAlignItems.Center,
+      TWCLASSMAP_BOX_GAP[3],
+    );
+
+    expect(
+      StyleSheet.flatten(scroll.props.contentContainerStyle),
+    ).toStrictEqual(StyleSheet.flatten(expectedContent));
+  });
+
+  it('merges twClassName into contentContainerStyle after defaults', () => {
+    const { getByTestId } = render(
+      <SegmentGroup
+        value="a"
+        onChange={noopPress}
+        testID={GROUP_TEST_ID}
+        twClassName="px-4"
+      >
+        <SegmentButton value="a" onPress={noopPress}>
+          A
+        </SegmentButton>
+      </SegmentGroup>,
+    );
+
+    const scroll = getByTestId(GROUP_TEST_ID);
+    const expectedContent = tw.style(
+      'flex',
+      BoxFlexDirection.Row,
+      BoxAlignItems.Center,
+      TWCLASSMAP_BOX_GAP[3],
+      'px-4',
+    );
+
+    expect(
+      StyleSheet.flatten(scroll.props.contentContainerStyle),
+    ).toStrictEqual(StyleSheet.flatten(expectedContent));
+  });
+
+  it('applies group variant to child segments that omit variant', () => {
+    const { getByTestId } = render(
+      <SegmentGroup
+        value="a"
+        onChange={noopPress}
+        testID={GROUP_TEST_ID}
+        variant={SegmentButtonVariant.Secondary}
+      >
+        <SegmentButton value="a" testID="seg-a" onPress={noopPress}>
+          A
+        </SegmentButton>
+      </SegmentGroup>,
+    );
+
+    expect(getByTestId('seg-a')).toHaveStyle(tw`bg-muted`);
+  });
+
+  it('exposes tablist role on the container', () => {
+    const { getByTestId } = render(
+      <SegmentGroup value="a" onChange={noopPress} testID={GROUP_TEST_ID}>
+        <SegmentButton value="a" onPress={noopPress}>
+          A
+        </SegmentButton>
+      </SegmentGroup>,
+    );
+
+    expect(getByTestId(GROUP_TEST_ID)).toHaveProp(
+      'accessibilityRole',
+      'tablist',
+    );
+  });
+
+  it('calls onChange when a different segment is pressed', () => {
+    const onChange = jest.fn();
+
+    const { getByText } = render(
+      <SegmentGroup value="a" onChange={onChange} testID={GROUP_TEST_ID}>
+        <SegmentButton value="a" onPress={noopPress}>
+          A
+        </SegmentButton>
+        <SegmentButton value="b" onPress={noopPress}>
+          B
+        </SegmentButton>
+      </SegmentGroup>,
+    );
+
+    fireEvent.press(getByText('B'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('does not call onChange when the active segment is pressed again', () => {
+    const onChange = jest.fn();
+
+    const { getByText } = render(
+      <SegmentGroup value="a" onChange={onChange} testID={GROUP_TEST_ID}>
+        <SegmentButton value="a" onPress={noopPress}>
+          A
+        </SegmentButton>
+        <SegmentButton value="b" onPress={noopPress}>
+          B
+        </SegmentButton>
+      </SegmentGroup>,
+    );
+
+    fireEvent.press(getByText('A'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('reflects selection from value for participating SegmentButtons', () => {
+    const { getByTestId } = render(
+      <SegmentGroup value="b" onChange={noopPress} testID={GROUP_TEST_ID}>
+        <SegmentButton value="a" testID="seg-a" onPress={noopPress}>
+          A
+        </SegmentButton>
+        <SegmentButton value="b" testID="seg-b" onPress={noopPress}>
+          B
+        </SegmentButton>
+      </SegmentGroup>,
+    );
+
+    expect(getByTestId('seg-a')).toHaveStyle(tw`bg-transparent`);
+    expect(getByTestId('seg-b')).toHaveStyle(tw`bg-icon-default`);
+  });
+
+  it('allows non-segment children without affecting selection', () => {
+    const onChange = jest.fn();
+
+    const { getByText, getByTestId } = render(
+      <SegmentGroup value="a" onChange={onChange} testID={GROUP_TEST_ID}>
+        <SegmentButton value="a" onPress={noopPress}>
+          A
+        </SegmentButton>
+        <SegmentButton value="b" onPress={noopPress}>
+          B
+        </SegmentButton>
+        <SelectButton
+          endArrowDirection={SelectButtonEndArrow.Down}
+          onPress={noopPress}
+          placeholder="More"
+        />
+      </SegmentGroup>,
+    );
+
+    fireEvent.press(getByText('More'));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(getByTestId(GROUP_TEST_ID)).toBeOnTheScreen();
+  });
+
+  const ControlledFixture = () => {
+    const [value, setValue] = useState('a');
+
+    return (
+      <SegmentGroup value={value} onChange={setValue} testID={GROUP_TEST_ID}>
+        <SegmentButton value="a" testID="seg-a" onPress={noopPress}>
+          A
+        </SegmentButton>
+        <SegmentButton value="b" testID="seg-b" onPress={noopPress}>
+          B
+        </SegmentButton>
+      </SegmentGroup>
+    );
+  };
+
+  it('updates selection when parent state changes after onChange', () => {
+    const { getByText, getByTestId } = render(<ControlledFixture />);
+
+    expect(getByTestId('seg-a')).toHaveStyle(tw`bg-icon-default`);
+
+    fireEvent.press(getByText('B'));
+
+    expect(getByTestId('seg-b')).toHaveStyle(tw`bg-icon-default`);
+    expect(getByTestId('seg-a')).toHaveStyle(tw`bg-transparent`);
+  });
+});

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.tsx
@@ -1,0 +1,59 @@
+import {
+  BoxAlignItems,
+  BoxFlexDirection,
+  SegmentGroupContext,
+} from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React, { useMemo } from 'react';
+import { ScrollView } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+import { TWCLASSMAP_BOX_GAP } from '../Box/Box.constants';
+
+import type { SegmentGroupProps } from './SegmentGroup.types';
+
+export const SegmentGroup = ({
+  value,
+  onChange,
+  variant,
+  children,
+  twClassName,
+  style,
+  contentContainerStyle,
+  ...scrollRest
+}: SegmentGroupProps) => {
+  const tw = useTailwind();
+
+  const contextValue = useMemo(
+    () => ({ value, onChange, variant }),
+    [value, onChange, variant],
+  );
+
+  const mergedContentContainerStyle: StyleProp<ViewStyle> = [
+    tw.style(
+      'flex',
+      BoxFlexDirection.Row,
+      BoxAlignItems.Center,
+      TWCLASSMAP_BOX_GAP[3],
+      twClassName,
+    ),
+    contentContainerStyle,
+  ];
+
+  return (
+    <SegmentGroupContext.Provider value={contextValue}>
+      <ScrollView
+        {...scrollRest}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        accessibilityRole="tablist"
+        style={[tw.style('self-stretch'), style]}
+        contentContainerStyle={mergedContentContainerStyle}
+      >
+        {children}
+      </ScrollView>
+    </SegmentGroupContext.Provider>
+  );
+};
+
+SegmentGroup.displayName = 'SegmentGroup';

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.types.ts
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.types.ts
@@ -1,0 +1,13 @@
+import type { SegmentGroupPropsShared } from '@metamask/design-system-shared';
+import type { ScrollViewProps } from 'react-native';
+
+/**
+ * SegmentGroup component props.
+ */
+export type SegmentGroupProps = SegmentGroupPropsShared &
+  Omit<ScrollViewProps, 'horizontal' | 'showsHorizontalScrollIndicator'> & {
+    /**
+     * Optional twrnc classes merged into `contentContainerStyle` after the default row layout.
+     */
+    twClassName?: string;
+  };

--- a/packages/design-system-react-native/src/components/SegmentGroup/index.ts
+++ b/packages/design-system-react-native/src/components/SegmentGroup/index.ts
@@ -1,0 +1,2 @@
+export { SegmentGroup } from './SegmentGroup';
+export type { SegmentGroupProps } from './SegmentGroup.types';

--- a/packages/design-system-react-native/src/components/SelectButton/README.md
+++ b/packages/design-system-react-native/src/components/SelectButton/README.md
@@ -10,7 +10,7 @@ import { SelectButton } from '@metamask/design-system-react-native';
 
 ## Props
 
-Shared fields are defined as **`SelectButtonPropsShared`** in **`@metamask/design-system-shared`**. The React Native type adds all **`ButtonBase`** props except **`children`**, **`endIconName`**, **`endIconProps`**, and **`disabled`** (use **`isDisabled`**; the label is derived from **`placeholder`** / **`value`**).
+The props contract is **`SelectButtonProps`** from **`@metamask/design-system-react-native`**. It includes all **`ButtonBase`** props except **`children`**, **`endIconName`**, **`endIconProps`**, and **`disabled`** (use **`isDisabled`**; the label is derived from **`placeholder`** / **`value`**).
 
 ### `placeholder`
 

--- a/packages/design-system-react-native/src/components/SelectButton/README.md
+++ b/packages/design-system-react-native/src/components/SelectButton/README.md
@@ -1,0 +1,302 @@
+# SelectButton
+
+SelectButton is a compact row for opening a picker or menu: it shows a **`placeholder`** or selected **`value`**, optional leading content, and a trailing chevron (by default **down**) unless you hide it or swap in custom trailing content. Use it next to **`SegmentButton`** rows in a **`SegmentGroup`**, or on its own for filters and dropdown-style actions.
+
+```tsx
+import { SelectButton } from '@metamask/design-system-react-native';
+
+<SelectButton placeholder="Select an option" onPress={() => {}} />;
+```
+
+## Props
+
+Shared fields are defined as **`SelectButtonPropsShared`** in **`@metamask/design-system-shared`**. The React Native type adds all **`ButtonBase`** props except **`children`**, **`endIconName`**, **`endIconProps`**, and **`disabled`** (use **`isDisabled`**; the label is derived from **`placeholder`** / **`value`**).
+
+### `placeholder`
+
+Label text when **`value`** is **`undefined`** or **`null`**. An empty string **`""`** still counts as a selected label, not a placeholder.
+
+| TYPE     | REQUIRED | DEFAULT |
+| -------- | -------- | ------- |
+| `string` | Yes      | N/A     |
+
+```tsx
+import { SelectButton } from '@metamask/design-system-react-native';
+
+<SelectButton placeholder="Network" onPress={() => {}} />;
+```
+
+### `value`
+
+Optional selected label. When set to a non-null string, it replaces **`placeholder`** in the row.
+
+| TYPE             | REQUIRED | DEFAULT     |
+| ---------------- | -------- | ----------- |
+| `string \| null` | No       | `undefined` |
+
+```tsx
+import { SelectButton } from '@metamask/design-system-react-native';
+
+<SelectButton
+  placeholder="Select network"
+  value="Ethereum Mainnet"
+  onPress={() => {}}
+/>;
+```
+
+### `onPress`
+
+Called when the row is pressed.
+
+| TYPE         | REQUIRED | DEFAULT     |
+| ------------ | -------- | ----------- |
+| `() => void` | No       | `undefined` |
+
+```tsx
+import { SelectButton } from '@metamask/design-system-react-native';
+
+<SelectButton placeholder="Open menu" onPress={() => console.log('open')} />;
+```
+
+### `variant`
+
+Controls row styling and default label colors.
+
+Available values:
+
+- `SelectButtonVariant.Primary` — muted filled row (default).
+- `SelectButtonVariant.Secondary` — transparent row with border treatment.
+- `SelectButtonVariant.Tertiary` — same container idea as secondary, with alternative label and trailing-arrow colors when using defaults.
+
+| TYPE                  | REQUIRED | DEFAULT                       |
+| --------------------- | -------- | ----------------------------- |
+| `SelectButtonVariant` | No       | `SelectButtonVariant.Primary` |
+
+```tsx
+import {
+  SelectButton,
+  SelectButtonVariant,
+} from '@metamask/design-system-react-native';
+
+<SelectButton
+  variant={SelectButtonVariant.Tertiary}
+  placeholder="Filter"
+  onPress={() => {}}
+/>;
+```
+
+### `endArrowDirection`
+
+Maps to the trailing **`Icon`**: **`ArrowUp`**, **`ArrowDown`**, **`ArrowLeft`**, or **`ArrowRight`**. When omitted and **`endAccessory`** is not used, the chevron defaults to **down**. When **`endAccessory`** is set and **`endArrowDirection`** is omitted, the accessory shows instead of the arrow. If both are set, the arrow wins and **`endAccessory`** is ignored.
+
+Available values:
+
+- `SelectButtonEndArrow.Up`
+- `SelectButtonEndArrow.Down`
+- `SelectButtonEndArrow.Left`
+- `SelectButtonEndArrow.Right`
+
+| TYPE                   | REQUIRED | DEFAULT                         |
+| ---------------------- | -------- | ------------------------------- |
+| `SelectButtonEndArrow` | No       | `Down` (when no `endAccessory`) |
+
+```tsx
+import {
+  SelectButton,
+  SelectButtonEndArrow,
+} from '@metamask/design-system-react-native';
+
+<SelectButton
+  placeholder="Navigate"
+  endArrowDirection={SelectButtonEndArrow.Right}
+  onPress={() => {}}
+/>;
+```
+
+### `hideEndArrow`
+
+When **`true`**, no trailing arrow is shown. **`endAccessory`** may still render when the resolved trailing slot is the accessory.
+
+| TYPE      | REQUIRED | DEFAULT |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
+```tsx
+import { SelectButton } from '@metamask/design-system-react-native';
+
+<SelectButton placeholder="No chevron" hideEndArrow onPress={() => {}} />;
+```
+
+### `endAccessory`
+
+Optional node at the end of the row when no trailing arrow is shown. Omit **`endArrowDirection`** and avoid relying on the default arrow, or set **`hideEndArrow`**.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+import {
+  Icon,
+  IconName,
+  IconSize,
+  SelectButton,
+} from '@metamask/design-system-react-native';
+
+<SelectButton
+  onPress={() => {}}
+  placeholder="With custom end"
+  hideEndArrow
+  endAccessory={<Icon name={IconName.Close} size={IconSize.Sm} />}
+/>;
+```
+
+### `startAccessory`
+
+Optional node before the label (for example a search icon).
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+import {
+  Icon,
+  IconName,
+  IconSize,
+  SelectButton,
+} from '@metamask/design-system-react-native';
+
+<SelectButton
+  onPress={() => {}}
+  placeholder="Search"
+  startAccessory={<Icon name={IconName.Search} size={IconSize.Sm} />}
+/>;
+```
+
+### `textProps`
+
+Optional props passed to **`Text`** when the label is a string.
+
+| TYPE                                   | REQUIRED | DEFAULT     |
+| -------------------------------------- | -------- | ----------- |
+| `Omit<Partial<TextProps>, 'children'>` | No       | `undefined` |
+
+```tsx
+import {
+  SelectButton,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+<SelectButton
+  onPress={() => {}}
+  placeholder="Styled label"
+  textProps={{ variant: TextVariant.BodySm, color: TextColor.TextAlternative }}
+/>;
+```
+
+### `endArrowDirectionIconProps`
+
+Optional props forwarded to the trailing **`Icon`** when a chevron is shown (except **`name`**, which comes from **`endArrowDirection`**).
+
+| TYPE                               | REQUIRED | DEFAULT     |
+| ---------------------------------- | -------- | ----------- |
+| `Partial<Omit<IconProps, 'name'>>` | No       | `undefined` |
+
+```tsx
+import {
+  IconSize,
+  SelectButton,
+  SelectButtonEndArrow,
+} from '@metamask/design-system-react-native';
+
+<SelectButton
+  endArrowDirection={SelectButtonEndArrow.Down}
+  onPress={() => {}}
+  placeholder="Compact arrow"
+  endArrowDirectionIconProps={{ size: IconSize.Sm }}
+/>;
+```
+
+### `isDisabled`
+
+Disables the pressable and applies reduced opacity.
+
+| TYPE      | REQUIRED | DEFAULT |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
+```tsx
+import { SelectButton } from '@metamask/design-system-react-native';
+
+<SelectButton placeholder="Disabled" isDisabled onPress={() => {}} />;
+```
+
+### `isLoading`
+
+Shows the loading overlay on the row (same behavior as **`ButtonBase`**).
+
+| TYPE      | REQUIRED | DEFAULT |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
+```tsx
+import { SelectButton } from '@metamask/design-system-react-native';
+
+<SelectButton placeholder="Loading" isLoading onPress={() => {}} />;
+```
+
+### `twClassName`
+
+Use the `twClassName` prop to add Tailwind CSS classes to the root row. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+| TYPE                                       | REQUIRED | DEFAULT     |
+| ------------------------------------------ | -------- | ----------- |
+| `string \| ((pressed: boolean) => string)` | No       | `undefined` |
+
+```tsx
+import { SelectButton } from '@metamask/design-system-react-native';
+
+// Add additional styles
+<SelectButton onPress={() => {}} placeholder="With margin" twClassName="mt-4" />
+
+// Override default styles
+<SelectButton onPress={() => {}} placeholder="Wider padding" twClassName="px-6" />
+```
+
+### `style`
+
+Use the `style` prop to customize the root with React Native styles. For consistent styling, prefer using `twClassName` with Tailwind classes when possible. Use `style` with `tw.style()` for conditionals or dynamic values.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `StyleProp<ViewStyle>` | No       | `undefined` |
+
+```tsx
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { SelectButton } from '@metamask/design-system-react-native';
+
+export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
+  const tw = useTailwind();
+
+  return (
+    <SelectButton
+      onPress={() => {}}
+      placeholder="Conditional styling"
+      style={tw.style('bg-transparent', isActive && 'bg-muted')}
+    />
+  );
+};
+```
+
+### Other `ButtonBase` props
+
+Pass through any other **`ButtonBase`** props you need (for example **`size`**, **`isFullWidth`**, **`accessibilityLabel`**, **`hitSlop`**).
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react-native/src/components/SelectButton/README.md
+++ b/packages/design-system-react-native/src/components/SelectButton/README.md
@@ -65,7 +65,7 @@ Controls row styling and default label colors.
 Available values:
 
 - `SelectButtonVariant.Primary` — muted filled row (default).
-- `SelectButtonVariant.Secondary` — transparent row with border treatment.
+- `SelectButtonVariant.Secondary` — transparent row (`border-0`); pressed and loading use the pressed background.
 - `SelectButtonVariant.Tertiary` — same container idea as secondary, with alternative label and trailing-arrow colors when using defaults.
 
 | TYPE                  | REQUIRED | DEFAULT                       |

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.constants.ts
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.constants.ts
@@ -1,0 +1,13 @@
+import { SelectButtonEndArrow } from '@metamask/design-system-shared';
+
+import { IconName } from '../../types';
+
+export const MAP_SELECTBUTTON_END_ARROW_DIRECTION_TO_ICON_NAME: Record<
+  (typeof SelectButtonEndArrow)[keyof typeof SelectButtonEndArrow],
+  IconName
+> = {
+  [SelectButtonEndArrow.Up]: IconName.ArrowUp,
+  [SelectButtonEndArrow.Down]: IconName.ArrowDown,
+  [SelectButtonEndArrow.Left]: IconName.ArrowLeft,
+  [SelectButtonEndArrow.Right]: IconName.ArrowRight,
+};

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.stories.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.stories.tsx
@@ -1,0 +1,200 @@
+import {
+  SelectButtonEndArrow,
+  SelectButtonVariant,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import type { ViewProps } from 'react-native';
+import { View } from 'react-native';
+
+import { Icon, IconName, IconSize } from '../Icon';
+
+import { SelectButton } from './SelectButton';
+import type { SelectButtonProps } from './SelectButton.types';
+
+const noopPress = () => undefined;
+
+const meta: Meta<SelectButtonProps> = {
+  title: 'Components/SelectButton',
+  component: SelectButton,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: Object.values(SelectButtonVariant),
+    },
+    endArrowDirection: {
+      control: 'select',
+      options: [...Object.values(SelectButtonEndArrow), undefined],
+    },
+    isDisabled: {
+      control: 'boolean',
+    },
+    hideEndArrow: {
+      control: 'boolean',
+    },
+    twClassName: {
+      control: 'text',
+    },
+    placeholder: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+
+const SelectButtonStoryWrapper: React.FC<ViewProps> = ({
+  children,
+  ...props
+}) => {
+  const tw = useTailwind();
+  return (
+    <View {...props} style={[tw`p-4`, props.style]}>
+      {children}
+    </View>
+  );
+};
+
+type Story = StoryObj<SelectButtonProps>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Select an option',
+    variant: SelectButtonVariant.Primary,
+    endArrowDirection: SelectButtonEndArrow.Down,
+    isDisabled: false,
+    twClassName: '',
+    onPress: noopPress,
+  },
+  render: (args) => (
+    <SelectButtonStoryWrapper>
+      <SelectButton {...args} />
+    </SelectButtonStoryWrapper>
+  ),
+};
+
+export const StartAccessory: Story = {
+  render: () => (
+    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+      <SelectButton
+        onPress={noopPress}
+        endArrowDirection={SelectButtonEndArrow.Down}
+        placeholder="With start accessory"
+        startAccessory={<Icon name={IconName.Search} size={IconSize.Sm} />}
+      />
+    </SelectButtonStoryWrapper>
+  ),
+};
+
+export const EndArrow: Story = {
+  render: () => (
+    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+      {(
+        Object.entries(SelectButtonEndArrow) as [
+          keyof typeof SelectButtonEndArrow,
+          (typeof SelectButtonEndArrow)[keyof typeof SelectButtonEndArrow],
+        ][]
+      ).map(([key, value]) => (
+        <SelectButton
+          key={key}
+          endArrowDirection={value}
+          testID={`select-button-end-${key}`}
+          onPress={noopPress}
+          placeholder={`End arrow: ${key}`}
+        />
+      ))}
+    </SelectButtonStoryWrapper>
+  ),
+};
+
+export const TextProps: Story = {
+  render: () => (
+    <SelectButtonStoryWrapper>
+      <SelectButton
+        onPress={noopPress}
+        endArrowDirection={SelectButtonEndArrow.Down}
+        placeholder="Custom text variant and color"
+        textProps={{
+          variant: TextVariant.BodySm,
+          color: TextColor.TextAlternative,
+        }}
+      />
+    </SelectButtonStoryWrapper>
+  ),
+};
+
+export const EndArrowDirectionIconProps: Story = {
+  render: () => (
+    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+      <SelectButton
+        onPress={noopPress}
+        endArrowDirection={SelectButtonEndArrow.Down}
+        placeholder="Small arrow"
+        endArrowDirectionIconProps={{ size: IconSize.Sm }}
+      />
+      <SelectButton
+        onPress={noopPress}
+        endArrowDirection={SelectButtonEndArrow.Down}
+        placeholder="Large arrow"
+        endArrowDirectionIconProps={{ size: IconSize.Lg }}
+      />
+    </SelectButtonStoryWrapper>
+  ),
+};
+
+export const IsDisabled: Story = {
+  render: () => (
+    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+      <SelectButton
+        onPress={noopPress}
+        endArrowDirection={SelectButtonEndArrow.Down}
+        placeholder="Enabled"
+      />
+      <SelectButton
+        onPress={noopPress}
+        endArrowDirection={SelectButtonEndArrow.Down}
+        placeholder="Disabled"
+        isDisabled
+      />
+    </SelectButtonStoryWrapper>
+  ),
+};
+
+export const EndAccessory: Story = {
+  render: () => (
+    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+      <SelectButton
+        onPress={noopPress}
+        placeholder="Custom trailing content"
+        endAccessory={<Icon name={IconName.Close} size={IconSize.Sm} />}
+      />
+    </SelectButtonStoryWrapper>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+      <SelectButton
+        onPress={noopPress}
+        variant={SelectButtonVariant.Primary}
+        endArrowDirection={SelectButtonEndArrow.Down}
+        placeholder="Primary (ButtonSecondary look)"
+      />
+      <SelectButton
+        onPress={noopPress}
+        variant={SelectButtonVariant.Secondary}
+        endArrowDirection={SelectButtonEndArrow.Down}
+        placeholder="Secondary (ButtonTertiary look)"
+      />
+      <SelectButton
+        onPress={noopPress}
+        variant={SelectButtonVariant.Tertiary}
+        endArrowDirection={SelectButtonEndArrow.Down}
+        placeholder="Tertiary (alternative text)"
+      />
+    </SelectButtonStoryWrapper>
+  ),
+};

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.stories.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.stories.tsx
@@ -88,7 +88,7 @@ export const StartAccessory: Story = {
   ),
 };
 
-export const EndArrow: Story = {
+export const EndArrowDirection: Story = {
   render: () => (
     <SelectButtonStoryWrapper style={{ gap: 16 }}>
       {(
@@ -174,7 +174,7 @@ export const EndAccessory: Story = {
   ),
 };
 
-export const Variants: Story = {
+export const Variant: Story = {
   render: () => (
     <SelectButtonStoryWrapper style={{ gap: 16 }}>
       <SelectButton

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.test.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.test.tsx
@@ -1,0 +1,556 @@
+import {
+  SelectButtonEndArrow,
+  SelectButtonVariant,
+  TextColor,
+} from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { renderHook } from '@testing-library/react-hooks';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { View } from 'react-native';
+
+import { IconColor, IconName, IconSize } from '../../types';
+import { TWCLASSMAP_ICON_SIZE_DIMENSION } from '../Icon/Icon.constants';
+
+import { SelectButton } from './SelectButton';
+import { MAP_SELECTBUTTON_END_ARROW_DIRECTION_TO_ICON_NAME } from './SelectButton.constants';
+
+const ROOT_TEST_ID = 'select-button';
+
+const noopPress = () => undefined;
+
+describe('SelectButton', () => {
+  let tw: ReturnType<typeof useTailwind>;
+
+  beforeAll(() => {
+    tw = renderHook(() => useTailwind()).result.current;
+  });
+
+  describe('when rendering the label', () => {
+    it('renders placeholder when value prop is omitted', () => {
+      const { getByText } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          placeholder="Select"
+        />,
+      );
+
+      expect(getByText('Select')).toHaveTextContent('Select');
+    });
+
+    it('renders value when value is set', () => {
+      const { getByText, queryByText } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          placeholder="Select"
+          value="Ethereum"
+        />,
+      );
+
+      expect(getByText('Ethereum')).toHaveTextContent('Ethereum');
+      expect(queryByText('Select')).toBeNull();
+    });
+
+    it('renders placeholder when value is null', () => {
+      const { getByText } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          placeholder="Select"
+          value={null}
+        />,
+      );
+
+      expect(getByText('Select')).toHaveTextContent('Select');
+    });
+
+    it('exposes testID on the root pressable', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID="custom-select-button"
+          onPress={noopPress}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId('custom-select-button')).toBeOnTheScreen();
+    });
+
+    it('renders startAccessory before the label', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          placeholder="With accessory"
+          startAccessory={<View testID="start-accessory" />}
+        />,
+      );
+
+      expect(getByTestId('start-accessory')).toBeOnTheScreen();
+    });
+  });
+
+  describe('when endArrowDirection is set', () => {
+    const cases: {
+      endArrowDirection: (typeof SelectButtonEndArrow)[keyof typeof SelectButtonEndArrow];
+      iconName: IconName;
+    }[] = [
+      {
+        endArrowDirection: SelectButtonEndArrow.Up,
+        iconName: IconName.ArrowUp,
+      },
+      {
+        endArrowDirection: SelectButtonEndArrow.Down,
+        iconName: IconName.ArrowDown,
+      },
+      {
+        endArrowDirection: SelectButtonEndArrow.Left,
+        iconName: IconName.ArrowLeft,
+      },
+      {
+        endArrowDirection: SelectButtonEndArrow.Right,
+        iconName: IconName.ArrowRight,
+      },
+    ];
+
+    it.each(cases)(
+      'maps endArrowDirection $endArrowDirection to trailing icon $iconName',
+      ({ endArrowDirection, iconName }) => {
+        const { getByTestId } = render(
+          <SelectButton
+            testID={ROOT_TEST_ID}
+            onPress={noopPress}
+            endArrowDirection={endArrowDirection}
+            endArrowDirectionIconProps={{ testID: 'end-arrow' }}
+            placeholder="Label"
+          />,
+        );
+
+        expect(getByTestId('end-arrow')).toHaveProp('name', iconName);
+      },
+    );
+  });
+
+  describe('when endArrowDirection is omitted', () => {
+    it('defaults the trailing icon to ArrowDown', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          endArrowDirectionIconProps={{ testID: 'end-arrow' }}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId('end-arrow')).toHaveProp(
+        'name',
+        MAP_SELECTBUTTON_END_ARROW_DIRECTION_TO_ICON_NAME[
+          SelectButtonEndArrow.Down
+        ],
+      );
+    });
+  });
+
+  describe('when hideEndArrow is true', () => {
+    it('does not render a trailing icon', () => {
+      const { queryByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          hideEndArrow
+          endArrowDirectionIconProps={{ testID: 'end-arrow' }}
+          placeholder="Label"
+        />,
+      );
+
+      expect(queryByTestId('end-arrow')).toBeNull();
+    });
+
+    it('still renders endAccessory when provided', () => {
+      const { getByTestId, queryByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          hideEndArrow
+          endAccessory={<View testID="end-accessory" />}
+          endArrowDirectionIconProps={{ testID: 'end-arrow' }}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId('end-accessory')).toBeOnTheScreen();
+      expect(queryByTestId('end-arrow')).toBeNull();
+    });
+  });
+
+  describe('when endAccessory is used', () => {
+    it('renders when endArrowDirection is omitted', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          endAccessory={<View testID="end-accessory" />}
+          placeholder="With end accessory"
+        />,
+      );
+
+      expect(getByTestId('end-accessory')).toBeOnTheScreen();
+    });
+
+    it('is ignored when endArrowDirection is set', () => {
+      const { getByTestId, queryByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          endArrowDirection={SelectButtonEndArrow.Down}
+          endAccessory={<View testID="end-accessory" />}
+          endArrowDirectionIconProps={{ testID: 'end-arrow' }}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId('end-arrow')).toHaveProp(
+        'name',
+        MAP_SELECTBUTTON_END_ARROW_DIRECTION_TO_ICON_NAME[
+          SelectButtonEndArrow.Down
+        ],
+      );
+      expect(queryByTestId('end-accessory')).toBeNull();
+    });
+  });
+
+  describe('when using variant', () => {
+    it('uses muted background for primary variant', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SelectButtonVariant.Primary}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-muted`);
+    });
+
+    it('uses transparent background for secondary variant', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SelectButtonVariant.Secondary}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-transparent`);
+    });
+
+    it('uses transparent background for tertiary variant', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SelectButtonVariant.Tertiary}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`bg-transparent`);
+    });
+
+    it('tertiary variant applies alternative color to string label text', () => {
+      const { getByText } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SelectButtonVariant.Tertiary}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByText('Label')).toHaveStyle(
+        tw.style(TextColor.TextAlternative),
+      );
+    });
+
+    it('tertiary variant applies alternative color to trailing arrow icon', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SelectButtonVariant.Tertiary}
+          endArrowDirection={SelectButtonEndArrow.Down}
+          endArrowDirectionIconProps={{ testID: 'end-arrow' }}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId('end-arrow')).toHaveStyle(
+        tw.style(
+          IconColor.IconAlternative,
+          TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Sm],
+        ),
+      );
+    });
+  });
+
+  describe('when rendering root pressable styles', () => {
+    it('uses default primary container radius and background', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          placeholder="Label"
+        />,
+      );
+
+      const root = getByTestId(ROOT_TEST_ID);
+      expect(root).toHaveStyle(tw`rounded-lg`);
+      expect(root).toHaveStyle(tw`bg-muted`);
+    });
+
+    it('applies disabled opacity when isDisabled is true', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          isDisabled
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`opacity-50`);
+    });
+
+    it('does not apply disabled opacity when isDisabled is false', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).not.toHaveStyle(tw`opacity-50`);
+    });
+
+    it('merges twClassName onto the root', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          twClassName="mt-4"
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`mt-4`);
+    });
+
+    it('merges twClassName when it is a function for primary variant', () => {
+      const twClassName = jest.fn(() => 'mt-2');
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SelectButtonVariant.Primary}
+          twClassName={twClassName}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`mt-2`);
+      expect(twClassName).toHaveBeenCalled();
+    });
+
+    it('merges twClassName when it is a function for secondary variant', () => {
+      const twClassName = jest.fn(() => 'mt-3');
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SelectButtonVariant.Secondary}
+          twClassName={twClassName}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`mt-3`);
+      expect(twClassName).toHaveBeenCalled();
+    });
+
+    it('merges twClassName when it is a function for tertiary variant', () => {
+      const twClassName = jest.fn(() => 'mt-5');
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SelectButtonVariant.Tertiary}
+          twClassName={twClassName}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`mt-5`);
+      expect(twClassName).toHaveBeenCalled();
+    });
+
+    it('merges the style prop after tailwind styles', () => {
+      const customStyle = { marginBottom: 20 };
+
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          style={customStyle}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle({ marginBottom: 20 });
+    });
+  });
+
+  describe('when the root receives a press', () => {
+    it('invokes onPress', () => {
+      const onPress = jest.fn();
+
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={onPress}
+          placeholder="Label"
+        />,
+      );
+
+      fireEvent.press(getByTestId(ROOT_TEST_ID));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies secondary variant pressed background on pressIn', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          variant={SelectButtonVariant.Secondary}
+          placeholder="Label"
+        />,
+      );
+
+      const root = getByTestId(ROOT_TEST_ID);
+      fireEvent(root, 'pressIn');
+      expect(root).toHaveStyle(tw`bg-pressed`);
+    });
+
+    it('applies primary variant pressed background on pressIn', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          placeholder="Label"
+        />,
+      );
+
+      const root = getByTestId(ROOT_TEST_ID);
+      fireEvent(root, 'pressIn');
+      expect(root).toHaveStyle(tw`bg-muted-pressed`);
+    });
+
+    it('does not throw when onPress is omitted', () => {
+      const { getByTestId } = render(
+        <SelectButton testID={ROOT_TEST_ID} placeholder="Label" />,
+      );
+
+      expect(() => {
+        fireEvent.press(getByTestId(ROOT_TEST_ID));
+      }).not.toThrow();
+    });
+
+    it('does not throw when isDisabled is true and onPress is omitted', () => {
+      const { getByTestId } = render(
+        <SelectButton testID={ROOT_TEST_ID} isDisabled placeholder="Label" />,
+      );
+
+      expect(() => {
+        fireEvent.press(getByTestId(ROOT_TEST_ID));
+      }).not.toThrow();
+    });
+
+    it('does not invoke onPress when isDisabled is true', () => {
+      const onPress = jest.fn();
+
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={onPress}
+          isDisabled
+          placeholder="Label"
+        />,
+      );
+
+      fireEvent.press(getByTestId(ROOT_TEST_ID));
+
+      expect(onPress).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when disabled', () => {
+    it('disables the root pressable', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          isDisabled
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toBeDisabled();
+    });
+  });
+
+  describe('when forwarding pressable props', () => {
+    it('forwards hitSlop to the root', () => {
+      const hitSlop = { top: 4, bottom: 4, left: 4, right: 4 };
+
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          hitSlop={hitSlop}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveProp('hitSlop', hitSlop);
+    });
+  });
+
+  describe('when endArrowDirectionIconProps is provided', () => {
+    it('applies size to the trailing icon', () => {
+      const { getByTestId } = render(
+        <SelectButton
+          testID={ROOT_TEST_ID}
+          onPress={noopPress}
+          endArrowDirection={SelectButtonEndArrow.Down}
+          endArrowDirectionIconProps={{
+            testID: 'end-arrow',
+            size: IconSize.Sm,
+          }}
+          placeholder="Label"
+        />,
+      );
+
+      expect(getByTestId('end-arrow')).toHaveStyle(
+        tw.style(
+          IconColor.IconDefault,
+          TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Sm],
+        ),
+      );
+    });
+  });
+});

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.tsx
@@ -31,13 +31,16 @@ export const SelectButton = ({
 }: SelectButtonProps) => {
   const labelContent = value ?? placeholder;
 
-  const resolvedEndArrowDirection = hideEndArrow
-    ? undefined
-    : endArrowDirection != null
-      ? endArrowDirection
-      : endAccessory
-        ? undefined
-        : SelectButtonEndArrow.Down;
+  let resolvedEndArrowDirection: SelectButtonEndArrow | undefined;
+  if (hideEndArrow) {
+    resolvedEndArrowDirection = undefined;
+  } else if (endArrowDirection !== undefined && endArrowDirection !== null) {
+    resolvedEndArrowDirection = endArrowDirection;
+  } else if (endAccessory) {
+    resolvedEndArrowDirection = undefined;
+  } else {
+    resolvedEndArrowDirection = SelectButtonEndArrow.Down;
+  }
 
   return (
     <ButtonBase
@@ -74,11 +77,7 @@ export const SelectButton = ({
       twClassName={(pressed) =>
         variant === SelectButtonVariant.Secondary ||
         variant === SelectButtonVariant.Tertiary
-          ? `min-w-0 ${pressed || isLoading ? 'bg-pressed' : 'bg-transparent'} ${
-              pressed || isLoading
-                ? 'border-background-pressed'
-                : 'border-transparent'
-            } border-0 ${
+          ? `min-w-0 ${pressed || isLoading ? 'bg-pressed' : 'bg-transparent'} border-0 ${
               typeof twClassName === 'function'
                 ? twClassName(pressed)
                 : twClassName

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.tsx
@@ -1,0 +1,103 @@
+import {
+  ButtonBaseSize,
+  SelectButtonEndArrow,
+  SelectButtonVariant,
+} from '@metamask/design-system-shared';
+import React from 'react';
+
+import { ButtonBase } from '../ButtonBase';
+import { IconColor } from '../Icon';
+import { TextColor } from '../Text';
+
+import { MAP_SELECTBUTTON_END_ARROW_DIRECTION_TO_ICON_NAME } from './SelectButton.constants';
+import type { SelectButtonProps } from './SelectButton.types';
+
+export const SelectButton = ({
+  placeholder,
+  value,
+  textProps,
+  startAccessory,
+  endArrowDirection,
+  endAccessory,
+  hideEndArrow = false,
+  isDisabled = false,
+  endArrowDirectionIconProps,
+  variant = SelectButtonVariant.Primary,
+  isLoading = false,
+  size = ButtonBaseSize.Sm,
+  twClassName = '',
+  style,
+  ...buttonBaseRest
+}: SelectButtonProps) => {
+  const labelContent = value ?? placeholder;
+
+  const resolvedEndArrowDirection = hideEndArrow
+    ? undefined
+    : endArrowDirection != null
+      ? endArrowDirection
+      : endAccessory
+        ? undefined
+        : SelectButtonEndArrow.Down;
+
+  return (
+    <ButtonBase
+      {...buttonBaseRest}
+      size={size}
+      isDisabled={isDisabled}
+      isLoading={isLoading}
+      children={labelContent}
+      textProps={{
+        ...(variant === SelectButtonVariant.Tertiary
+          ? { color: TextColor.TextAlternative }
+          : {}),
+        ...textProps,
+      }}
+      startAccessory={startAccessory}
+      endAccessory={resolvedEndArrowDirection ? undefined : endAccessory}
+      endIconName={
+        resolvedEndArrowDirection
+          ? MAP_SELECTBUTTON_END_ARROW_DIRECTION_TO_ICON_NAME[
+              resolvedEndArrowDirection
+            ]
+          : undefined
+      }
+      endIconProps={
+        resolvedEndArrowDirection
+          ? {
+              ...(variant === SelectButtonVariant.Tertiary
+                ? { color: IconColor.IconAlternative }
+                : {}),
+              ...endArrowDirectionIconProps,
+            }
+          : undefined
+      }
+      twClassName={(pressed) =>
+        variant === SelectButtonVariant.Secondary ||
+        variant === SelectButtonVariant.Tertiary
+          ? `min-w-0 ${pressed || isLoading ? 'bg-pressed' : 'bg-transparent'} ${
+              pressed || isLoading
+                ? 'border-background-pressed'
+                : 'border-transparent'
+            } border-0 ${
+              typeof twClassName === 'function'
+                ? twClassName(pressed)
+                : twClassName
+            }`
+          : `min-w-0 ${pressed || isLoading ? 'bg-muted-pressed' : 'bg-muted'} border-transparent border ${
+              typeof twClassName === 'function'
+                ? twClassName(pressed)
+                : twClassName
+            }`
+      }
+      textClassName={() =>
+        variant === SelectButtonVariant.Tertiary ? '' : 'text-default'
+      }
+      iconClassName={() =>
+        variant === SelectButtonVariant.Tertiary ? '' : 'text-default'
+      }
+      style={style}
+    />
+  );
+};
+
+SelectButton.displayName = 'SelectButton';

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.types.ts
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.types.ts
@@ -1,0 +1,18 @@
+import type { SelectButtonPropsShared } from '@metamask/design-system-shared';
+
+import type { ButtonBaseProps } from '../ButtonBase/ButtonBase.types';
+import type { IconProps } from '../Icon/Icon.types';
+
+/**
+ * SelectButton component props.
+ */
+export type SelectButtonProps = SelectButtonPropsShared &
+  Omit<
+    ButtonBaseProps,
+    'children' | 'endIconName' | 'endIconProps' | 'disabled'
+  > & {
+    /**
+     * Optional props passed to the trailing arrow `Icon` when a trailing arrow is shown (excluding `name`, which is derived from the resolved direction).
+     */
+    endArrowDirectionIconProps?: Partial<Omit<IconProps, 'name'>>;
+  };

--- a/packages/design-system-react-native/src/components/SelectButton/index.ts
+++ b/packages/design-system-react-native/src/components/SelectButton/index.ts
@@ -1,0 +1,6 @@
+export {
+  SelectButtonEndArrow,
+  SelectButtonVariant,
+} from '@metamask/design-system-shared';
+export { SelectButton } from './SelectButton';
+export type { SelectButtonProps } from './SelectButton.types';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -188,6 +188,19 @@ export type { MaskiconProps } from './temp-components/Maskicon';
 export { MainActionButton } from './MainActionButton';
 export type { MainActionButtonProps } from './MainActionButton';
 
+export { SegmentButton, SegmentButtonVariant } from './SegmentButton';
+export type { SegmentButtonProps } from './SegmentButton';
+
+export { SegmentGroup } from './SegmentGroup';
+export type { SegmentGroupProps } from './SegmentGroup';
+
+export {
+  SelectButton,
+  SelectButtonEndArrow,
+  SelectButtonVariant,
+} from './SelectButton';
+export type { SelectButtonProps } from './SelectButton';
+
 export { Skeleton } from './Skeleton';
 export type { SkeletonProps } from './Skeleton';
 

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -57,9 +57,11 @@
     "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^27.4.1",
     "@types/react": "^18.2.0",
+    "@types/react-test-renderer": "^18",
     "deepmerge": "^4.2.2",
     "jest": "^29.7.0",
     "react": "18.3.1",
+    "react-test-renderer": "^18.3.1",
     "ts-jest": "^29.2.5",
     "tsx": "^4.20.6",
     "typescript": "~5.2.2"

--- a/packages/design-system-shared/src/contexts/SegmentGroup/SegmentGroup.context.test.ts
+++ b/packages/design-system-shared/src/contexts/SegmentGroup/SegmentGroup.context.test.ts
@@ -3,10 +3,8 @@ import { act, create } from 'react-test-renderer';
 
 import { SegmentButtonVariant } from '../../types/SegmentButton/SegmentButton.types';
 
-import {
-  SegmentGroupContext,
-  type SegmentGroupContextValue,
-} from './index';
+import type { SegmentGroupContextValue } from '.';
+import { SegmentGroupContext } from '.';
 
 describe('SegmentGroupContext', () => {
   it('uses displayName for React DevTools', () => {
@@ -20,7 +18,7 @@ describe('SegmentGroupContext', () => {
         return createElement('span', null, value === null ? 'empty' : 'set');
       }
 
-      let root: ReturnType<typeof create>;
+      let root!: ReturnType<typeof create>;
       act(() => {
         root = create(createElement(Consumer));
       });
@@ -48,7 +46,7 @@ describe('SegmentGroupContext', () => {
         return createElement('span', null, ctx.value);
       }
 
-      let root: ReturnType<typeof create>;
+      let root!: ReturnType<typeof create>;
       act(() => {
         root = create(
           createElement(
@@ -77,11 +75,13 @@ describe('SegmentGroupContext', () => {
         return createElement(
           'span',
           null,
-          ctx?.variant === SegmentButtonVariant.Secondary ? 'secondary' : 'other',
+          ctx?.variant === SegmentButtonVariant.Secondary
+            ? 'secondary'
+            : 'other',
         );
       }
 
-      let root: ReturnType<typeof create>;
+      let root!: ReturnType<typeof create>;
       act(() => {
         root = create(
           createElement(

--- a/packages/design-system-shared/src/contexts/SegmentGroup/SegmentGroup.context.test.ts
+++ b/packages/design-system-shared/src/contexts/SegmentGroup/SegmentGroup.context.test.ts
@@ -1,0 +1,101 @@
+import { createElement, useContext } from 'react';
+import { act, create } from 'react-test-renderer';
+
+import { SegmentButtonVariant } from '../../types/SegmentButton/SegmentButton.types';
+
+import {
+  SegmentGroupContext,
+  type SegmentGroupContextValue,
+} from './index';
+
+describe('SegmentGroupContext', () => {
+  it('uses displayName for React DevTools', () => {
+    expect(SegmentGroupContext.displayName).toBe('SegmentGroupContext');
+  });
+
+  describe('when read outside a Provider', () => {
+    it('yields null to consumers', () => {
+      function Consumer() {
+        const value = useContext(SegmentGroupContext);
+        return createElement('span', null, value === null ? 'empty' : 'set');
+      }
+
+      let root: ReturnType<typeof create>;
+      act(() => {
+        root = create(createElement(Consumer));
+      });
+
+      expect(root.toJSON()).toMatchObject({
+        type: 'span',
+        children: ['empty'],
+      });
+    });
+  });
+
+  describe('when provided by SegmentGroupContext.Provider', () => {
+    it('exposes value and onChange to consumers', () => {
+      const onChange = jest.fn();
+      const providerValue: SegmentGroupContextValue = {
+        value: 'segment-b',
+        onChange,
+      };
+
+      function Consumer() {
+        const ctx = useContext(SegmentGroupContext);
+        if (!ctx) {
+          return createElement('span', null, 'missing');
+        }
+        return createElement('span', null, ctx.value);
+      }
+
+      let root: ReturnType<typeof create>;
+      act(() => {
+        root = create(
+          createElement(
+            SegmentGroupContext.Provider,
+            { value: providerValue },
+            createElement(Consumer),
+          ),
+        );
+      });
+
+      expect(root.toJSON()).toMatchObject({
+        type: 'span',
+        children: ['segment-b'],
+      });
+    });
+
+    it('exposes optional variant when set', () => {
+      const providerValue: SegmentGroupContextValue = {
+        value: 'a',
+        onChange: jest.fn(),
+        variant: SegmentButtonVariant.Secondary,
+      };
+
+      function Consumer() {
+        const ctx = useContext(SegmentGroupContext);
+        return createElement(
+          'span',
+          null,
+          ctx?.variant === SegmentButtonVariant.Secondary ? 'secondary' : 'other',
+        );
+      }
+
+      let root: ReturnType<typeof create>;
+      act(() => {
+        root = create(
+          createElement(
+            SegmentGroupContext.Provider,
+            { value: providerValue },
+            createElement(Consumer),
+          ),
+        );
+      });
+
+      expect(root.toJSON()).toMatchObject({
+        type: 'span',
+        children: ['secondary'],
+      });
+    });
+  });
+});

--- a/packages/design-system-shared/src/contexts/SegmentGroup/SegmentGroup.context.ts
+++ b/packages/design-system-shared/src/contexts/SegmentGroup/SegmentGroup.context.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+
+import type { SegmentButtonVariant } from '../../types/SegmentButton/SegmentButton.types';
+
+export type SegmentGroupContextValue = {
+  value: string;
+  onChange: (nextValue: string) => void;
+  variant?: SegmentButtonVariant;
+};
+
+export const SegmentGroupContext =
+  createContext<SegmentGroupContextValue | null>(null);
+
+SegmentGroupContext.displayName = 'SegmentGroupContext';

--- a/packages/design-system-shared/src/contexts/SegmentGroup/index.ts
+++ b/packages/design-system-shared/src/contexts/SegmentGroup/index.ts
@@ -1,0 +1,4 @@
+export {
+  SegmentGroupContext,
+  type SegmentGroupContextValue,
+} from './SegmentGroup.context';

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -197,3 +197,25 @@ export {
   type CustomLength,
   type SensitiveTextPropsShared,
 } from './types/SensitiveText';
+
+// SegmentButton types (ADR-0003 + ADR-0004)
+export {
+  SegmentButtonVariant,
+  type SegmentButtonPropsShared,
+} from './types/SegmentButton';
+
+// SegmentGroup types (ADR-0003 + ADR-0004)
+export { type SegmentGroupPropsShared } from './types/SegmentGroup';
+
+// SegmentGroup context (ADR-0003 + ADR-0004)
+export {
+  SegmentGroupContext,
+  type SegmentGroupContextValue,
+} from './contexts/SegmentGroup';
+
+// SelectButton types (ADR-0003 + ADR-0004)
+export {
+  SelectButtonEndArrow,
+  SelectButtonVariant,
+  type SelectButtonPropsShared,
+} from './types/SelectButton';

--- a/packages/design-system-shared/src/types/SegmentButton/SegmentButton.types.ts
+++ b/packages/design-system-shared/src/types/SegmentButton/SegmentButton.types.ts
@@ -1,0 +1,32 @@
+/**
+ * SegmentButton visual variant (ADR-0003).
+ * Maps to combinations of ButtonPrimary / ButtonSecondary / ButtonTertiary presentation with `isSelected`.
+ */
+export const SegmentButtonVariant = {
+  Primary: 'primary',
+  Secondary: 'secondary',
+} as const;
+export type SegmentButtonVariant =
+  (typeof SegmentButtonVariant)[keyof typeof SegmentButtonVariant];
+
+/**
+ * SegmentButton component shared props (ADR-0004).
+ */
+export type SegmentButtonPropsShared = {
+  /**
+   * Segment identity when used inside `SegmentGroup`. When set and an ancestor `SegmentGroup` exists, selection is derived from the group `value` and `isSelected` is ignored.
+   */
+  value?: string;
+  /**
+   * When true, the segment uses the "selected" visual for the current `variant`.
+   *
+   * @default false
+   */
+  isSelected?: boolean;
+  /**
+   * Visual variant: `primary` toggles between ButtonPrimary (selected) and ButtonSecondary (unselected); `secondary` toggles between ButtonSecondary (selected) and ButtonTertiary-like row with alternative text/icon color (unselected).
+   *
+   * @default primary
+   */
+  variant?: SegmentButtonVariant;
+};

--- a/packages/design-system-shared/src/types/SegmentButton/index.ts
+++ b/packages/design-system-shared/src/types/SegmentButton/index.ts
@@ -1,0 +1,4 @@
+export {
+  SegmentButtonVariant,
+  type SegmentButtonPropsShared,
+} from './SegmentButton.types';

--- a/packages/design-system-shared/src/types/SegmentGroup/SegmentGroup.types.ts
+++ b/packages/design-system-shared/src/types/SegmentGroup/SegmentGroup.types.ts
@@ -1,0 +1,20 @@
+import type { SegmentButtonVariant } from '../SegmentButton/SegmentButton.types';
+
+/**
+ * SegmentGroup component shared props (ADR-0004).
+ * Controlled-only: parent owns `value` and updates it from `onChange`.
+ */
+export type SegmentGroupPropsShared = {
+  /**
+   * Selected segment value; must match a child `SegmentButton` `value`.
+   */
+  value: string;
+  /**
+   * Called when the user selects a segment (via a participating `SegmentButton`).
+   */
+  onChange: (value: string) => void;
+  /**
+   * Optional default `variant` for segment buttons in this group. Each `SegmentButton` may still override with its own `variant` prop.
+   */
+  variant?: SegmentButtonVariant;
+};

--- a/packages/design-system-shared/src/types/SegmentGroup/index.ts
+++ b/packages/design-system-shared/src/types/SegmentGroup/index.ts
@@ -1,0 +1,1 @@
+export { type SegmentGroupPropsShared } from './SegmentGroup.types';

--- a/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
+++ b/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react';
+
+/**
+ * SelectButton — trailing arrow direction (maps to platform arrow icons).
+ * Convert from enum to const object (ADR-0003).
+ */
+export const SelectButtonEndArrow = {
+  Up: 'up',
+  Down: 'down',
+  Left: 'left',
+  Right: 'right',
+} as const;
+export type SelectButtonEndArrow =
+  (typeof SelectButtonEndArrow)[keyof typeof SelectButtonEndArrow];
+
+/**
+ * SelectButton visual variant (ADR-0003).
+ * `primary` matches ButtonSecondary; `secondary` and `tertiary` match ButtonTertiary container styling.
+ */
+export const SelectButtonVariant = {
+  Primary: 'primary',
+  Secondary: 'secondary',
+  Tertiary: 'tertiary',
+} as const;
+export type SelectButtonVariant =
+  (typeof SelectButtonVariant)[keyof typeof SelectButtonVariant];
+
+/**
+ * SelectButton component shared props (ADR-0004).
+ */
+export type SelectButtonPropsShared = {
+  /**
+   * Label shown when `value` is `undefined` or `null`. Only those two are treated as “no selection”; other falsy values (for example `""`) still render as `value`.
+   */
+  placeholder: string;
+  /**
+   * Selected label text. When `undefined` or `null`, `placeholder` is rendered instead.
+   */
+  value?: string | null;
+  /**
+   * Visual variant: `primary` matches ButtonSecondary; `secondary` and `tertiary` match ButtonTertiary row styling; `tertiary` uses alternative text and trailing arrow icon color.
+   *
+   * @default primary
+   */
+  variant?: SelectButtonVariant;
+  /**
+   * Optional node rendered before the label (for example an icon).
+   */
+  startAccessory?: ReactNode;
+  /**
+   * Maps to the trailing arrow `Icon` at the end of the row.
+   * Defaults to `down` when neither `hideEndArrow` nor `endAccessory` is used.
+   * When `endAccessory` is passed and this prop is omitted, `endAccessory` is shown instead of the arrow.
+   * When both are passed, `endArrowDirection` takes precedence and `endAccessory` is ignored.
+   *
+   * @default down (when no `endAccessory`)
+   */
+  endArrowDirection?: SelectButtonEndArrow;
+  /**
+   * When `true`, the trailing arrow is not rendered (`endAccessory` may still render).
+   *
+   * @default false
+   */
+  hideEndArrow?: boolean;
+  /**
+   * Optional node at the end of the row when no trailing arrow is shown (for example a custom icon or badge).
+   */
+  endAccessory?: ReactNode;
+  /**
+   * When true, disables the root control and applies disabled presentation.
+   *
+   * @default false
+   */
+  isDisabled?: boolean;
+};

--- a/packages/design-system-shared/src/types/SelectButton/index.ts
+++ b/packages/design-system-shared/src/types/SelectButton/index.ts
@@ -1,0 +1,5 @@
+export {
+  SelectButtonEndArrow,
+  SelectButtonVariant,
+  type SelectButtonPropsShared,
+} from './SelectButton.types';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds segmented control and companion UI primitives to the MetaMask Design System for React Native (DSRN), aligned with shared cross-platform contracts.

**What changed**

- **`SegmentGroup`** — Controlled horizontal group with `value` / `onChange`, horizontal scrolling when content overflows, optional default `variant` for children, and React Native-specific props layered on the shared `SegmentGroupPropsShared` type.
- **`SegmentButton`** — Single segment: primary/secondary variants, optional `value` for group coordination or standalone `isSelected`, loading and icon support consistent with existing button patterns.
- **`SelectButton`** — Compact row for picker/menu-style actions: `placeholder` / `value`, configurable chevron direction (`SelectButtonEndArrow`), variants (`SelectButtonVariant`), built on `ButtonBase` with shared `SelectButtonPropsShared` fields.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-563, https://consensyssoftware.atlassian.net/browse/DSYS-562, https://consensyssoftware.atlassian.net/browse/DSYS-672

<!-- Add issue keys if applicable, e.g. Fixes: #1234 -->

## **Manual testing steps**

1. From the repo root, run React Native Storybook (e.g. `yarn storybook:ios` or `yarn storybook:android` per project docs).
2. Open **Components → SegmentGroup** and confirm controlled selection, scrolling with many segments, and combined **SegmentButton** + **SelectButton** layouts.
3. Open **Components → SegmentButton** and **Components → SelectButton** and verify variants, loading/disabled states, and chevron / label behavior match expectations.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- N/A — new components; optional: screenshot of Storybook without these stories -->

### **After**
SelectButton

https://github.com/user-attachments/assets/e1b9bfa9-f7eb-46e5-be53-db44da4ce97c


SegmentButton

https://github.com/user-attachments/assets/a8b3ffab-d8b0-409e-8788-3378e36a8c97


SegmentGroup

https://github.com/user-attachments/assets/3d020df2-6eda-451e-8bf2-fc58568c4bc3


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new exported UI primitives with shared contracts and context-driven selection logic, expanding the public API surface and interaction behavior. Risk is mainly around styling/pressed-state behavior and selection updates when used in consumer apps.
> 
> **Overview**
> Adds three new React Native components—`SegmentButton`, `SegmentGroup`, and `SelectButton`—built on `ButtonBase`, with Storybook stories, README docs, and comprehensive tests.
> 
> `SegmentGroup` provides a controlled, horizontally scrolling container that exposes a `SegmentGroupContext` so child `SegmentButton`s derive selection from the group `value` and can trigger `onChange` when a new segment is pressed (with optional group-level `variant`). `SelectButton` adds a compact picker/menu row with placeholder vs value label resolution, optional trailing chevron direction/defaulting, and variant-based styling including tertiary alternative text/icon treatment.
> 
> Exports are wired through `design-system-react-native` and new shared contracts (`SegmentButtonVariant`, `SelectButtonVariant`, `SelectButtonEndArrow`, `SegmentGroupPropsShared`, and `SegmentGroupContext`) are added to `design-system-shared`, including new `react-test-renderer` dev deps for context tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 347bb34288f90e98313002bdd708f6b4ff022172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->