### PR TITLE
feat(shared,react,react-native): add FlashFilled icon

### DIFF
--- a/packages/design-system-react-native/src/components/Icon/Icon.assets.ts
+++ b/packages/design-system-react-native/src/components/Icon/Icon.assets.ts
@@ -111,6 +111,7 @@ import FingerprintSVG from './assets/fingerprint.svg';
 import FireSVG from './assets/fire.svg';
 import FirstPageSVG from './assets/first-page.svg';
 import FlagSVG from './assets/flag.svg';
+import FlashFilledSVG from './assets/flash-filled.svg';
 import FlashSlashSVG from './assets/flash-slash.svg';
 import FlashSVG from './assets/flash.svg';
 import FlaskSVG from './assets/flask.svg';
@@ -406,6 +407,7 @@ export const assetByIconName: AssetByIconName = {
   Fire: FireSVG,
   FirstPage: FirstPageSVG,
   Flag: FlagSVG,
+  FlashFilled: FlashFilledSVG,
   FlashSlash: FlashSlashSVG,
   Flash: FlashSVG,
   Flask: FlaskSVG,

--- a/packages/design-system-react-native/src/components/Icon/assets/flash-filled.svg
+++ b/packages/design-system-react-native/src/components/Icon/assets/flash-filled.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M10 21.8855V13.8855H7V1.8855H17L15 8.8855H19L10 21.8855Z"/></svg>

--- a/packages/design-system-react/src/components/Icon/icons/FlashFilled.tsx
+++ b/packages/design-system-react/src/components/Icon/icons/FlashFilled.tsx
@@ -1,0 +1,6 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+import { Ref, forwardRef } from "react";
+const SvgFlashFilled = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" ref={ref} {...props}><path d="M10 21.886v-8H7v-12h10l-2 7h4z" /></svg>;
+const ForwardRef = forwardRef(SvgFlashFilled);
+export default ForwardRef;

--- a/packages/design-system-react/src/components/Icon/icons/index.ts
+++ b/packages/design-system-react/src/components/Icon/icons/index.ts
@@ -111,6 +111,7 @@ import Fingerprint from './Fingerprint';
 import Fire from './Fire';
 import FirstPage from './FirstPage';
 import Flag from './Flag';
+import FlashFilled from './FlashFilled';
 import FlashSlash from './FlashSlash';
 import Flash from './Flash';
 import Flask from './Flask';
@@ -402,6 +403,7 @@ export const Icons = {
   Fire,
   FirstPage,
   Flag,
+  FlashFilled,
   FlashSlash,
   Flash,
   Flask,

--- a/packages/design-system-shared/src/assets/icons/flash-filled.svg
+++ b/packages/design-system-shared/src/assets/icons/flash-filled.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M10 21.8855V13.8855H7V1.8855H17L15 8.8855H19L10 21.8855Z"/></svg>

--- a/packages/design-system-shared/src/types/Icon/Icon.types.ts
+++ b/packages/design-system-shared/src/types/Icon/Icon.types.ts
@@ -159,6 +159,7 @@ export const IconName = {
   Fire: 'Fire',
   FirstPage: 'FirstPage',
   Flag: 'Flag',
+  FlashFilled: 'FlashFilled',
   FlashSlash: 'FlashSlash',
   Flash: 'Flash',
   Flask: 'Flask',


### PR DESCRIPTION
## Summary

Adds a filled variant of the existing `Flash` icon to the shared icon set, generating it across all three platforms (`shared`, `react`, `react-native`).

- Path geometry is the **outer outline of the existing `flash.svg`** — the two variants align pixel-perfectly on the 24x24 grid.
- All boilerplate (`IconName.FlashFilled`, RN `assetByIconName` entry, React `Icons` barrel + TSX component) is regenerated via `yarn generate:icons` — no hand-written generated code.

## Why

The MetaMask mobile app's Asset Details screen is gaining a Quick Buy entry point styled as a circular accent button with a filled lightning bolt (per Figma [`Swap-Next` design](https://www.figma.com/design/GO9uJiYlhdWRuXJe8dzZfR/Swap-Next?node-id=2236-23950)). The outlined `Flash` icon already exists; the filled variant is the missing primitive.

Adding it here (instead of shipping a one-off SVG in the mobile repo) keeps icons centralized, themable via `currentColor` on web, and `tintColor`-able on RN.

## Changes

| File | Change |
| --- | --- |
| `packages/design-system-shared/src/assets/icons/flash-filled.svg` | New source SVG (hand-authored) |
| `packages/design-system-shared/src/types/Icon/Icon.types.ts` | Adds `FlashFilled: 'FlashFilled'` to `IconName` const (generated) |
| `packages/design-system-react-native/src/components/Icon/assets/flash-filled.svg` | Copy of shared SVG (generated) |
| `packages/design-system-react-native/src/components/Icon/Icon.assets.ts` | Registers `FlashFilled` in `assetByIconName` (generated) |
| `packages/design-system-react/src/components/Icon/icons/FlashFilled.tsx` | SVGR-generated React component (generated) |
| `packages/design-system-react/src/components/Icon/icons/index.ts` | Adds `FlashFilled` to the `Icons` barrel (generated) |

Per [the release workflow](.cursor/rules/release-workflow.md), no `CHANGELOG.md` or `MIGRATION.md` edits — this is an additive, non-breaking change and changelog entries are written on the release branch.

## Test plan

- [x] `yarn build` (topological, all packages) — clean
- [x] `yarn workspace @metamask/design-system-react-native jest --testPathPattern Icon --coverage=false` — 69/69 passing
- [x] `yarn lint:eslint packages/design-system-react/src/components/Icon/icons/FlashFilled.tsx` — zero violations on the new file
- [x] `IconName.FlashFilled` resolvable from each platform (verified via grep across `Icon.types.ts`, `Icon.assets.ts`, and `icons/index.ts`)
- [ ] Visual review of the icon in Storybook (web + RN)

## Consumer

Once published, [metamask-mobile](https://github.com/MetaMask/metamask-mobile) will bump `@metamask/design-system-react-native` and replace a temporary local `flash-filled.svg` with `IconName.FlashFilled` in the Asset Details Quick Buy footer button.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive icon-only change with no API or behavior changes beyond a new IconName value.
> 
> **Overview**
> Adds a **filled lightning bolt** icon (`FlashFilled`) to the shared design-system icon set and wires it through **shared**, **React**, and **React Native** the same way as other icons.
> 
> A new source SVG is introduced in shared; `IconName.FlashFilled` and the RN asset map, React SVGR component, and icon barrels are updated via the usual icon generation flow. Consumers can use `IconName.FlashFilled` instead of a one-off asset (e.g. mobile Quick Buy UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33c041309141cbe49f73d0698bd71a71ef6e0a7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->