### PR TITLE
fix: Storybook RN controls type import

### DIFF
--- a/.yarn/patches/@storybook-addon-ondevice-controls-npm-10.4.4-6e8c0f15d9.patch
+++ b/.yarn/patches/@storybook-addon-ondevice-controls-npm-10.4.4-6e8c0f15d9.patch
@@ -23,7 +23,7 @@ index f5247c7674cb2e788daf47b343bc6f5708715024..1a9c0961c21a514b8f592b1bcca795f2
  import { jsxs as _jsxs, jsx as _jsx } from "react/jsx-runtime";
  import { styled } from '@storybook/react-native-theming';
 -import TypeMap from './types';
-+import TypeMap from './types.js';
++import TypeMap from './types/index.js';
  const InvalidTypeText = styled.Text(({ theme }) => ({
      color: theme.color.negative,
  }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4873,7 +4873,7 @@ __metadata:
 
 "@storybook/addon-ondevice-controls@patch:@storybook/addon-ondevice-controls@npm%3A10.4.4#~/.yarn/patches/@storybook-addon-ondevice-controls-npm-10.4.4-6e8c0f15d9.patch":
   version: 10.4.4
-  resolution: "@storybook/addon-ondevice-controls@patch:@storybook/addon-ondevice-controls@npm%3A10.4.4#~/.yarn/patches/@storybook-addon-ondevice-controls-npm-10.4.4-6e8c0f15d9.patch::version=10.4.4&hash=16f846"
+  resolution: "@storybook/addon-ondevice-controls@patch:@storybook/addon-ondevice-controls@npm%3A10.4.4#~/.yarn/patches/@storybook-addon-ondevice-controls-npm-10.4.4-6e8c0f15d9.patch::version=10.4.4&hash=63d90c"
   dependencies:
     "@gorhom/portal": "npm:^1.0.14"
     "@storybook/react-native-theming": "npm:^10.4.4"
@@ -4891,7 +4891,7 @@ __metadata:
   peerDependenciesMeta:
     "@gorhom/bottom-sheet":
       optional: true
-  checksum: 10/e0360a59720484e63bfbc93d57e9b1c98f5a3bd201284a0f2a2fc3bfb5e8aced89408a30bad1e8d8dd124f2f6d29a5fac1ced33ee4b730527b288675eff1fe5d
+  checksum: 10/be492ea7ffbc628300fd35055588b0cc5a548a63db452956c06fc49151fc0ab73f067bbbd913e7dfe5c6ef3f8e90479ae8f2477e806ad1df60533bcdb0f25f33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Fixes the React Native Storybook iOS bundle failure from `@storybook/addon-ondevice-controls`.

The existing Yarn patch changed `PropField.js` from `./types` to `./types.js`, but the published package does not contain `dist/types.js`. It contains `dist/types/index.js`, so Metro could not resolve the controls addon during bundling.

This updates the patch to import `./types/index.js` and refreshes the Yarn lock hash/checksum for the patched package.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn install`
2. Run `yarn workspace @metamask/storybook-react-native prestorybook`
3. Run `yarn workspace @metamask/storybook-react-native exec expo export --platform ios --output-dir /tmp/mmds-storybook-rn-export`

## **Screenshots/Recordings**

N/A. This is a Metro bundling fix.

### **Before**

React Native Storybook iOS bundling failed resolving `./types.js` from `node_modules/@storybook/addon-ondevice-controls/dist/PropField.js`.

<img width="221" height="453" alt="Screenshot 2026-06-08 at 10 37 36 AM" src="https://github.com/user-attachments/assets/c450043f-9fa5-428f-8736-d90ea05109a0" />

### **After**

React Native Storybook iOS export completes successfully.

<img width="222" height="487" alt="Screenshot 2026-06-08 at 10 36 42 AM" src="https://github.com/user-attachments/assets/d7cb88a3-0b9c-4bda-97a7-005d268c28cc" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency patch and lockfile metadata only; no application runtime or security logic changes.
> 
> **Overview**
> Fixes React Native Storybook iOS bundling by correcting the **TypeMap** import in the existing Yarn patch for `@storybook/addon-ondevice-controls`.
> 
> In `PropField.js`, the patch had pointed Metro at `./types.js`, which is not shipped in the package; the addon only exposes `dist/types/index.js`. The import is updated to `./types/index.js`, and `yarn.lock` is refreshed with the new patch resolution hash and checksum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 563df71477c773c3ff4001cf930f1872fa1d070e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->