### PR TITLE
refactor: updated segment group style and gap

### DIFF
--- a/packages/design-system-react-native/src/components/SegmentGroup/README.md
+++ b/packages/design-system-react-native/src/components/SegmentGroup/README.md
@@ -109,7 +109,7 @@ export const WithGroupVariant = () => {
 
 ### `twClassName`
 
-Optional Tailwind classes merged into the scroll content row after the default horizontal layout (**`gap-3`** between children, row alignment). These classes will be merged with the default classes using `twMerge`, allowing you to:
+Optional Tailwind classes merged into the scroll content row after the default horizontal layout (**`gap-1`** between children, row alignment). These classes will be merged with the default classes using `twMerge`, allowing you to:
 
 - Add new styles that don't exist in the default component
 - Override the component's default styles when needed

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.test.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.test.tsx
@@ -49,7 +49,7 @@ describe('SegmentGroup', () => {
     expect(scroll.props.horizontal).toBe(true);
     expect(scroll.props.showsHorizontalScrollIndicator).toBe(false);
 
-    const expectedContent = tw.style('flex-row items-center gap-2');
+    const expectedContent = tw.style('flex-row items-center gap-1');
 
     expect(
       StyleSheet.flatten(scroll.props.contentContainerStyle),
@@ -71,7 +71,7 @@ describe('SegmentGroup', () => {
     );
 
     const scroll = getByTestId(GROUP_TEST_ID);
-    const expectedContent = tw.style('flex-row items-center gap-2', 'px-4');
+    const expectedContent = tw.style('flex-row items-center gap-1', 'px-4');
 
     expect(
       StyleSheet.flatten(scroll.props.contentContainerStyle),

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.test.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.test.tsx
@@ -49,7 +49,7 @@ describe('SegmentGroup', () => {
     expect(scroll.props.horizontal).toBe(true);
     expect(scroll.props.showsHorizontalScrollIndicator).toBe(false);
 
-    const expectedContent = tw.style('flex-row items-center gap-1');
+    const expectedContent = tw.style('flex flex-row items-center gap-1');
 
     expect(
       StyleSheet.flatten(scroll.props.contentContainerStyle),
@@ -71,7 +71,10 @@ describe('SegmentGroup', () => {
     );
 
     const scroll = getByTestId(GROUP_TEST_ID);
-    const expectedContent = tw.style('flex-row items-center gap-1', 'px-4');
+    const expectedContent = tw.style(
+      'flex flex-row items-center gap-1',
+      'px-4',
+    );
 
     expect(
       StyleSheet.flatten(scroll.props.contentContainerStyle),

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.test.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.test.tsx
@@ -1,6 +1,4 @@
 import {
-  BoxAlignItems,
-  BoxFlexDirection,
   SelectButtonEndArrow,
   SegmentButtonVariant,
 } from '@metamask/design-system-shared';
@@ -9,7 +7,6 @@ import { fireEvent, render, renderHook } from '@testing-library/react-native';
 import React, { useState } from 'react';
 import { StyleSheet } from 'react-native';
 
-import { TWCLASSMAP_BOX_GAP } from '../Box/Box.constants';
 import { SegmentButton } from '../SegmentButton';
 import { SelectButton } from '../SelectButton';
 
@@ -52,12 +49,7 @@ describe('SegmentGroup', () => {
     expect(scroll.props.horizontal).toBe(true);
     expect(scroll.props.showsHorizontalScrollIndicator).toBe(false);
 
-    const expectedContent = tw.style(
-      'flex',
-      BoxFlexDirection.Row,
-      BoxAlignItems.Center,
-      TWCLASSMAP_BOX_GAP[3],
-    );
+    const expectedContent = tw.style('flex-row items-center gap-2');
 
     expect(
       StyleSheet.flatten(scroll.props.contentContainerStyle),
@@ -79,13 +71,7 @@ describe('SegmentGroup', () => {
     );
 
     const scroll = getByTestId(GROUP_TEST_ID);
-    const expectedContent = tw.style(
-      'flex',
-      BoxFlexDirection.Row,
-      BoxAlignItems.Center,
-      TWCLASSMAP_BOX_GAP[3],
-      'px-4',
-    );
+    const expectedContent = tw.style('flex-row items-center gap-2', 'px-4');
 
     expect(
       StyleSheet.flatten(scroll.props.contentContainerStyle),

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.tsx
@@ -1,14 +1,7 @@
-import {
-  BoxAlignItems,
-  BoxFlexDirection,
-  SegmentGroupContext,
-} from '@metamask/design-system-shared';
+import { SegmentGroupContext } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useMemo } from 'react';
 import { ScrollView } from 'react-native';
-import type { StyleProp, ViewStyle } from 'react-native';
-
-import { TWCLASSMAP_BOX_GAP } from '../Box/Box.constants';
 
 import type { SegmentGroupProps } from './SegmentGroup.types';
 
@@ -29,17 +22,6 @@ export const SegmentGroup = ({
     [value, onChange, variant],
   );
 
-  const mergedContentContainerStyle: StyleProp<ViewStyle> = [
-    tw.style(
-      'flex',
-      BoxFlexDirection.Row,
-      BoxAlignItems.Center,
-      TWCLASSMAP_BOX_GAP[3],
-      twClassName,
-    ),
-    contentContainerStyle,
-  ];
-
   return (
     <SegmentGroupContext.Provider value={contextValue}>
       <ScrollView
@@ -48,7 +30,10 @@ export const SegmentGroup = ({
         showsHorizontalScrollIndicator={false}
         accessibilityRole="tablist"
         style={[tw.style('self-stretch'), style]}
-        contentContainerStyle={mergedContentContainerStyle}
+        contentContainerStyle={[
+          tw.style('flex-row items-center gap-2', twClassName),
+          contentContainerStyle,
+        ]}
       >
         {children}
       </ScrollView>

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.tsx
@@ -31,7 +31,7 @@ export const SegmentGroup = ({
         accessibilityRole="tablist"
         style={[tw.style('self-stretch'), style]}
         contentContainerStyle={[
-          tw.style('flex-row items-center gap-2', twClassName),
+          tw.style('flex-row items-center gap-1', twClassName),
           contentContainerStyle,
         ]}
       >

--- a/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.tsx
+++ b/packages/design-system-react-native/src/components/SegmentGroup/SegmentGroup.tsx
@@ -31,7 +31,7 @@ export const SegmentGroup = ({
         accessibilityRole="tablist"
         style={[tw.style('self-stretch'), style]}
         contentContainerStyle={[
-          tw.style('flex-row items-center gap-1', twClassName),
+          tw.style('flex flex-row items-center gap-1', twClassName),
           contentContainerStyle,
         ]}
       >


### PR DESCRIPTION
## **Description**

Refactors `SegmentGroup` content container styling to match React Native design-system conventions and tightens default spacing between segments.

**Why:** The previous implementation built `contentContainerStyle` via a separate variable, pulled in `BoxFlexDirection` / `BoxAlignItems` enums and `TWCLASSMAP_BOX_GAP`, and used `gap-3` as the default. That pattern didn’t align with how other native components apply `tw.style()` (inline array merge with `style` / `contentContainerStyle`).

**What changed:**
- Apply default row layout inline: `contentContainerStyle={[tw.style('flex-row items-center gap-1', twClassName), contentContainerStyle]}`
- Reduce default gap from `gap-3` to `gap-1` for tighter segment spacing
- Remove unused imports (`BoxFlexDirection`, `BoxAlignItems`, `TWCLASSMAP_BOX_GAP`, `StyleProp`, `ViewStyle`)
- Update unit tests to assert the new default layout classes

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open React Native Storybook (`yarn storybook:ios` or `yarn storybook:android`)
2. Navigate to **SegmentGroup** stories
3. Confirm segments in a horizontal group are laid out in a row with tighter spacing (`gap-1`) between items
4. Verify `twClassName` still merges correctly (e.g. `twClassName="px-4"` adds horizontal padding without breaking row layout)
5. Confirm selection, `onChange`, and mixed children (e.g. `SelectButton`) still behave as before

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- SegmentGroup with gap-3 spacing between segment buttons -->

### **After**

https://github.com/user-attachments/assets/d37c44d2-6e08-4456-b496-194a2f156862

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Design-system layout and spacing only; no API or behavioral logic changes beyond visual gap.
> 
> **Overview**
> **`SegmentGroup`** now builds its horizontal segment row with inline `tw.style('flex flex-row items-center gap-1', twClassName)` on `contentContainerStyle`, dropping `BoxFlexDirection` / `BoxAlignItems` and `TWCLASSMAP_BOX_GAP`.
> 
> Default spacing between segments is **tighter** (`gap-3` → **`gap-1`**). Docs and unit tests were updated to match; selection and `twClassName` merge behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit facfcb3669ca844ad6757b2eba1bc88d8affe61f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->