### PR TITLE
chore: drop Node v18 support

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     outputs:
       child-workspace-package-names: ${{ steps.workspace-package-names.outputs.child-workspace-package-names }}
     steps:
@@ -97,7 +97,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment

--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -48,7 +48,7 @@
     "typescript": "~5.2.2"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20"
   },
   "installConfig": {}
 }

--- a/apps/storybook-react/package.json
+++ b/apps/storybook-react/package.json
@@ -44,7 +44,7 @@
     "vitest": "^3.2.0"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20"
   },
   "lavamoat": {
     "allowScripts": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   },
   "packageManager": "yarn@4.10.3",
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20"
   },
   "lavamoat": {
     "allowScripts": {

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -100,7 +100,7 @@
     "react-native-safe-area-context": ">=5.0.0"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -87,7 +87,7 @@
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -70,7 +70,7 @@
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -61,7 +61,7 @@
     "tailwindcss": "^3.0.0"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/design-system-twrnc-preset/package.json
+++ b/packages/design-system-twrnc-preset/package.json
@@ -85,7 +85,7 @@
     "react": ">=18.2.0"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -65,7 +65,7 @@
     "typescript": "~5.2.2"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -210,8 +210,8 @@ module.exports = defineConfig({
         expectWorkspaceField(workspace, 'packageManager', 'yarn@4.10.3');
       }
 
-      // All packages must specify a minimum Node.js version of 18.18.
-      expectWorkspaceField(workspace, 'engines.node', '^18.18 || >=20');
+      // All packages must specify a minimum Node.js version of 20.
+      expectWorkspaceField(workspace, 'engines.node', '>=20');
 
       // All non-root public packages should be published to the NPM registry;
       // all non-root private packages should not.


### PR DESCRIPTION
## **Description**

Drops Node 18 support across the monorepo, setting the minimum Node.js version to 20.

Node 18 reached end-of-life. Extension has moved to Node >=24, Mobile is on Node ^20.18.0. There is no longer a need to support Node 18 in the design system.

Context: https://consensys.slack.com/archives/C1L7H42BT/p1780090599233229

Changes:
- Updated `engines.node` from `"^18.18 || >=20"` to `">=20"` in all package and app `package.json` files
- Updated `yarn.config.cjs` constraint to enforce `>=20`
- Removed `18.x` from the CI test matrix in `lint-build-test.yml`

## **Related issues**

Fixes:

## **Manual testing steps**

1. CI passes on Node 20.x and 22.x

## **Screenshots/Recordings**

### Before

CI ran some workflows with node v18

### After

CI only runs with node v20 & v22

https://github.com/user-attachments/assets/052a25f1-45f7-4fe1-9ca0-5bde6639c8d9

Approximate time savings are only around 13s

<img width="378" height="323" alt="Screenshot 2026-06-02 at 9 23 21 AM" src="https://github.com/user-attachments/assets/9bfd3fe5-59e9-430a-8de7-376986df3a6f" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and engine metadata only; no runtime application logic changes, though consumers still on Node 18 must upgrade before developing or installing.
> 
> **Overview**
> Raises the monorepo’s supported Node.js floor from **18** to **20** now that Node 18 is EOL and downstream MetaMask clients already target newer runtimes.
> 
> Every workspace `package.json` updates `engines.node` from `^18.18 || >=20` to `>=20`, and `yarn.config.cjs` enforces the same via `yarn constraints`. CI in `lint-build-test.yml` drops the **18.x** matrix leg for **prepare** and **test**, so those jobs only run on **20.x** and **22.x** (lint/build/changelog jobs were already 22-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c6c2ada2d116d4d6c5023bac6458b7e02791c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->