### PR TITLE
feat(rn): add SelectButtonSize and align SelectButton with Figma

### DIFF
--- a/packages/design-system-react-native/src/components/SelectButton/README.md
+++ b/packages/design-system-react-native/src/components/SelectButton/README.md
@@ -300,12 +300,12 @@ Controls the height of the button. Use `SelectButtonSize` values to keep the typ
 Available values:
 
 - `SelectButtonSize.Sm` — 32px height, `rounded-lg` corners.
-- `SelectButtonSize.Md` — 40px height, `rounded-xl` corners (default).
+- `SelectButtonSize.Md` — 40px height, `rounded-xl` corners.
 - `SelectButtonSize.Lg` — 48px height, `rounded-xl` corners.
 
 | TYPE               | REQUIRED | DEFAULT               |
 | ------------------ | -------- | --------------------- |
-| `SelectButtonSize` | No       | `SelectButtonSize.Md` |
+| `SelectButtonSize` | No       | `SelectButtonSize.Sm` |
 
 ```tsx
 import {

--- a/packages/design-system-react-native/src/components/SelectButton/README.md
+++ b/packages/design-system-react-native/src/components/SelectButton/README.md
@@ -293,9 +293,34 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 };
 ```
 
+### `size`
+
+Controls the height of the button. Use `SelectButtonSize` values to keep the type aligned with the component API.
+
+Available values:
+
+- `SelectButtonSize.Sm` — 32px height, `rounded-lg` corners.
+- `SelectButtonSize.Md` — 40px height, `rounded-xl` corners (default).
+- `SelectButtonSize.Lg` — 48px height, `rounded-xl` corners.
+
+| TYPE               | REQUIRED | DEFAULT               |
+| ------------------ | -------- | --------------------- |
+| `SelectButtonSize` | No       | `SelectButtonSize.Md` |
+
+```tsx
+import {
+  SelectButton,
+  SelectButtonSize,
+} from '@metamask/design-system-react-native';
+
+<SelectButton size={SelectButtonSize.Sm} placeholder="Compact" onPress={() => {}} />
+<SelectButton size={SelectButtonSize.Md} placeholder="Default" onPress={() => {}} />
+<SelectButton size={SelectButtonSize.Lg} placeholder="Large" onPress={() => {}} />
+```
+
 ### Other `ButtonBase` props
 
