### PR TITLE
Release/41.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "40.0.0",
+  "version": "41.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: Update Telegram icon to official logo design ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
+- feat: [DSRN] Added TitleAlert ([#1131](https://github.com/MetaMask/metamask-design-system/pull/1131))
+- feat: [DSRN] Added SectionHeader ([#1175](https://github.com/MetaMask/metamask-design-system/pull/1175))
+- feat: [DSRN] Added SectionDivider ([#1174](https://github.com/MetaMask/metamask-design-system/pull/1174))
+
 ## [0.25.0]
 
 ### Added

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0]
+
 ### Uncategorized
 
 - chore: Update Telegram icon to official logo design ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
@@ -441,7 +443,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.25.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.26.0...HEAD
+[0.26.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.25.0...@metamask/design-system-react-native@0.26.0
 [0.25.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.24.0...@metamask/design-system-react-native@0.25.0
 [0.24.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.23.0...@metamask/design-system-react-native@0.24.0
 [0.23.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.22.0...@metamask/design-system-react-native@0.23.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.26.0]
 
-### Uncategorized
+### Added
 
-- chore: Update Telegram icon to official logo design ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
-- feat: [DSRN] Added TitleAlert ([#1131](https://github.com/MetaMask/metamask-design-system/pull/1131))
-- feat: [DSRN] Added SectionHeader ([#1175](https://github.com/MetaMask/metamask-design-system/pull/1175))
-- feat: [DSRN] Added SectionDivider ([#1174](https://github.com/MetaMask/metamask-design-system/pull/1174))
+- Added `TitleAlert` for alert-style headings with a severity icon, title row, and optional description in modals, bottom sheets, and other compact surfaces ([#1131](https://github.com/MetaMask/metamask-design-system/pull/1131))
+- Added `SectionHeader` for section titles with optional start and end accessories, icon shortcuts, and an inline title accessory ([#1175](https://github.com/MetaMask/metamask-design-system/pull/1175))
+- Added `SectionDivider` as a horizontal rule with a muted top border and default vertical spacing for separating screen sections ([#1174](https://github.com/MetaMask/metamask-design-system/pull/1174))
+
+### Changed
+
+- Updated the `Telegram` icon asset to match the official Telegram logo ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
 
 ## [0.25.0]
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.23.1]
 
-### Uncategorized
+### Changed
 
-- chore: Update Telegram icon to official logo design ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
+- Updated the `Telegram` icon asset to match the official Telegram logo ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
 
 ## [0.23.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1]
+
 ### Uncategorized
 
 - chore: Update Telegram icon to official logo design ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
@@ -324,7 +326,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.23.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.23.1...HEAD
+[0.23.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.23.0...@metamask/design-system-react@0.23.1
 [0.23.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.22.0...@metamask/design-system-react@0.23.0
 [0.22.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.21.0...@metamask/design-system-react@0.22.0
 [0.21.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.20.0...@metamask/design-system-react@0.21.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: Update Telegram icon to official logo design ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
+
 ## [0.23.0]
 
 ### Added

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0]
+
 ### Uncategorized
 
 - chore: Update Telegram icon to official logo design ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
@@ -195,7 +197,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.18.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.19.0...HEAD
+[0.19.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.18.0...@metamask/design-system-shared@0.19.0
 [0.18.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.17.0...@metamask/design-system-shared@0.18.0
 [0.17.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.16.0...@metamask/design-system-shared@0.17.0
 [0.16.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.15.0...@metamask/design-system-shared@0.16.0

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: Update Telegram icon to official logo design ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
+- feat: [DSRN] Added TitleAlert ([#1131](https://github.com/MetaMask/metamask-design-system/pull/1131))
+- feat: [DSRN] Added SectionHeader ([#1175](https://github.com/MetaMask/metamask-design-system/pull/1175))
+
 ## [0.18.0]
 
 ### Added

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.0]
 
-### Uncategorized
+### Added
 
-- chore: Update Telegram icon to official logo design ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
-- feat: [DSRN] Added TitleAlert ([#1131](https://github.com/MetaMask/metamask-design-system/pull/1131))
-- feat: [DSRN] Added SectionHeader ([#1175](https://github.com/MetaMask/metamask-design-system/pull/1175))
+- Exported `TitleAlertPropsShared` for cross-platform alert title layouts ([#1131](https://github.com/MetaMask/metamask-design-system/pull/1131))
+- Exported `SectionHeaderPropsShared` for cross-platform section heading layouts ([#1175](https://github.com/MetaMask/metamask-design-system/pull/1175))
+
+### Changed
+
+- Updated the shared `Telegram` icon asset to match the official Telegram logo so React and React Native stay aligned ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))
 
 ## [0.18.0]
 

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Release 41.0.0

This release adds mobile layout components (`TitleAlert`, `SectionHeader`, `SectionDivider`), exports shared types for the new cross-platform contracts, and updates the `Telegram` icon asset on web and mobile. There are no breaking API changes.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.19.0**
- `@metamask/design-system-react`: **0.23.1**
- `@metamask/design-system-react-native`: **0.26.0**

### 🔄 Shared Type Updates (0.19.0)

#### Component Type Additions ([#1131](https://github.com/MetaMask/metamask-design-system/pull/1131), [#1175](https://github.com/MetaMask/metamask-design-system/pull/1175))

**What Changed:**

- Exported `TitleAlertPropsShared` for alert-style title layouts (severity, title row, optional description)
- Exported `SectionHeaderPropsShared` for section headings with optional accessories and icon shortcuts
- Updated the shared `Telegram` icon asset to match the official Telegram logo ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))

**Impact:**

- Enables consistent `TitleAlert` and `SectionHeader` implementations across React and React Native
- Continues ADR-0003/ADR-0004 const-object + string-union pattern adoption
- Apps using `IconName.Telegram` on either platform get the updated glyph without API changes

### 🌐 React Web Updates (0.23.1)

#### Changed

- Updated the `Telegram` icon asset to match the official Telegram logo ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))

### 📱 React Native Updates (0.26.0)

#### Added

- Added `TitleAlert` for alert-style headings with a severity icon, title row, and optional description in modals, bottom sheets, and other compact surfaces ([#1131](https://github.com/MetaMask/metamask-design-system/pull/1131))
- Added `SectionHeader` for section titles with optional start and end accessories, icon shortcuts, and an inline title accessory ([#1175](https://github.com/MetaMask/metamask-design-system/pull/1175))
- Added `SectionDivider` as a horizontal rule with a muted top border and default vertical spacing for separating screen sections ([#1174](https://github.com/MetaMask/metamask-design-system/pull/1174))

#### Changed

- Updated the `Telegram` icon asset to match the official Telegram logo ([#1176](https://github.com/MetaMask/metamask-design-system/pull/1176))

### ⚠️ Breaking Changes

None in this release.

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: **minor** (0.18.0 → 0.19.0) — new shared type exports + icon asset update
  - [x] design-system-react: **patch** (0.23.0 → 0.23.1) — `Telegram` icon asset update only
  - [x] design-system-react-native: **minor** (0.25.0 → 0.26.0) — new components + icon asset update
- [x] Breaking changes documented with migration guidance — N/A (no breaking changes)
- [x] Migration guides updated with before/after examples — N/A (no breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples — N/A
- [ ] All unreleased changes are accounted for in changelogs