### PR TITLE
feat: [DSRN] Added Content component

### DIFF
--- a/packages/design-system-react-native/src/components/Content/Content.constants.ts
+++ b/packages/design-system-react-native/src/components/Content/Content.constants.ts
@@ -1,0 +1,12 @@
+import {
+  BoxAlignItems,
+  ContentVerticalAlignment,
+} from '@metamask/design-system-shared';
+
+export const VERTICAL_ALIGNMENT_MAP: Record<
+  ContentVerticalAlignment,
+  BoxAlignItems
+> = {
+  [ContentVerticalAlignment.Top]: BoxAlignItems.Start,
+  [ContentVerticalAlignment.Center]: BoxAlignItems.Center,
+};

--- a/packages/design-system-react-native/src/components/Content/Content.stories.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.stories.tsx
@@ -1,14 +1,21 @@
-import { ContentVerticalAlignment } from '@metamask/design-system-shared';
+import {
+  BoxBackgroundColor,
+  ButtonBaseSize,
+  ButtonVariant,
+  ContentVerticalAlignment,
+  IconName,
+  IconSize,
+  TextVariant,
+} from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import React from 'react';
 import { View } from 'react-native';
 
-import { Box, BoxBackgroundColor } from '../Box';
-import { Button, ButtonVariant } from '../Button';
-import { ButtonBaseSize } from '../ButtonBase';
-import { Icon, IconName, IconSize } from '../Icon';
-import { Text, TextVariant } from '../Text';
+import { Box } from '../Box';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
 
 import { Content } from './Content';
 import type { ContentProps } from './Content.types';

