### PR TITLE
feat(storybook): enable Storybook MCP manifest generation for GitHub Pages hosting

### DIFF
--- a/apps/storybook-react/.storybook/main.ts
+++ b/apps/storybook-react/.storybook/main.ts
@@ -21,6 +21,9 @@ function getAbsolutePath(value: string): any {
 const isTestMode = process.env.VITEST === 'true';
 
 const config: StorybookConfig = {
+  features: {
+    componentsManifest: true,
+  },
   stories: [
     '../stories/',
     // Only include MDX documentation files when not in test mode

--- a/apps/storybook-react/package.json
+++ b/apps/storybook-react/package.json
@@ -19,7 +19,7 @@
     "@playwright/test": "^1.52.0",
     "@storybook/addon-a11y": "^10.3.1",
     "@storybook/addon-docs": "^10.3.1",
-    "@storybook/addon-mcp": "^0.4.1",
+    "@storybook/addon-mcp": "^0.6.0",
     "@storybook/addon-vitest": "^10.3.1",
     "@storybook/react-vite": "^10.3.1",
     "@testing-library/dom": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3652,7 +3652,7 @@ __metadata:
     "@playwright/test": "npm:^1.52.0"
     "@storybook/addon-a11y": "npm:^10.3.1"
     "@storybook/addon-docs": "npm:^10.3.1"
-    "@storybook/addon-mcp": "npm:^0.4.1"
+    "@storybook/addon-mcp": "npm:^0.6.0"
     "@storybook/addon-vitest": "npm:^10.3.1"
     "@storybook/react-vite": "npm:^10.3.1"
     "@testing-library/dom": "npm:^9.0.0"
@@ -4577,23 +4577,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-mcp@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@storybook/addon-mcp@npm:0.4.1"
+"@storybook/addon-mcp@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@storybook/addon-mcp@npm:0.6.0"
   dependencies:
-    "@storybook/mcp": "npm:0.6.1"
-    "@tmcp/adapter-valibot": "npm:^0.1.4"
-    "@tmcp/transport-http": "npm:^0.8.0"
+    "@storybook/mcp": "npm:0.7.0"
+    "@tmcp/adapter-valibot": "npm:^0.1.5"
+    "@tmcp/transport-http": "npm:^0.8.5"
     picoquery: "npm:^2.5.0"
-    tmcp: "npm:^1.16.0"
+    tmcp: "npm:^1.19.3"
     valibot: "npm:1.2.0"
   peerDependencies:
-    "@storybook/addon-vitest": ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
-    storybook: ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+    "@storybook/addon-vitest": ^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+    storybook: ^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
   peerDependenciesMeta:
     "@storybook/addon-vitest":
       optional: true
-  checksum: 10/549b00c8b6ab8e96c646a005365d42ca85fc8f021ee1f9b69d6a9ca5f93f4befa64cf589d9ae2b128140a22aadbec329d68e1d42c17db62953d2a6dd737eb987
+  checksum: 10/47599162729ff331be78fe161544fb135cbddf49c1819986a1f81f2ac4edbb11aef435aadd41b488342d5560da6d4cf11b63589fd97fd45bf1569207a80dd95c
   languageName: node
   linkType: hard
 
@@ -4765,15 +4765,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/mcp@npm:0.6.1":
-  version: 0.6.1
-  resolution: "@storybook/mcp@npm:0.6.1"
+"@storybook/mcp@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@storybook/mcp@npm:0.7.0"
   dependencies:
-    "@tmcp/adapter-valibot": "npm:^0.1.4"
-    "@tmcp/transport-http": "npm:^0.8.0"
-    tmcp: "npm:^1.16.0"
+    "@tmcp/adapter-valibot": "npm:^0.1.5"
+    "@tmcp/transport-http": "npm:^0.8.5"
+    tmcp: "npm:^1.19.3"
     valibot: "npm:1.2.0"
-  checksum: 10/0f61c6a3866197ee894eda99642896d83dbbcc946dce089b8b5f099b6de3ec5ec4ec0fc40e0a36fd9e5ef9ff0d3241a49e371aaf5d9ef75ef4f50fd46b5787f8
+  checksum: 10/9386600235faf93430984c587a4ad7c2b24bacdc217deb9c857d197a065e016b724eaa223f987e1f1bab0221f307cce1057e8689a023c176ff11fb3196cf5166
   languageName: node
   linkType: hard
 
@@ -5260,7 +5260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tmcp/transport-http@npm:^0.8.0, @tmcp/transport-http@npm:^0.8.5":
+"@tmcp/transport-http@npm:^0.8.5":
   version: 0.8.5
   resolution: "@tmcp/transport-http@npm:0.8.5"
   dependencies:
@@ -15989,7 +15989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmcp@npm:^1.16.0, tmcp@npm:^1.19.3":
+"tmcp@npm:^1.19.3":
   version: 1.19.3
   resolution: "tmcp@npm:1.19.3"
   dependencies:


### PR DESCRIPTION
## **Description**

Enables the Storybook MCP (Model Context Protocol) server to be hosted via our existing GitHub Pages deployment at https://metamask.github.io/metamask-design-system/.

**What changed:**
- Added `features: { componentsManifest: true }` to `apps/storybook-react/.storybook/main.ts` — this feature flag tells Storybook to emit `manifests/components.json` and `manifests/docs.json` into the static build output, which is required for MCP to work
- Upgraded `@storybook/addon-mcp` from `^0.4.1` → `^0.6.0` (latest, compatible with storybook 10.3.x)

**Why:** Without the `componentsManifest` feature flag, `writeManifests` in Storybook core is never called during `storybook build`, so the manifest files were never generated and the GitHub Pages deployment returned 404 on those routes.

**After this merges:** The static build will include:
- `manifests/components.json` — 53 components with props, stories, and docgen data (~540KB)
- `manifests/docs.json` — MDX documentation
- `manifests/components.html` — debug viewer

These manifests are the foundation for hosting the Storybook MCP endpoint so AI agents (Claude Code, Cursor, etc.) can discover and use our design system components. Follow-up work to set up the actual MCP proxy server is being discussed with the platform team.

**Docs:** https://storybook.js.org/docs/ai/mcp/sharing

## **Related issues**

Fixes:

## **Manual testing steps**

1. After the GitHub Pages deployment completes, visit: https://metamask.github.io/metamask-design-system/manifests/components.json
2. Confirm the file loads and contains component entries (should show 53 components)
3. Also verify: https://metamask.github.io/metamask-design-system/manifests/components.html (debug viewer)

## **Screenshots/Recordings**

### **Before**

`https://metamask.github.io/metamask-design-system/manifests/components.json` → 404

### **After**

`https://metamask.github.io/metamask-design-system/manifests/components.json` → 53 components with props, stories, and documentation

[Storybook build with components.json](https://diuv6g5fj9pvx.cloudfront.net/metamask-design-system/26536573828/storybook-build/manifests/components.json)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storybook build config and devDependency-only bumps; no runtime app, auth, or data-path changes.
> 
> **Overview**
> Turns on Storybook’s **`componentsManifest`** feature in `apps/storybook-react` so static **`storybook build`** output includes **`manifests/components.json`**, **`manifests/docs.json`**, and related assets—fixing 404s on GitHub Pages for MCP discovery.
> 
> Bumps **`@storybook/addon-mcp`** from **0.4.1** to **0.6.0** (and lockfile transitives such as **`@storybook/mcp`**, **tmcp**) to stay aligned with Storybook 10.3.x for the MCP addon path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671cecdabf75df1273f8e3812fde70495542219b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->