-Pass through any other **`ButtonBase`** props you need (for example **`size`**, **`isFullWidth`**, **`accessibilityLabel`**, **`hitSlop`**).
+Pass through any other **`ButtonBase`** props you need (for example **`isFullWidth`**, **`accessibilityLabel`**, **`hitSlop`**).
 
 ## References
 

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.stories.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.stories.tsx
@@ -1,5 +1,6 @@
 import {
   SelectButtonEndArrow,
+  SelectButtonSize,
   SelectButtonVariant,
   TextColor,
   TextVariant,
@@ -20,6 +21,12 @@ const meta: Meta<SelectButtonProps> = {
   title: 'Components/SelectButton',
   component: SelectButton,
   argTypes: {
+    size: {
+      control: 'select',
+      options: Object.keys(SelectButtonSize),
+      mapping: SelectButtonSize,
+      description: 'Height size of the button.',
+    },
     variant: {
       control: 'select',
       options: Object.values(SelectButtonVariant),
@@ -195,6 +202,26 @@ export const Variant: Story = {
         endArrowDirection={SelectButtonEndArrow.Down}
         placeholder="Tertiary (alternative text)"
       />
+    </SelectButtonStoryWrapper>
+  ),
+};
+
+export const Size: Story = {
+  render: () => (
+    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+      {(
+        Object.entries(SelectButtonSize) as [
+          keyof typeof SelectButtonSize,
+          (typeof SelectButtonSize)[keyof typeof SelectButtonSize],
+        ][]
+      ).map(([key, value]) => (
+        <SelectButton
+          key={key}
+          size={value}
+          onPress={noopPress}
+          placeholder={`Size: ${key}`}
+        />
+      ))}
     </SelectButtonStoryWrapper>
   ),
 };

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.stories.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.stories.tsx
@@ -5,11 +5,10 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-shared';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import type { Meta, StoryObj } from '@storybook/react-native';
-import type { ViewProps } from 'react-native';
-import { View } from 'react-native';
 
+import { Box } from '../Box';
+import type { BoxProps } from '../Box';
 import { Icon, IconName, IconSize } from '../Icon';
 
 import { SelectButton } from './SelectButton';
@@ -52,15 +51,14 @@ const meta: Meta<SelectButtonProps> = {
 
 export default meta;
 
-const SelectButtonStoryWrapper: React.FC<ViewProps> = ({
+const SelectButtonStoryWrapper: React.FC<BoxProps> = ({
   children,
   ...props
 }) => {
-  const tw = useTailwind();
   return (
-    <View {...props} style={[tw`p-4`, props.style]}>
+    <Box padding={4} {...props}>
       {children}
-    </View>
+    </Box>
   );
 };
 
@@ -84,7 +82,7 @@ export const Default: Story = {
 
 export const StartAccessory: Story = {
   render: () => (
-    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+    <SelectButtonStoryWrapper gap={4}>
       <SelectButton
         onPress={noopPress}
         endArrowDirection={SelectButtonEndArrow.Down}
@@ -97,7 +95,7 @@ export const StartAccessory: Story = {
 
 export const EndArrowDirection: Story = {
   render: () => (
-    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+    <SelectButtonStoryWrapper gap={4}>
       {(
         Object.entries(SelectButtonEndArrow) as [
           keyof typeof SelectButtonEndArrow,
@@ -134,7 +132,7 @@ export const TextProps: Story = {
 
 export const EndArrowDirectionIconProps: Story = {
   render: () => (
-    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+    <SelectButtonStoryWrapper gap={4}>
       <SelectButton
         onPress={noopPress}
         endArrowDirection={SelectButtonEndArrow.Down}
@@ -153,7 +151,7 @@ export const EndArrowDirectionIconProps: Story = {
 
 export const IsDisabled: Story = {
   render: () => (
-    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+    <SelectButtonStoryWrapper gap={4}>
       <SelectButton
         onPress={noopPress}
         endArrowDirection={SelectButtonEndArrow.Down}
@@ -171,7 +169,7 @@ export const IsDisabled: Story = {
 
 export const EndAccessory: Story = {
   render: () => (
-    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+    <SelectButtonStoryWrapper gap={4}>
       <SelectButton
         onPress={noopPress}
         placeholder="Custom trailing content"
@@ -183,7 +181,7 @@ export const EndAccessory: Story = {
 
 export const Variant: Story = {
   render: () => (
-    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+    <SelectButtonStoryWrapper gap={4}>
       <SelectButton
         onPress={noopPress}
         variant={SelectButtonVariant.Primary}
@@ -208,7 +206,7 @@ export const Variant: Story = {
 
 export const Size: Story = {
   render: () => (
-    <SelectButtonStoryWrapper style={{ gap: 16 }}>
+    <SelectButtonStoryWrapper gap={4}>
       {(
         Object.entries(SelectButtonSize) as [
           keyof typeof SelectButtonSize,

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.test.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.test.tsx
@@ -308,7 +308,7 @@ describe('SelectButton', () => {
       );
 
       const root = getByTestId(ROOT_TEST_ID);
-      expect(root).toHaveStyle(tw`rounded-lg`);
+      expect(root).toHaveStyle(tw`rounded-xl`);
       expect(root).toHaveStyle(tw`bg-muted`);
     });
 

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.test.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.test.tsx
@@ -308,7 +308,7 @@ describe('SelectButton', () => {
       );
 
       const root = getByTestId(ROOT_TEST_ID);
-      expect(root).toHaveStyle(tw`rounded-xl`);
+      expect(root).toHaveStyle(tw`rounded-lg`);
       expect(root).toHaveStyle(tw`bg-muted`);
     });
 

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.tsx
@@ -24,7 +24,7 @@ export const SelectButton = ({
   endArrowDirectionIconProps,
   variant = SelectButtonVariant.Primary,
   isLoading = false,
-  size = SelectButtonSize.Md,
+  size = SelectButtonSize.Sm,
   twClassName = '',
   style,
   ...buttonBaseRest

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.tsx
@@ -1,6 +1,6 @@
 import {
-  ButtonBaseSize,
   SelectButtonEndArrow,
+  SelectButtonSize,
   SelectButtonVariant,
 } from '@metamask/design-system-shared';
 import React from 'react';
@@ -24,7 +24,7 @@ export const SelectButton = ({
   endArrowDirectionIconProps,
   variant = SelectButtonVariant.Primary,
   isLoading = false,
-  size = ButtonBaseSize.Sm,
+  size = SelectButtonSize.Md,
   twClassName = '',
   style,
   ...buttonBaseRest

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.types.ts
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.types.ts
@@ -9,7 +9,7 @@ import type { IconProps } from '../Icon/Icon.types';
 export type SelectButtonProps = SelectButtonPropsShared &
   Omit<
     ButtonBaseProps,
-    'children' | 'endIconName' | 'endIconProps' | 'disabled'
+    'children' | 'endIconName' | 'endIconProps' | 'disabled' | 'size'
   > & {
     /**
      * Optional props passed to the trailing arrow `Icon` when a trailing arrow is shown (excluding `name`, which is derived from the resolved direction).

--- a/packages/design-system-react-native/src/components/SelectButton/index.ts
+++ b/packages/design-system-react-native/src/components/SelectButton/index.ts
@@ -1,4 +1,5 @@
 export {
+  SelectButtonSize,
   SelectButtonEndArrow,
   SelectButtonVariant,
 } from '@metamask/design-system-shared';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -200,6 +200,7 @@ export type { SegmentGroupProps } from './SegmentGroup';
 export {
   SelectButton,
   SelectButtonEndArrow,
+  SelectButtonSize,
   SelectButtonVariant,
 } from './SelectButton';
 export type { SelectButtonProps } from './SelectButton';

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -218,6 +218,7 @@ export {
 
 // SelectButton types (ADR-0003 + ADR-0004)
 export {
+  SelectButtonSize,
   SelectButtonEndArrow,
   SelectButtonVariant,
   type SelectButtonPropsShared,

--- a/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
+++ b/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
@@ -1,13 +1,16 @@
 import type { ReactNode } from 'react';
 
-import { ButtonBaseSize } from '../ButtonBase/ButtonBase.types';
-
 /**
- * SelectButton size — alias of ButtonBaseSize.
+ * SelectButton size options (ADR-0003).
  * Sm (32px) | Md (40px, default) | Lg (48px).
  */
-export const SelectButtonSize = ButtonBaseSize;
-export type SelectButtonSize = ButtonBaseSize;
+export const SelectButtonSize = {
+  Sm: 'sm',
+  Md: 'md',
+  Lg: 'lg',
+} as const;
+export type SelectButtonSize =
+  (typeof SelectButtonSize)[keyof typeof SelectButtonSize];
 
 /**
  * SelectButton — trailing arrow direction (maps to platform arrow icons).

--- a/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
+++ b/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
@@ -1,16 +1,12 @@
 import type { ReactNode } from 'react';
+import { ButtonBaseSize } from '../ButtonBase/ButtonBase.types';
 
 /**
  * SelectButton size options (ADR-0003).
- * Sm (32px) | Md (40px, default) | Lg (48px).
+ * Alias to ButtonBaseSize to keep values in sync.
  */
-export const SelectButtonSize = {
-  Sm: 'sm',
-  Md: 'md',
-  Lg: 'lg',
-} as const;
-export type SelectButtonSize =
-  (typeof SelectButtonSize)[keyof typeof SelectButtonSize];
+export const SelectButtonSize = ButtonBaseSize;
+export type SelectButtonSize = ButtonBaseSize;
 
 /**
  * SelectButton — trailing arrow direction (maps to platform arrow icons).

--- a/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
+++ b/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+
 import { ButtonBaseSize } from '../ButtonBase/ButtonBase.types';
 
 /**

--- a/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
+++ b/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
@@ -1,18 +1,13 @@
 import type { ReactNode } from 'react';
 
+import { ButtonBaseSize } from '../ButtonBase/ButtonBase.types';
+
 /**
- * SelectButton size options (ADR-0003).
- * Values match ButtonBaseSize — Sm (32px), Md (40px), Lg (48px).
- *
- * @default Md
+ * SelectButton size — alias of ButtonBaseSize.
+ * Sm (32px) | Md (40px, default) | Lg (48px).
  */
-export const SelectButtonSize = {
-  Sm: 'sm',
-  Md: 'md',
-  Lg: 'lg',
-} as const;
-export type SelectButtonSize =
-  (typeof SelectButtonSize)[keyof typeof SelectButtonSize];
+export const SelectButtonSize = ButtonBaseSize;
+export type SelectButtonSize = ButtonBaseSize;
 
 /**
  * SelectButton — trailing arrow direction (maps to platform arrow icons).

--- a/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
+++ b/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
@@ -48,7 +48,7 @@ export type SelectButtonPropsShared = {
   /**
    * Height size of the button. Maps 1:1 to ButtonBaseSize values.
    *
-   * @default Md
+   * @default Sm
    */
   size?: SelectButtonSize;
   /**

--- a/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
+++ b/packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
@@ -1,6 +1,20 @@
 import type { ReactNode } from 'react';
 
 /**
+ * SelectButton size options (ADR-0003).
+ * Values match ButtonBaseSize — Sm (32px), Md (40px), Lg (48px).
+ *
+ * @default Md
+ */
+export const SelectButtonSize = {
+  Sm: 'sm',
+  Md: 'md',
+  Lg: 'lg',
+} as const;
+export type SelectButtonSize =
+  (typeof SelectButtonSize)[keyof typeof SelectButtonSize];
+
+/**
  * SelectButton — trailing arrow direction (maps to platform arrow icons).
  * Convert from enum to const object (ADR-0003).
  */
@@ -30,9 +44,15 @@ export type SelectButtonVariant =
  */
 export type SelectButtonPropsShared = {
   /**
-   * Label shown when `value` is `undefined` or `null`. Only those two are treated as “no selection”; other falsy values (for example `""`) still render as `value`.
+   * Label shown when `value` is `undefined` or `null`. Only those two are treated as “no selection”; other falsy values (for example `””`) still render as `value`.
    */
   placeholder: string;
+  /**
+   * Height size of the button. Maps 1:1 to ButtonBaseSize values.
+   *
+   * @default Md
+   */
+  size?: SelectButtonSize;
   /**
    * Selected label text. When `undefined` or `null`, `placeholder` is rendered instead.
    */

--- a/packages/design-system-shared/src/types/SelectButton/index.ts
+++ b/packages/design-system-shared/src/types/SelectButton/index.ts
@@ -1,4 +1,5 @@
 export {
+  SelectButtonSize,
   SelectButtonEndArrow,
   SelectButtonVariant,
   type SelectButtonPropsShared,


### PR DESCRIPTION
## **Description**

Adds `SelectButtonSize` as a first-class const object in `@metamask/design-system-shared` following ADR-0003/ADR-0004, aligning the `SelectButton` component's size API with its Figma counterpart.

Previously, `SelectButton` used `ButtonBaseSize` directly and defaulted to `ButtonBaseSize.Sm`. This PR:
1. Introduces `SelectButtonSize` (`Sm/Md/Lg`) in the shared package so consumers have a semantically correct type
2. Moves `size` into `SelectButtonPropsShared` (ADR-0004 centralised types)
3. Changes the default from `Sm` to `Md` to match the Figma design's "Md (default)" label
4. Updates the Figma component set to reflect the code API (see Figma changes below)

**Figma branch:** [SelectButton — branch 8KPwHulIorYFJiTWK8MapC](https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/branch/8KPwHulIorYFJiTWK8MapC/%F0%9F%A6%8A-MMDS-Components?node-id=13719-742)

Figma changes made on the branch:
- Added `variant` property (`Primary / Secondary / Tertiary`) to the component set
- Renamed sizes `Large / Md (default) / Small` → `Lg / Md / Sm` to match code naming
- Reorganised layout from single vertical column to 3×3 grid (sizes across, variants down)
- Secondary / Tertiary: cleared background fills (transparent)
- Tertiary: applied `text/alternative` design token to label text and arrow icon

## **Related issues**

Fixes: [DSYS-742](https://consensyssoftware.atlassian.net/browse/DSYS-742)

## **Manual testing steps**

1. Run `yarn workspace @metamask/design-system-react-native test --testPathPattern="SelectButton"` — all 36 tests should pass
2. Run `yarn storybook:ios`, navigate to **Components → SelectButton → Variant** and verify three visual variants render correctly (Primary with muted bg, Secondary transparent, Tertiary with alternative text colour)
3. Verify `SelectButtonSize` is importable: `import { SelectButtonSize } from '@metamask/design-system-react-native'`

## **Screenshots/Recordings**

### **After**

- `size` defaults to `SelectButtonSize.Md` (40px / `rounded-xl`)
- `SelectButtonSize.Sm | Md | Lg` exported from both `@metamask/design-system-shared` and `@metamask/design-system-react-native`
- Figma: `size` × `variant` 3×3 grid matching code API exactly


https://github.com/user-attachments/assets/504e74bc-b75f-4fd4-a131-dca5985440f3


https://github.com/user-attachments/assets/c0244746-54a1-4b7a-a424-50117522dc80

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to public API/type changes around `SelectButton` sizing (new exported `SelectButtonSize`, `size` moved into shared props, and `ButtonBase` `size` omitted), which may require consumer updates but has limited runtime impact.
> 
> **Overview**
> **Adds a first-class `SelectButtonSize` option set** (aliased to `ButtonBaseSize`) in `@metamask/design-system-shared`, and re-exports it through `design-system-react-native` so consumers can use a semantically named size type.
> 
> Updates `SelectButton`’s API/types to use `SelectButtonSize` (including defaulting `size` via this new type) and prevents prop-type collisions by omitting `ButtonBase`’s `size` from `SelectButtonProps`. Storybook and docs are refreshed to demonstrate and control the new `size` prop, and the stories’ wrapper layout is migrated from `View`+Tailwind to `Box` props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 916d358b0110f3756f6c8159aa47508f1bbde4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->