--- a/packages/design-system-react-native/src/components/Content/Content.stories.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.stories.tsx
@@ -1,0 +1,348 @@
+import { ContentVerticalAlignment } from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import React from 'react';
+import { View } from 'react-native';
+
+import { Button, ButtonVariant } from '../Button';
+import { ButtonBaseSize } from '../ButtonBase';
+import { Box, BoxBackgroundColor } from '../Box';
+import { Icon, IconName, IconSize } from '../Icon';
+import { Text, TextVariant } from '../Text';
+
+import { Content } from './Content';
+import type { ContentProps } from './Content.types';
+
+const meta: Meta<ContentProps> = {
+  title: 'Components/Content',
+  component: Content,
+  args: {
+    title: 'Label',
+    description: 'Secondary text',
+    value: 'Value',
+    verticalAlignment: ContentVerticalAlignment.Center,
+  },
+  argTypes: {
+    verticalAlignment: {
+      control: 'select',
+      options: Object.keys(ContentVerticalAlignment),
+      mapping: ContentVerticalAlignment,
+    },
+    title: { control: 'text' },
+    description: { control: 'text' },
+    value: { control: 'text' },
+    subvalue: { control: 'text' },
+  },
+  decorators: [
+    (Story) => (
+      <Box
+        twClassName="w-full"
+        backgroundColor={BoxBackgroundColor.BackgroundDefault}
+      >
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<ContentProps>;
+
+const StoryWrapper: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const tw = useTailwind();
+  return <View style={tw`p-4`}>{children}</View>;
+};
+
+export const Default: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content {...args} />
+    </StoryWrapper>
+  ),
+};
+
+export const Title: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Title only"
+        description={undefined}
+        value={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const Description: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Title"
+        description="Description with secondary styling"
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const Value: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Amount"
+        value="$10.00"
+        description={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const Subvalue: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Network"
+        value="1.234 ETH"
+        subvalue="~$2,500"
+        description={undefined}
+      />
+      <Content
+        {...args}
+        title={undefined}
+        description={undefined}
+        value={undefined}
+        avatar={
+          <Box twClassName="h-10 w-10 items-center justify-center rounded-full bg-primary-alternative">
+            <Icon name={IconName.AttachMoney} size={IconSize.Sm} />
+          </Box>
+        }
+        subvalue={
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonBaseSize.Sm}
+            onPress={() => {}}
+          >
+            3% bonus
+          </Button>
+        }
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const VerticalAlignment: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      {Object.values(ContentVerticalAlignment).map((alignment) => (
+        <Content
+          key={alignment}
+          {...args}
+          verticalAlignment={alignment}
+          avatar={<Box twClassName="h-12 w-12 rounded-lg bg-primary-default" />}
+          title={alignment}
+          description={
+            <>
+              <Text variant={TextVariant.BodySm}>Secondary line</Text>
+              <Text variant={TextVariant.BodySm}>Third line</Text>
+            </>
+          }
+          value="Value"
+        />
+      ))}
+    </StoryWrapper>
+  ),
+};
+
+export const Avatar: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        avatar={<Box twClassName="h-10 w-10 rounded-full bg-primary-default" />}
+        title="With avatar"
+        value="Value"
+        description={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const StartAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        startAccessory={<Icon name={IconName.Add} />}
+        title="With start accessory"
+        description={undefined}
+        value={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const EndAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        endAccessory={<Icon name={IconName.ArrowRight} />}
+        title="With end accessory"
+        description={undefined}
+        value={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const TopAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        topAccessory={
+          <Box twClassName="rounded bg-warning-muted px-2 py-1">
+            <Icon name={IconName.Info} />
+          </Box>
+        }
+        title="With top accessory"
+        description={undefined}
+        value={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const BottomAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        bottomAccessory={<Icon name={IconName.Question} />}
+        title="With bottom accessory"
+        description={undefined}
+        value={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const TitleStartAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        titleStartAccessory={<Icon name={IconName.Info} />}
+        title="Title with start accessory"
+        value="Value"
+        description={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const TitleEndAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        titleEndAccessory={<Icon name={IconName.Question} />}
+        title="Title with end accessory"
+        value="Value"
+        description={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const DescriptionStartAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Network"
+        description="Ethereum Mainnet"
+        descriptionStartAccessory={<Icon name={IconName.Info} />}
+        value="1.234 ETH"
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const DescriptionEndAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Network"
+        description="Ethereum Mainnet"
+        descriptionEndAccessory={<Icon name={IconName.Question} />}
+        value="1.234 ETH"
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const ValueStartAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Label"
+        valueStartAccessory={<Icon name={IconName.Check} />}
+        value="100"
+        description={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const ValueEndAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Label"
+        value="100"
+        valueEndAccessory={<Icon name={IconName.Info} />}
+        description={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const SubvalueStartAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Amount"
+        value="$10.00"
+        subvalue="~$0.50 fee"
+        subvalueStartAccessory={<Icon name={IconName.Info} />}
+        description={undefined}
+      />
+    </StoryWrapper>
+  ),
+};
+
+export const SubvalueEndAccessory: Story = {
+  render: (args: ContentProps) => (
+    <StoryWrapper>
+      <Content
+        {...args}
+        title="Amount"
+        value="$10.00"
+        subvalue="~$0.50 fee"
+        subvalueEndAccessory={<Icon name={IconName.Question} />}
+        description={undefined}
+      />
+    </StoryWrapper>
+  ),
+};

--- a/packages/design-system-react-native/src/components/Content/Content.stories.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.stories.tsx
@@ -4,9 +4,9 @@ import type { Meta, StoryObj } from '@storybook/react-native';
 import React from 'react';
 import { View } from 'react-native';
 
+import { Box, BoxBackgroundColor } from '../Box';
 import { Button, ButtonVariant } from '../Button';
 import { ButtonBaseSize } from '../ButtonBase';
-import { Box, BoxBackgroundColor } from '../Box';
 import { Icon, IconName, IconSize } from '../Icon';
 import { Text, TextVariant } from '../Text';
 
@@ -126,7 +126,7 @@ export const Subvalue: Story = {
           <Button
             variant={ButtonVariant.Secondary}
             size={ButtonBaseSize.Sm}
-            onPress={() => {}}
+            onPress={() => undefined}
           >
             3% bonus
           </Button>

--- a/packages/design-system-react-native/src/components/Content/Content.test.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.test.tsx
@@ -469,7 +469,7 @@ describe('Content', () => {
       );
 
       expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
-        tw`flex-row items-center gap-4 min-h-[46px]`,
+        tw`min-h-[46px] flex-row items-center gap-4`,
       );
     });
 
@@ -483,7 +483,7 @@ describe('Content', () => {
       );
 
       expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
-        tw`flex-row items-start gap-4 min-h-[46px]`,
+        tw`min-h-[46px] flex-row items-start gap-4`,
       );
     });
   });

--- a/packages/design-system-react-native/src/components/Content/Content.test.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.test.tsx
@@ -1,0 +1,511 @@
+import {
+  BoxFlexDirection,
+  ContentVerticalAlignment,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { renderHook } from '@testing-library/react-hooks';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { Text, View } from 'react-native';
+
+import { Content } from './Content';
+
+const ROOT_TEST_ID = 'content-root';
+
+describe('Content', () => {
+  let tw: ReturnType<typeof useTailwind>;
+
+  beforeAll(() => {
+    tw = renderHook(() => useTailwind()).result.current;
+  });
+
+  describe('title', () => {
+    it('renders string title on screen', () => {
+      const { getByText } = render(
+        <Content title="Label" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByText('Label')).toBeOnTheScreen();
+    });
+
+    it('renders default title text styles', () => {
+      const { getByText } = render(
+        <Content title="Title" testID={ROOT_TEST_ID} />,
+      );
+
+      // eslint-disable-next-line tailwindcss/no-custom-classname
+      const bodyMdStyles = tw`text-${TextVariant.BodyMd}` as {
+        fontSize?: number;
+      };
+
+      expect(getByText('Title')).toHaveStyle({
+        fontSize: bodyMdStyles.fontSize,
+      });
+      expect(getByText('Title')).toHaveStyle(tw.style('text-default'));
+    });
+
+    it('renders custom title node on screen', () => {
+      const { getByText } = render(
+        <Content
+          title={<Text testID="custom-title">Custom node</Text>}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByText('Custom node')).toBeOnTheScreen();
+    });
+
+    it('omits title row when title is undefined', () => {
+      const { getByText, queryByText } = render(
+        <Content value="100" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByText('100')).toBeOnTheScreen();
+      expect(queryByText('Label')).toBeNull();
+    });
+  });
+
+  describe('titleProps', () => {
+    it('merges titleProps over default title text styles', () => {
+      const { getByText } = render(
+        <Content
+          title="Custom"
+          titleProps={{
+            variant: TextVariant.BodySm,
+            color: TextColor.TextAlternative,
+          }}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByText('Custom')).toHaveStyle(tw.style('text-alternative'));
+    });
+  });
+
+  describe('description', () => {
+    it('renders string description on screen', () => {
+      const { getByText } = render(
+        <Content title="Title" description="Secondary" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByText('Secondary')).toBeOnTheScreen();
+    });
+
+    it('renders default description text styles', () => {
+      const { getByText } = render(
+        <Content title="Title" description="Desc" testID={ROOT_TEST_ID} />,
+      );
+
+      // eslint-disable-next-line tailwindcss/no-custom-classname
+      const bodySmStyles = tw`text-${TextVariant.BodySm}` as {
+        fontSize?: number;
+      };
+
+      expect(getByText('Desc')).toHaveStyle({
+        fontSize: bodySmStyles.fontSize,
+      });
+      expect(getByText('Desc')).toHaveStyle(tw.style('text-alternative'));
+    });
+
+    it('renders description without title', () => {
+      const { getByText } = render(
+        <Content description="Only description" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByText('Only description')).toBeOnTheScreen();
+    });
+  });
+
+  describe('descriptionProps', () => {
+    it('merges descriptionProps over default description text styles', () => {
+      const { getByText } = render(
+        <Content
+          title="Title"
+          description="Desc"
+          descriptionProps={{ color: TextColor.ErrorDefault }}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByText('Desc')).toHaveStyle(tw.style('text-error-default'));
+    });
+  });
+
+  describe('value', () => {
+    it('renders string value on screen', () => {
+      const { getByText } = render(
+        <Content title="Label" value="100" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByText('100')).toBeOnTheScreen();
+    });
+
+    it('renders custom value node on screen', () => {
+      const { getByText } = render(
+        <Content
+          title="Label"
+          value={<Text testID="custom-value">Custom value</Text>}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByText('Custom value')).toBeOnTheScreen();
+    });
+  });
+
+  describe('valueProps', () => {
+    it('merges valueProps over default value text styles', () => {
+      const { getByText } = render(
+        <Content
+          title="Label"
+          value="100"
+          valueProps={{ color: TextColor.ErrorDefault }}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByText('100')).toHaveStyle(tw.style('text-error-default'));
+    });
+  });
+
+  describe('subvalue', () => {
+    it('renders string subvalue on screen', () => {
+      const { getByText } = render(
+        <Content
+          title="Label"
+          value="100"
+          subvalue="Balance"
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByText('Balance')).toBeOnTheScreen();
+    });
+
+    it('renders subvalue without value', () => {
+      const { getByText } = render(
+        <Content subvalue="Fee only" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByText('Fee only')).toBeOnTheScreen();
+    });
+
+    it('renders custom subvalue node on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          value="100"
+          subvalue={<Text testID="custom-subvalue">Custom subvalue</Text>}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId('custom-subvalue')).toBeOnTheScreen();
+    });
+  });
+
+  describe('subvalueProps', () => {
+    it('merges subvalueProps over default subvalue text styles', () => {
+      const { getByText } = render(
+        <Content
+          title="Label"
+          value="100"
+          subvalue="Balance"
+          subvalueProps={{ color: TextColor.ErrorDefault }}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByText('Balance')).toHaveStyle(tw.style('text-error-default'));
+    });
+  });
+
+  describe('avatar', () => {
+    it('renders avatar slot content on screen', () => {
+      const { getByTestId, getByText } = render(
+        <Content
+          testID={ROOT_TEST_ID}
+          avatar={<Text testID="avatar-icon">S</Text>}
+          title="Label"
+        />,
+      );
+
+      expect(getByTestId('avatar-icon')).toBeOnTheScreen();
+      expect(getByText('Label')).toBeOnTheScreen();
+    });
+  });
+
+  describe('titleStartAccessory', () => {
+    it('renders titleStartAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          testID={ROOT_TEST_ID}
+          title="Label"
+          titleStartAccessory={<Text testID="title-start">A</Text>}
+        />,
+      );
+
+      expect(getByTestId('title-start')).toBeOnTheScreen();
+    });
+  });
+
+  describe('titleEndAccessory', () => {
+    it('renders titleEndAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          testID={ROOT_TEST_ID}
+          title="Label"
+          titleEndAccessory={<Text testID="title-end">B</Text>}
+        />,
+      );
+
+      expect(getByTestId('title-end')).toBeOnTheScreen();
+    });
+  });
+
+  describe('descriptionStartAccessory', () => {
+    it('renders descriptionStartAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          testID={ROOT_TEST_ID}
+          title="Label"
+          description="Secondary"
+          descriptionStartAccessory={<Text testID="description-start">A</Text>}
+        />,
+      );
+
+      expect(getByTestId('description-start')).toBeOnTheScreen();
+    });
+  });
+
+  describe('descriptionEndAccessory', () => {
+    it('renders descriptionEndAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          testID={ROOT_TEST_ID}
+          title="Label"
+          description="Secondary"
+          descriptionEndAccessory={<Text testID="description-end">B</Text>}
+        />,
+      );
+
+      expect(getByTestId('description-end')).toBeOnTheScreen();
+    });
+  });
+
+  describe('valueStartAccessory', () => {
+    it('renders valueStartAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          testID={ROOT_TEST_ID}
+          title="Label"
+          value="100"
+          valueStartAccessory={<Text testID="value-start">X</Text>}
+        />,
+      );
+
+      expect(getByTestId('value-start')).toBeOnTheScreen();
+    });
+  });
+
+  describe('valueEndAccessory', () => {
+    it('renders valueEndAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          testID={ROOT_TEST_ID}
+          title="Label"
+          value="100"
+          valueEndAccessory={<Text testID="value-end">Y</Text>}
+        />,
+      );
+
+      expect(getByTestId('value-end')).toBeOnTheScreen();
+    });
+  });
+
+  describe('subvalueStartAccessory', () => {
+    it('renders subvalueStartAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          testID={ROOT_TEST_ID}
+          title="Label"
+          value="100"
+          subvalue="Balance"
+          subvalueStartAccessory={<Text testID="subvalue-start">X</Text>}
+        />,
+      );
+
+      expect(getByTestId('subvalue-start')).toBeOnTheScreen();
+    });
+  });
+
+  describe('subvalueEndAccessory', () => {
+    it('renders subvalueEndAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          testID={ROOT_TEST_ID}
+          title="Label"
+          value="100"
+          subvalue="Balance"
+          subvalueEndAccessory={<Text testID="subvalue-end">Y</Text>}
+        />,
+      );
+
+      expect(getByTestId('subvalue-end')).toBeOnTheScreen();
+    });
+  });
+
+  describe('startAccessory', () => {
+    it('renders startAccessory on the content row', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          startAccessory={<Text testID="start-accessory">S</Text>}
+        />,
+      );
+
+      expect(getByTestId('start-accessory')).toBeOnTheScreen();
+    });
+
+    it('renders startAccessory with avatar on the content row', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          startAccessory={<Text testID="start-accessory">S</Text>}
+          avatar={<Text testID="avatar-slot">A</Text>}
+        />,
+      );
+
+      expect(getByTestId('start-accessory')).toBeOnTheScreen();
+      expect(getByTestId('avatar-slot')).toBeOnTheScreen();
+    });
+  });
+
+  describe('endAccessory', () => {
+    it('renders endAccessory on the content row', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          endAccessory={<Text testID="end-accessory">E</Text>}
+        />,
+      );
+
+      expect(getByTestId('end-accessory')).toBeOnTheScreen();
+    });
+  });
+
+  describe('topAccessory', () => {
+    it('renders topAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          topAccessory={<View testID="top-accessory" />}
+        />,
+      );
+
+      expect(getByTestId('top-accessory')).toBeOnTheScreen();
+    });
+
+    it('uses BoxColumn root when topAccessory is provided', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          topAccessory={<View testID="top-accessory" />}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
+        tw.style('flex', BoxFlexDirection.Column),
+      );
+    });
+
+    it('applies twClassName on column shell root', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          topAccessory={<View testID="top-accessory" />}
+          twClassName="px-2"
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`px-2`);
+    });
+  });
+
+  describe('bottomAccessory', () => {
+    it('renders bottomAccessory on screen', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          bottomAccessory={<View testID="bottom-accessory" />}
+        />,
+      );
+
+      expect(getByTestId('bottom-accessory')).toBeOnTheScreen();
+    });
+
+    it('uses BoxColumn root when only bottomAccessory is provided', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          bottomAccessory={<View testID="bottom-accessory" />}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
+        tw.style('flex', BoxFlexDirection.Column),
+      );
+    });
+  });
+
+  describe('verticalAlignment', () => {
+    it('applies center alignment on flat BoxRow root by default', () => {
+      const { getByTestId } = render(
+        <Content title="Label" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
+        tw`flex-row items-center gap-4 min-h-[46px]`,
+      );
+    });
+
+    it('applies top alignment on flat BoxRow root when verticalAlignment is Top', () => {
+      const { getByTestId } = render(
+        <Content
+          title="Label"
+          verticalAlignment={ContentVerticalAlignment.Top}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
+        tw`flex-row items-start gap-4 min-h-[46px]`,
+      );
+    });
+  });
+
+  describe('twClassName', () => {
+    it('applies twClassName on flat BoxRow root', () => {
+      const { getByTestId } = render(
+        <Content title="Label" twClassName="mt-2" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`mt-2`);
+    });
+  });
+
+  describe('root layout', () => {
+    it('passes testID to flat BoxRow root', () => {
+      const { getByTestId } = render(
+        <Content title="Label" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toBeOnTheScreen();
+    });
+  });
+});

