### PR TITLE
chore: refactor TextOrChildren to util

### DIFF
--- a/packages/design-system-react-native/src/components/BoxColumn/BoxColumn.tsx
+++ b/packages/design-system-react-native/src/components/BoxColumn/BoxColumn.tsx
@@ -2,7 +2,7 @@ import { BoxFlexDirection } from '@metamask/design-system-shared';
 import React from 'react';
 
 import { Box } from '../Box';
-import { TextOrChildren } from '../temp-components/TextOrChildren';
+import { renderTextOrChildren } from '../utils';
 
 import type { BoxColumnProps } from './BoxColumn.types';
 
@@ -20,7 +20,7 @@ export const BoxColumn = ({
     {...rest}
   >
     {topAccessory}
-    <TextOrChildren textProps={textProps}>{children}</TextOrChildren>
+    {renderTextOrChildren(children, textProps)}
     {bottomAccessory}
   </Box>
 );

--- a/packages/design-system-react-native/src/components/BoxRow/BoxRow.tsx
+++ b/packages/design-system-react-native/src/components/BoxRow/BoxRow.tsx
@@ -5,7 +5,7 @@ import {
 import React from 'react';
 
 import { Box } from '../Box';
-import { TextOrChildren } from '../temp-components/TextOrChildren';
+import { renderTextOrChildren } from '../utils';
 
 import type { BoxRowProps } from './BoxRow.types';
 
@@ -25,7 +25,7 @@ export const BoxRow = ({
     {...rest}
   >
     {startAccessory}
-    <TextOrChildren textProps={textProps}>{children}</TextOrChildren>
+    {renderTextOrChildren(children, textProps)}
     {endAccessory}
   </Box>
 );

--- a/packages/design-system-react-native/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system-react-native/src/components/Checkbox/Checkbox.tsx
@@ -10,7 +10,7 @@ import type { PressableStateCallbackType } from 'react-native';
 import { Pressable, Animated, Easing } from 'react-native';
 
 import { Icon, IconName, IconColor, IconSize } from '../Icon';
-import { TextOrChildren } from '../temp-components/TextOrChildren';
+import { renderTextOrChildren } from '../utils';
 
 import type { CheckboxProps } from './Checkbox.types';
 
@@ -144,13 +144,12 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
                 />
               </Animated.View>
             </AnimatedView>
-            {label ? (
-              <TextOrChildren
-                textProps={{ ...labelProps, twClassName: 'ml-3' }}
-              >
-                {label}
-              </TextOrChildren>
-            ) : null}
+            {label
+              ? renderTextOrChildren(label, {
+                  ...labelProps,
+                  twClassName: 'ml-3',
+                })
+              : null}
           </>
         )}
       </Pressable>

--- a/packages/design-system-react-native/src/components/Content/Content.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { BoxColumn } from '../BoxColumn';
 import { BoxRow } from '../BoxRow';
-import { TextOrChildren } from '../temp-components/TextOrChildren';
+import { renderTextOrChildren } from '../utils';
 
 import { VERTICAL_ALIGNMENT_MAP } from './Content.constants';
 import type { ContentProps } from './Content.types';
@@ -62,16 +62,12 @@ export const Content: React.FC<ContentProps> = ({
               endAccessory={descriptionEndAccessory}
               gap={1}
             >
-              <TextOrChildren
-                textProps={{
-                  variant: TextVariant.BodySm,
-                  fontWeight: FontWeight.Medium,
-                  color: TextColor.TextAlternative,
-                  ...descriptionProps,
-                }}
-              >
-                {description}
-              </TextOrChildren>
+              {renderTextOrChildren(description, {
+                variant: TextVariant.BodySm,
+                fontWeight: FontWeight.Medium,
+                color: TextColor.TextAlternative,
+                ...descriptionProps,
+              })}
             </BoxRow>
           ) : null
         }
@@ -83,16 +79,12 @@ export const Content: React.FC<ContentProps> = ({
             endAccessory={titleEndAccessory}
             gap={1}
           >
-            <TextOrChildren
-              textProps={{
-                variant: TextVariant.BodyMd,
-                fontWeight: FontWeight.Medium,
-                color: TextColor.TextDefault,
-                ...titleProps,
-              }}
-            >
-              {title}
-            </TextOrChildren>
+            {renderTextOrChildren(title, {
+              variant: TextVariant.BodyMd,
+              fontWeight: FontWeight.Medium,
+              color: TextColor.TextDefault,
+              ...titleProps,
+            })}
           </BoxRow>
         ) : null}
       </BoxColumn>
@@ -108,16 +100,12 @@ export const Content: React.FC<ContentProps> = ({
                 endAccessory={subvalueEndAccessory}
                 gap={1}
               >
-                <TextOrChildren
-                  textProps={{
-                    variant: TextVariant.BodySm,
-                    fontWeight: FontWeight.Medium,
-                    color: TextColor.TextAlternative,
-                    ...subvalueProps,
-                  }}
-                >
-                  {subvalue}
-                </TextOrChildren>
+                {renderTextOrChildren(subvalue, {
+                  variant: TextVariant.BodySm,
+                  fontWeight: FontWeight.Medium,
+                  color: TextColor.TextAlternative,
+                  ...subvalueProps,
+                })}
               </BoxRow>
             ) : null
           }
@@ -129,16 +117,12 @@ export const Content: React.FC<ContentProps> = ({
               endAccessory={valueEndAccessory}
               gap={1}
             >
-              <TextOrChildren
-                textProps={{
-                  variant: TextVariant.BodyMd,
-                  fontWeight: FontWeight.Medium,
-                  color: TextColor.TextDefault,
-                  ...valueProps,
-                }}
-              >
-                {value}
-              </TextOrChildren>
+              {renderTextOrChildren(value, {
+                variant: TextVariant.BodyMd,
+                fontWeight: FontWeight.Medium,
+                color: TextColor.TextDefault,
+                ...valueProps,
+              })}
             </BoxRow>
           ) : null}
         </BoxColumn>

--- a/packages/design-system-react-native/src/components/HeaderBase/HeaderBase.tsx
+++ b/packages/design-system-react-native/src/components/HeaderBase/HeaderBase.tsx
@@ -9,7 +9,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 // External dependencies.
 import { ButtonIcon, ButtonIconSize } from '../ButtonIcon';
 import type { ButtonIconProps } from '../ButtonIcon';
-import { TextOrChildren } from '../temp-components/TextOrChildren';
+import { renderTextOrChildren } from '../utils';
 
 import type { HeaderBaseProps } from './HeaderBase.types';
 
@@ -174,15 +174,11 @@ export const HeaderBase: React.FC<HeaderBaseProps> = ({
 
       {/* Title */}
       <View style={tw.style('flex-1 items-center')} {...childrenWrapperProps}>
-        <TextOrChildren
-          textProps={{
-            variant: TextVariant.HeadingSm,
-            ...textProps,
-            style: [tw.style('text-center'), textProps?.style],
-          }}
-        >
-          {children}
-        </TextOrChildren>
+        {renderTextOrChildren(children, {
+          variant: TextVariant.HeadingSm,
+          ...textProps,
+          style: [tw.style('text-center'), textProps?.style],
+        })}
       </View>
 
       {/* End accessory */}

--- a/packages/design-system-react-native/src/components/RadioButton/RadioButton.tsx
+++ b/packages/design-system-react-native/src/components/RadioButton/RadioButton.tsx
@@ -2,7 +2,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
 import { View, TouchableOpacity } from 'react-native';
 
-import { TextOrChildren } from '../temp-components/TextOrChildren';
+import { renderTextOrChildren } from '../utils';
 
 import type { RadioButtonProps } from './RadioButton.types';
 
@@ -99,11 +99,9 @@ export const RadioButton = ({
             />
           )}
         </View>
-        {label ? (
-          <TextOrChildren textProps={{ ...labelProps, twClassName: 'ml-3' }}>
-            {label}
-          </TextOrChildren>
-        ) : null}
+        {label
+          ? renderTextOrChildren(label, { ...labelProps, twClassName: 'ml-3' })
+          : null}
       </TouchableOpacity>
     </View>
   );

--- a/packages/design-system-react-native/src/components/TitleAlert/TitleAlert.tsx
+++ b/packages/design-system-react-native/src/components/TitleAlert/TitleAlert.tsx
@@ -12,7 +12,7 @@ import { Box } from '../Box';
 import { BoxColumn } from '../BoxColumn';
 import { BoxRow } from '../BoxRow';
 import { IconAlert } from '../IconAlert';
-import { TextOrChildren } from '../temp-components/TextOrChildren';
+import { renderTextOrChildren } from '../utils';
 
 import type { TitleAlertProps } from './TitleAlert.types';
 
@@ -53,17 +53,13 @@ export const TitleAlert: React.FC<TitleAlertProps> = ({
       bottomAccessory={
         description ? (
           <Box twClassName="self-stretch">
-            <TextOrChildren
-              textProps={{
-                variant: TextVariant.BodySm,
-                color: TextColor.TextAlternative,
-                fontWeight: FontWeight.Medium,
-                ...descriptionProps,
-                style: [{ textAlign: 'center' }, descriptionProps?.style],
-              }}
-            >
-              {description}
-            </TextOrChildren>
+            {renderTextOrChildren(description, {
+              variant: TextVariant.BodySm,
+              color: TextColor.TextAlternative,
+              fontWeight: FontWeight.Medium,
+              ...descriptionProps,
+              style: [{ textAlign: 'center' }, descriptionProps?.style],
+            })}
           </Box>
         ) : undefined
       }

--- a/packages/design-system-react-native/src/components/temp-components/HeaderStandardCenterColumn/HeaderStandardCenterColumn.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/HeaderStandardCenterColumn/HeaderStandardCenterColumn.tsx
@@ -6,7 +6,7 @@ import { BoxAlignItems } from '../../Box';
 import { BoxColumn } from '../../BoxColumn';
 import type { TextProps } from '../../Text';
 import { FontWeight, TextColor, TextVariant } from '../../Text';
-import { TextOrChildren } from '../TextOrChildren';
+import { renderTextOrChildren } from '../../utils';
 
 // Internal dependencies.
 import type { HeaderStandardCenterColumnProps } from './HeaderStandardCenterColumn.types';
@@ -38,11 +38,7 @@ export function HeaderStandardCenterColumn({
         ...titleProps,
       }}
       bottomAccessory={
-        subtitle ? (
-          <TextOrChildren textProps={subtitleTextProps}>
-            {subtitle}
-          </TextOrChildren>
-        ) : undefined
+        subtitle ? renderTextOrChildren(subtitle, subtitleTextProps) : undefined
       }
     >
       {title}

--- a/packages/design-system-react-native/src/components/temp-components/TextOrChildren/TextOrChildren.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/TextOrChildren/TextOrChildren.tsx
@@ -1,15 +1,17 @@
-import React from 'react';
-
-import { Text } from '../../Text';
+import { renderTextOrChildren } from '../../utils';
 
 import type { TextOrChildrenProps } from './TextOrChildren.types';
 
-export const TextOrChildren = ({
-  children,
-  textProps,
-}: TextOrChildrenProps) => {
-  if (typeof children === 'string') {
-    return <Text {...textProps}>{children}</Text>;
-  }
-  return <>{children}</>;
-};
+/**
+ * Renders string children with the design-system `Text` component and returns
+ * non-string children directly.
+ *
+ * @param options0 - TextOrChildren props.
+ * @param options0.children - Content to render.
+ * @param options0.textProps - Props applied when string children are rendered as `Text`.
+ * @returns Rendered text or children.
+ * @deprecated Use explicit `Text` for string content, or use the internal
+ * `renderTextOrChildren` helper inside design-system implementation code.
+ */
+export const TextOrChildren = ({ children, textProps }: TextOrChildrenProps) =>
+  renderTextOrChildren(children, textProps);

--- a/packages/design-system-react-native/src/components/utils/index.ts
+++ b/packages/design-system-react-native/src/components/utils/index.ts
@@ -1,0 +1,1 @@
+export { renderTextOrChildren } from './renderTextOrChildren';

--- a/packages/design-system-react-native/src/components/utils/renderTextOrChildren.test.tsx
+++ b/packages/design-system-react-native/src/components/utils/renderTextOrChildren.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import { Text } from '../Text';
+
+import { renderTextOrChildren } from './renderTextOrChildren';
+
+describe('renderTextOrChildren', () => {
+  it('renders Text component when children is a string', () => {
+    const { getByText } = render(<>{renderTextOrChildren('Sample Text')}</>);
+    expect(getByText('Sample Text')).toBeDefined();
+  });
+
+  it('passes textProps when children is a string', () => {
+    const { getByTestId } = render(
+      <>
+        {renderTextOrChildren('Sample Text', {
+          testID: 'sample-text',
+        })}
+      </>,
+    );
+
+    expect(getByTestId('sample-text')).toBeDefined();
+  });
+
+  it('renders child components when children is not a string', () => {
+    const { getByText } = render(
+      <>{renderTextOrChildren(<Text>Nested Text</Text>)}</>,
+    );
+
+    expect(getByText('Nested Text')).toBeDefined();
+  });
+
+  it('returns null when children is null', () => {
+    expect(renderTextOrChildren(null)).toBeNull();
+  });
+});

--- a/packages/design-system-react-native/src/components/utils/renderTextOrChildren.tsx
+++ b/packages/design-system-react-native/src/components/utils/renderTextOrChildren.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+
+import { Text } from '../Text';
+import type { TextProps } from '../Text';
+
+export const renderTextOrChildren = (
+  children: ReactNode,
+  textProps?: Omit<Partial<TextProps>, 'children'>,
+) => {
+  if (typeof children === 'string') {
+    return <Text {...textProps}>{children}</Text>;
+  }
+  return children;
+};


### PR DESCRIPTION
## **Description**

Refactors React Native internal `TextOrChildren` usage to reduce unnecessary component layers in common layout primitives. Adds an internal `renderTextOrChildren` helper under `components/utils`, updates internal production components to use it directly, and keeps the public `TextOrChildren` component exported as a deprecated compatibility wrapper.

This reduces React DevTools tree depth for components such as `BoxRow`, `BoxColumn`, and consumers that render simple string content, without changing the public behavior of those components.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn workspace @metamask/design-system-react-native test:verbose renderTextOrChildren.test.tsx TextOrChildren.test.tsx BoxRow.test.tsx BoxColumn.test.tsx --runInBand --coverage=false`.
2. Run `yarn workspace @metamask/design-system-react-native test:verbose Content.test.tsx HeaderBase.test.tsx TitleAlert.test.tsx HeaderStandardCenterColumn.test.tsx RadioButton.test.tsx Checkbox.test.tsx --runInBand --coverage=false`.
3. Inspect a simple `BoxRow` or `SectionHeader` in React Native DevTools and confirm the `TextOrChildren` component layer is no longer present in internal render paths.

## **Screenshots/Recordings**

### **Before**
<img width="424" height="137" alt="Screenshot 2026-06-03 at 5 12 19 PM" src="https://github.com/user-attachments/assets/2ac6b31b-e653-4479-93b1-15fb27d07ea7" />

--

<img width="328" height="460" alt="Screenshot 2026-06-03 at 5 25 03 PM" src="https://github.com/user-attachments/assets/27e3d5a3-e42a-49a5-b36f-368433c0a8cd" />

--

<img width="425" height="121" alt="Screenshot 2026-06-03 at 5 12 05 PM" src="https://github.com/user-attachments/assets/9997c36b-4479-4a66-b763-4ca1f57a47d4" />

--

<img width="272" height="260" alt="Screenshot 2026-06-03 at 5 25 20 PM" src="https://github.com/user-attachments/assets/cbfedc08-fd71-469f-8272-f899074bc3e6" />

### **After**


<img width="424" height="137" alt="Screenshot 2026-06-03 at 5 12 19 PM" src="https://github.com/user-attachments/assets/b9df351c-ddbb-4e64-8aa8-f8b1f07022c1" />

--

<img width="277" height="383" alt="Screenshot 2026-06-03 at 5 11 28 PM" src="https://github.com/user-attachments/assets/187bd933-bc53-455b-9436-44cb36f2461e" />

--

<img width="425" height="121" alt="Screenshot 2026-06-03 at 5 12 05 PM" src="https://github.com/user-attachments/assets/2a1cf5ac-d677-44af-b6e0-2857bcaf36c9" />

--

<img width="197" height="214" alt="Screenshot 2026-06-03 at 5 11 58 PM" src="https://github.com/user-attachments/assets/ce8b1c41-fc25-4b67-9533-465d4ad13c11" />

## **Pre-merge author checklist**

- [ ] I have followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I have completed the PR template to the best of my ability
- [x] I have included tests if applicable
- [x] I have documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I have applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I have manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal rendering refactor with preserved public API and added tests; no auth, data, or behavioral contract changes beyond fewer wrapper components in the tree.
> 
> **Overview**
> Introduces an internal **`renderTextOrChildren`** helper under `components/utils` and switches several React Native layout primitives (**`BoxRow`**, **`BoxColumn`**, **`Content`**, **`HeaderBase`**, **`Checkbox`**, **`RadioButton`**, **`TitleAlert`**, **`HeaderStandardCenterColumn`**) to call it inline instead of wrapping content in **`TextOrChildren`**.
> 
> Behavior is unchanged: strings still render as **`Text`** with the given props; non-string nodes pass through. The public **`TextOrChildren`** export remains as a **deprecated** thin wrapper around the helper, with new unit tests for the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9db69ad9b8e548c2683c0442e28ca32df0de4d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->