--- a/packages/design-system-react-native/src/components/Content/Content.test.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.test.tsx
@@ -5,8 +5,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { renderHook } from '@testing-library/react-hooks';
-import { render } from '@testing-library/react-native';
+import { render, renderHook } from '@testing-library/react-native';
 import React from 'react';
 import { Text, View } from 'react-native';
 

--- a/packages/design-system-react-native/src/components/Content/Content.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.tsx
@@ -12,6 +12,7 @@ import { TextOrChildren } from '../temp-components/TextOrChildren';
 
 import { VERTICAL_ALIGNMENT_MAP } from './Content.constants';
 import type { ContentProps } from './Content.types';
+
 export const Content: React.FC<ContentProps> = ({
   startAccessory,
   endAccessory,

--- a/packages/design-system-react-native/src/components/Content/Content.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.tsx
@@ -57,6 +57,7 @@ export const Content: React.FC<ContentProps> = ({
         bottomAccessory={
           description ? (
             <BoxRow
+              twClassName="w-full"
               startAccessory={descriptionStartAccessory}
               endAccessory={descriptionEndAccessory}
               gap={1}

--- a/packages/design-system-react-native/src/components/Content/Content.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.tsx
@@ -49,7 +49,7 @@ export const Content: React.FC<ContentProps> = ({
       twClassName={`min-h-[46px] ${hasColumnShell ? 'min-w-0' : (twClassName ?? '')}`.trim()}
       {...(hasColumnShell ? {} : rest)}
     >
-      {avatar && avatar}
+      {avatar}
       {/* Title and description Column */}
       <BoxColumn
         twClassName="flex-1 min-w-0"

--- a/packages/design-system-react-native/src/components/Content/Content.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.tsx
@@ -37,7 +37,7 @@ export const Content: React.FC<ContentProps> = ({
   subvalueProps,
   subvalueStartAccessory,
   subvalueEndAccessory,
-  ...rest
+  ...props
 }) => {
   const hasColumnShell = Boolean(topAccessory) || Boolean(bottomAccessory);
 
@@ -48,7 +48,7 @@ export const Content: React.FC<ContentProps> = ({
       alignItems={VERTICAL_ALIGNMENT_MAP[verticalAlignment]}
       gap={4}
       twClassName={`min-h-[46px] ${hasColumnShell ? 'min-w-0' : (twClassName ?? '')}`.trim()}
-      {...(hasColumnShell ? {} : rest)}
+      {...(hasColumnShell ? {} : props)}
     >
       {avatar}
       {/* Title and description Column */}
@@ -153,7 +153,7 @@ export const Content: React.FC<ContentProps> = ({
         topAccessory={topAccessory}
         bottomAccessory={bottomAccessory}
         twClassName={twClassName}
-        {...rest}
+        {...props}
       >
         {contentRow}
       </BoxColumn>

--- a/packages/design-system-react-native/src/components/Content/Content.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.tsx
@@ -1,0 +1,164 @@
+import {
+  ContentVerticalAlignment,
+  FontWeight,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-shared';
+import React from 'react';
+
+import { BoxColumn } from '../BoxColumn';
+import { BoxRow } from '../BoxRow';
+import { TextOrChildren } from '../temp-components/TextOrChildren';
+
+import { VERTICAL_ALIGNMENT_MAP } from './Content.constants';
+import type { ContentProps } from './Content.types';
+export const Content: React.FC<ContentProps> = ({
+  startAccessory,
+  endAccessory,
+  topAccessory,
+  bottomAccessory,
+  verticalAlignment = ContentVerticalAlignment.Center,
+  avatar,
+  twClassName,
+  title,
+  titleProps,
+  titleStartAccessory,
+  titleEndAccessory,
+  description,
+  descriptionProps,
+  descriptionStartAccessory,
+  descriptionEndAccessory,
+  value,
+  valueProps,
+  valueStartAccessory,
+  valueEndAccessory,
+  subvalue,
+  subvalueProps,
+  subvalueStartAccessory,
+  subvalueEndAccessory,
+  ...rest
+}) => {
+  const hasColumnShell = Boolean(topAccessory) || Boolean(bottomAccessory);
+
+  const contentRow = (
+    <BoxRow
+      startAccessory={startAccessory}
+      endAccessory={endAccessory}
+      alignItems={VERTICAL_ALIGNMENT_MAP[verticalAlignment]}
+      gap={4}
+      twClassName={`min-h-[46px] ${hasColumnShell ? 'min-w-0' : (twClassName ?? '')}`.trim()}
+      {...(hasColumnShell ? {} : rest)}
+    >
+      {avatar && avatar}
+      {/* Title and description Column */}
+      <BoxColumn
+        twClassName="flex-1 min-w-0"
+        bottomAccessory={
+          description ? (
+            <BoxRow
+              startAccessory={descriptionStartAccessory}
+              endAccessory={descriptionEndAccessory}
+              gap={1}
+            >
+              <TextOrChildren
+                textProps={{
+                  variant: TextVariant.BodySm,
+                  fontWeight: FontWeight.Medium,
+                  color: TextColor.TextAlternative,
+                  ...descriptionProps,
+                }}
+              >
+                {description}
+              </TextOrChildren>
+            </BoxRow>
+          ) : null
+        }
+      >
+        {title ? (
+          <BoxRow
+            twClassName="w-full"
+            startAccessory={titleStartAccessory}
+            endAccessory={titleEndAccessory}
+            gap={1}
+          >
+            <TextOrChildren
+              textProps={{
+                variant: TextVariant.BodyMd,
+                fontWeight: FontWeight.Medium,
+                color: TextColor.TextDefault,
+                ...titleProps,
+              }}
+            >
+              {title}
+            </TextOrChildren>
+          </BoxRow>
+        ) : null}
+      </BoxColumn>
+      {/* Value and subvalue Column */}
+      {value || subvalue ? (
+        <BoxColumn
+          twClassName="min-w-0"
+          bottomAccessory={
+            subvalue ? (
+              <BoxRow
+                twClassName="w-full"
+                startAccessory={subvalueStartAccessory}
+                endAccessory={subvalueEndAccessory}
+                gap={1}
+              >
+                <TextOrChildren
+                  textProps={{
+                    variant: TextVariant.BodySm,
+                    fontWeight: FontWeight.Medium,
+                    color: TextColor.TextAlternative,
+                    ...subvalueProps,
+                  }}
+                >
+                  {subvalue}
+                </TextOrChildren>
+              </BoxRow>
+            ) : null
+          }
+        >
+          {value ? (
+            <BoxRow
+              twClassName="w-full"
+              startAccessory={valueStartAccessory}
+              endAccessory={valueEndAccessory}
+              gap={1}
+            >
+              <TextOrChildren
+                textProps={{
+                  variant: TextVariant.BodyMd,
+                  fontWeight: FontWeight.Medium,
+                  color: TextColor.TextDefault,
+                  ...valueProps,
+                }}
+              >
+                {value}
+              </TextOrChildren>
+            </BoxRow>
+          ) : null}
+        </BoxColumn>
+      ) : null}
+    </BoxRow>
+  );
+
+  if (hasColumnShell) {
+    return (
+      <BoxColumn
+        gap={1}
+        topAccessory={topAccessory}
+        bottomAccessory={bottomAccessory}
+        twClassName={twClassName}
+        {...rest}
+      >
+        {contentRow}
+      </BoxColumn>
+    );
+  }
+
+  return contentRow;
+};
+
+Content.displayName = 'Content';

--- a/packages/design-system-react-native/src/components/Content/Content.types.ts
+++ b/packages/design-system-react-native/src/components/Content/Content.types.ts
@@ -1,0 +1,33 @@
+import type { ContentPropsShared } from '@metamask/design-system-shared';
+
+import type { BoxProps } from '../Box/Box.types';
+import type { TextProps } from '../Text/Text.types';
+
+/**
+ * Content component props.
+ *
+ * Props-only layout for list rows (`title`, `avatar`, accessories, etc.).
+ */
+export type ContentProps = Omit<BoxProps, 'children'> &
+  ContentPropsShared & {
+    /**
+     * Optional props for the title Text when `title` is a string.
+     * Default: TextVariant.BodyMd, FontWeight.Medium, TextColor.TextDefault.
+     */
+    titleProps?: Partial<Omit<TextProps, 'children'>>;
+    /**
+     * Optional props for the description Text when `description` is a string.
+     * Default: TextVariant.BodySm, FontWeight.Medium, TextColor.TextAlternative.
+     */
+    descriptionProps?: Partial<Omit<TextProps, 'children'>>;
+    /**
+     * Optional props for the value Text when `value` is a string.
+     * Default: TextVariant.BodyMd, FontWeight.Medium, TextColor.TextDefault.
+     */
+    valueProps?: Partial<Omit<TextProps, 'children'>>;
+    /**
+     * Optional props for the subvalue Text when `subvalue` is a string.
+     * Default: TextVariant.BodySm, FontWeight.Medium, TextColor.TextAlternative.
+     */
+    subvalueProps?: Partial<Omit<TextProps, 'children'>>;
+  };

--- a/packages/design-system-react-native/src/components/Content/README.md
+++ b/packages/design-system-react-native/src/components/Content/README.md
@@ -1,0 +1,442 @@
+# Content
+
+Content lays out the inner row for list items: optional leading and trailing accessories, an avatar, title and description on the left, and value and subvalue on the right. Use it when you need the row layout without `ListItem` padding or press handling. For compound slots (`ListItem.Title`, `ListItem.Avatar`, …), use [ListItem](../ListItem/README.md) instead.
+
+Without `topAccessory` or `bottomAccessory`, the root is a horizontal row (`min-h-[46px]`). When either shell accessory is set, the root becomes a column with that row nested inside.
+
+```tsx
+import { Content } from '@metamask/design-system-react-native';
+
+<Content
+  title="Label"
+  description="Secondary"
+  value="Value"
+  subvalue="Subvalue"
+/>;
+```
+
+## Props
+
+### `title`
+
+Primary label on the left. Pass a string for default body styling, or a node for custom content.
+
+Default string styles: `TextVariant.BodyMd`, `FontWeight.Medium`, `TextColor.TextDefault`.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content title="Network" />
+
+<Content title={<Text variant={TextVariant.HeadingSm}>Custom title</Text>} />
+```
+
+### `description`
+
+Secondary line under the title on the left. Pass a string for default body styling, or a node for custom content.
+
+Default string styles: `TextVariant.BodySm`, `FontWeight.Medium`, `TextColor.TextAlternative`.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content title="Network" description="Ethereum Mainnet" />
+```
+
+### `value`
+
+Primary value on the right. Pass a string for default body styling, or a node for custom content.
+
+Default string styles: `TextVariant.BodyMd`, `FontWeight.Medium`, `TextColor.TextDefault`.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content title="Amount" value="$10.00" />
+```
+
+### `subvalue`
+
+Secondary line under the value on the right. Pass a string for default body styling, or a node (for example a button). Can be used with or without `value`.
+
+Default string styles: `TextVariant.BodySm`, `FontWeight.Medium`, `TextColor.TextAlternative`.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content title="Network" value="1.234 ETH" subvalue="~$2,500" />
+
+<Content
+  avatar={<AvatarToken name="ETH" src={ethIcon} size={AvatarTokenSize.Lg} />}
+  subvalue={
+    <Button variant={ButtonVariant.Secondary} size={ButtonBaseSize.Sm}>
+      3% bonus
+    </Button>
+  }
+/>
+```
+
+### `titleProps`
+
+Props merged onto the `Text` component when `title` is a string. Overrides default title text styles.
+
+| TYPE                                   | REQUIRED | DEFAULT     |
+| -------------------------------------- | -------- | ----------- |
+| `Partial<Omit<TextProps, 'children'>>` | No       | `undefined` |
+
+```tsx
+<Content title="Warning" titleProps={{ color: TextColor.WarningDefault }} />
+```
+
+### `descriptionProps`
+
+Props merged onto the `Text` component when `description` is a string. Overrides default description text styles.
+
+| TYPE                                   | REQUIRED | DEFAULT     |
+| -------------------------------------- | -------- | ----------- |
+| `Partial<Omit<TextProps, 'children'>>` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Network"
+  description="Ethereum Mainnet"
+  descriptionProps={{ color: TextColor.TextMuted }}
+/>
+```
+
+### `valueProps`
+
+Props merged onto the `Text` component when `value` is a string. Overrides default value text styles.
+
+| TYPE                                   | REQUIRED | DEFAULT     |
+| -------------------------------------- | -------- | ----------- |
+| `Partial<Omit<TextProps, 'children'>>` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Balance"
+  value="100"
+  valueProps={{ color: TextColor.SuccessDefault }}
+/>
+```
+
+### `subvalueProps`
+
+Props merged onto the `Text` component when `subvalue` is a string. Overrides default subvalue text styles.
+
+| TYPE                                   | REQUIRED | DEFAULT     |
+| -------------------------------------- | -------- | ----------- |
+| `Partial<Omit<TextProps, 'children'>>` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Amount"
+  value="$10.00"
+  subvalue="+2.5%"
+  subvalueProps={{ color: TextColor.SuccessDefault }}
+/>
+```
+
+### `avatar`
+
+Optional leading visual after `startAccessory` and before the title column. Use large avatars (40×40) in this slot.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  Content,
+} from '@metamask/design-system-react-native';
+
+<Content
+  avatar={<AvatarToken name="ETH" src={ethIcon} size={AvatarTokenSize.Lg} />}
+  title="Ethereum"
+  value="0.24 ETH"
+/>;
+```
+
+### `startAccessory`
+
+Optional leading element on the content row, before the avatar (for example a rank or icon). Icons in this slot should be 20×20 (`IconSize.Md`).
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+import { Content, Icon, IconName } from '@metamask/design-system-react-native';
+
+<Content
+  startAccessory={<Icon name={IconName.Token} />}
+  title="With leading icon"
+/>;
+```
+
+### `endAccessory`
+
+Optional trailing element on the content row, after the value column (for example a chevron or button).
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+import { Content, Icon, IconName } from '@metamask/design-system-react-native';
+
+<Content title="Network" endAccessory={<Icon name={IconName.ArrowRight} />} />;
+```
+
+### `topAccessory`
+
+Optional content above the content row. Setting `topAccessory` or `bottomAccessory` switches the root to a column layout.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content topAccessory={<BannerAlert />} title="Token" value="100" />
+```
+
+### `bottomAccessory`
+
+Optional content below the content row. Setting `topAccessory` or `bottomAccessory` switches the root to a column layout.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Token"
+  value="100"
+  bottomAccessory={<Text variant={TextVariant.BodySm}>Details</Text>}
+/>
+```
+
+### `titleStartAccessory`
+
+Optional node before the title on the same line (for example an icon or badge).
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content title="Network" titleStartAccessory={<Icon name={IconName.Info} />} />
+```
+
+### `titleEndAccessory`
+
+Optional node after the title on the same line (for example a status dot).
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Network"
+  titleEndAccessory={<Icon name={IconName.Question} />}
+/>
+```
+
+### `descriptionStartAccessory`
+
+Optional node before the description on the same line.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Network"
+  description="Ethereum Mainnet"
+  descriptionStartAccessory={<Icon name={IconName.Info} />}
+/>
+```
+
+### `descriptionEndAccessory`
+
+Optional node after the description on the same line.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Network"
+  description="Ethereum Mainnet"
+  descriptionEndAccessory={<Icon name={IconName.Question} />}
+/>
+```
+
+### `valueStartAccessory`
+
+Optional node before the value on the same line.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Label"
+  value="100"
+  valueStartAccessory={<Icon name={IconName.Check} />}
+/>
+```
+
+### `valueEndAccessory`
+
+Optional node after the value on the same line.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Label"
+  value="100"
+  valueEndAccessory={<Icon name={IconName.Info} />}
+/>
+```
+
+### `subvalueStartAccessory`
+
+Optional node before the subvalue on the same line.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Amount"
+  value="$10.00"
+  subvalue="~$0.50 fee"
+  subvalueStartAccessory={<Icon name={IconName.Info} />}
+/>
+```
+
+### `subvalueEndAccessory`
+
+Optional node after the subvalue on the same line.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<Content
+  title="Amount"
+  value="$10.00"
+  subvalue="~$0.50 fee"
+  subvalueEndAccessory={<Icon name={IconName.Question} />}
+/>
+```
+
+### `verticalAlignment`
+
+Vertical alignment of the content row (`alignItems` on the inner `BoxRow`).
+
+Available values:
+
+- `ContentVerticalAlignment.Center` — default; use for one- or two-line rows
+- `ContentVerticalAlignment.Top` — use for taller rows (three+ lines or ~88dp+ height)
+
+| TYPE                       | REQUIRED | DEFAULT                           |
+| -------------------------- | -------- | --------------------------------- |
+| `ContentVerticalAlignment` | No       | `ContentVerticalAlignment.Center` |
+
+```tsx
+import {
+  Content,
+  ContentVerticalAlignment,
+} from '@metamask/design-system-react-native';
+
+<Content title="Label" description="Line one\nLine two\nLine three" />
+
+<Content
+  title="Label"
+  description="Line one\nLine two\nLine three"
+  verticalAlignment={ContentVerticalAlignment.Top}
+/>
+```
+
+### `twClassName`
+
+Use the `twClassName` prop to add Tailwind CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+Applied on the outermost node: the flat content `BoxRow`, or the column shell `BoxColumn` when `topAccessory` or `bottomAccessory` is set.
+
+| TYPE     | REQUIRED | DEFAULT     |
+| -------- | -------- | ----------- |
+| `string` | No       | `undefined` |
+
+```tsx
+import { Content } from '@metamask/design-system-react-native';
+
+// Flat row
+<Content title="Label" twClassName="opacity-80" />
+
+// Column shell
+<Content
+  topAccessory={<BannerAlert />}
+  title="Token"
+  twClassName="gap-3"
+/>
+```
+
+### `style`
+
+Use the `style` prop to customize the component's appearance with React Native styles. For consistent styling, prefer using `twClassName` with Tailwind classes when possible. Use `style` with `tw.style()` for conditionals or dynamic values.
+
+Forwarded to the outermost node (`BoxRow` or column shell `BoxColumn`), same as `twClassName`.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `StyleProp<ViewStyle>` | No       | `undefined` |
+
+```tsx
+import { Content } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+
+export const HighlightedContent = ({
+  isHighlighted,
+}: {
+  isHighlighted: boolean;
+}) => {
+  const tw = useTailwind();
+
+  return (
+    <Content
+      title="Network"
+      description="Ethereum Mainnet"
+      style={tw.style(isHighlighted && 'bg-background-muted')}
+    />
+  );
+};
+```
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react-native/src/components/Content/README.md
+++ b/packages/design-system-react-native/src/components/Content/README.md
@@ -1,6 +1,6 @@
 # Content
 
-Content lays out the inner row for list items: optional leading and trailing accessories, an avatar, title and description on the left, and value and subvalue on the right. Use it when you need the row layout without `ListItem` padding or press handling. For compound slots (`ListItem.Title`, `ListItem.Avatar`, …), use [ListItem](../ListItem/README.md) instead.
+Content lays out the inner row for list items: optional leading and trailing accessories, an avatar, title and description on the left, and value and subvalue on the right. Use it when you need the row layout without `ListItem` padding or press handling.
 
 Without `topAccessory` or `bottomAccessory`, the root is a horizontal row (`min-h-[46px]`). When either shell accessory is set, the root becomes a column with that row nested inside.
 

--- a/packages/design-system-react-native/src/components/Content/index.ts
+++ b/packages/design-system-react-native/src/components/Content/index.ts
@@ -1,0 +1,3 @@
+export { ContentVerticalAlignment } from '@metamask/design-system-shared';
+export { Content } from './Content';
+export type { ContentProps } from './Content.types';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -103,6 +103,9 @@ export type { BoxColumnProps } from './BoxColumn';
 export { Card } from './Card';
 export type { CardProps } from './Card';
 
+export { Content } from './Content';
+export type { ContentProps } from './Content';
+
 export { ButtonAnimated } from './temp-components/ButtonAnimated';
 export type { ButtonAnimatedProps } from './temp-components/ButtonAnimated';
 

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -103,7 +103,7 @@ export type { BoxColumnProps } from './BoxColumn';
 export { Card } from './Card';
 export type { CardProps } from './Card';
 
-export { Content } from './Content';
+export { Content, ContentVerticalAlignment } from './Content';
 export type { ContentProps } from './Content';
 
 export { ButtonAnimated } from './temp-components/ButtonAnimated';

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -30,6 +30,12 @@ export {
   type BadgeStatusPropsShared,
 } from './types/BadgeStatus';
 
+// Content types (ADR-0003 + ADR-0004)
+export {
+  ContentVerticalAlignment,
+  type ContentPropsShared,
+} from './types/Content';
+
 // HelpText types (ADR-0003 + ADR-0004)
 export { HelpTextSeverity, type HelpTextPropsShared } from './types/HelpText';
 

--- a/packages/design-system-shared/src/types/Content/Content.types.ts
+++ b/packages/design-system-shared/src/types/Content/Content.types.ts
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Vertical alignment options for the Content row.
+ */
+export const ContentVerticalAlignment = {
+  Top: 'top',
+  Center: 'center',
+} as const;
+
+export type ContentVerticalAlignment =
+  (typeof ContentVerticalAlignment)[keyof typeof ContentVerticalAlignment];
+
+/**
+ * Content shared props (ADR-0004).
+ * Platform-independent properties shared across React and React Native.
+ */
+export type ContentPropsShared = {
+  /**
+   * Optional node rendered before the content row (e.g. leading icon), via
+   * `BoxRow.startAccessory` — before `avatar`.
+   */
+  startAccessory?: ReactNode;
+  /**
+   * Optional node rendered after the content row (e.g. chevron), via
+   * `BoxRow.endAccessory` — after the value/subvalue column.
+   */
+  endAccessory?: ReactNode;
+  /**
+   * Optional content above the content row. When set (with `bottomAccessory` or
+   * alone), root is `BoxColumn` with this as `topAccessory`.
+   */
+  topAccessory?: ReactNode;
+  /**
+   * Optional content below the content row. When set (with `topAccessory` or
+   * alone), root is `BoxColumn` with this as `bottomAccessory`.
+   */
+  bottomAccessory?: ReactNode;
+  /**
+   * Vertical alignment of the row (avatar, text columns, and value column).
+   *
+   * Prefer `center` when the row is one or two lines tall—the usual list-item case.
+   * Prefer `top` when the row is taller (for example three or more lines of text,
+   * or overall row height of 88dp or more) so the avatar and trailing content
+   * align with the first line.
+   *
+   * @default ContentVerticalAlignment.Center
+   */
+  verticalAlignment?: ContentVerticalAlignment;
+  /** Optional leading visual (e.g. avatar), rendered in a 40px-wide centered slot. */
+  avatar?: ReactNode;
+  /** Optional title (string or node). Default text: BodyMd, Medium, TextDefault. */
+  title?: ReactNode;
+  /** Optional node rendered before the title. */
+  titleStartAccessory?: ReactNode;
+  /** Optional node rendered after the title. */
+  titleEndAccessory?: ReactNode;
+  /** Optional description (string or node). Default text: BodySm, Medium, TextAlternative. */
+  description?: ReactNode;
+  /** Optional node rendered before the description. */
+  descriptionStartAccessory?: ReactNode;
+  /** Optional node rendered after the description. */
+  descriptionEndAccessory?: ReactNode;
+  /** Optional value (string or node). Default text: BodyMd, Medium, TextDefault. */
+  value?: ReactNode;
+  /** Optional node rendered before the value. */
+  valueStartAccessory?: ReactNode;
+  /** Optional node rendered after the value. */
+  valueEndAccessory?: ReactNode;
+  /** Optional subvalue (string or node). Default text: BodySm, Medium, TextAlternative. */
+  subvalue?: ReactNode;
+  /** Optional node rendered before the subvalue. */
+  subvalueStartAccessory?: ReactNode;
+  /** Optional node rendered after the subvalue. */
+  subvalueEndAccessory?: ReactNode;
+};

--- a/packages/design-system-shared/src/types/Content/index.ts
+++ b/packages/design-system-shared/src/types/Content/index.ts
@@ -1,0 +1,4 @@
+export {
+  ContentVerticalAlignment,
+  type ContentPropsShared,
+} from './Content.types';


### PR DESCRIPTION
## **Description**

Adds the **Content** component to `@metamask/design-system-react-native`, with shared types in `@metamask/design-system-shared` (ADR-0003 / ADR-0004).

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-762

## **Manual testing steps**

1. From repo root: `yarn storybook:ios` or `yarn storybook:android`
2. Open **Components → Content** in Storybook
3. Confirm **Default** — title, description, value render with expected typography
4. Walk through slot stories: **Avatar**, **StartAccessory** / **EndAccessory**, **TopAccessory** / **BottomAccessory**, title/description/value/subvalue accessories
5. In **VerticalAlignment**, compare `center` vs `top` on multi-line description
6. Toggle controls (title, description, value, subvalue, `verticalAlignment`) and confirm layout updates without errors

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — new component

### **After**

https://github.com/user-attachments/assets/78b28888-a83e-4ecf-9a61-b0f222a8b9e2

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable — `Content.test.tsx` (37 tests)
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable — shared types in `Content.types.ts`; component README
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New design-system UI component and types only; no auth, data, or changes to existing ListItem behavior in this PR.
> 
> **Overview**
> Introduces a new **`Content`** layout primitive for React Native list-style rows (title/description on the left, value/subvalue on the right) without `ListItem` padding or press behavior.
> 
> **Shared layer:** Adds `ContentPropsShared` and `ContentVerticalAlignment` in `@metamask/design-system-shared` and re-exports them from the shared package index.
> 
> **RN implementation:** `Content` composes `BoxRow` / `BoxColumn` with optional `avatar`, row accessories (`start`/`end`), shell accessories (`top`/`bottom` that switch the root to a column), per-field inline accessories, and `titleProps` / `descriptionProps` / `valueProps` / `subvalueProps` for string slots. Default row is `min-h-[46px]` with center alignment; `Top` maps to `alignItems` start via `VERTICAL_ALIGNMENT_MAP`.
> 
> **Surface area:** Public export from `design-system-react-native`, README, Storybook stories, and unit tests. No changes to existing `ListItem` in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 277ebd44f9079cb59aa6e0481c10c163cd4fc4a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->