### PR TITLE
chore: points icon imports to shared

### DIFF
--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.test.tsx
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.test.tsx
@@ -1,9 +1,12 @@
-import { BoxBackgroundColor } from '@metamask/design-system-shared';
+import {
+  BoxBackgroundColor,
+  IconColor,
+  IconName,
+} from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { render } from '@testing-library/react-native';
 import React from 'react';
 
-import { IconColor, IconName } from '../../types';
 import { BannerBase } from '../BannerBase';
 
 import { BannerAlert } from './BannerAlert';

--- a/packages/design-system-react-native/src/components/Icon/Icon.constants.ts
+++ b/packages/design-system-react-native/src/components/Icon/Icon.constants.ts
@@ -1,4 +1,4 @@
-import { IconSize } from '../../types';
+import { IconSize } from '@metamask/design-system-shared';
 
 export const TWCLASSMAP_ICON_SIZE_DIMENSION: Record<IconSize, string> = {
   [IconSize.Xs]: 'w-3 h-3', // 12px

--- a/packages/design-system-react-native/src/components/Icon/Icon.stories.tsx
+++ b/packages/design-system-react-native/src/components/Icon/Icon.stories.tsx
@@ -1,9 +1,8 @@
+import { IconColor, IconName, IconSize } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import React from 'react';
 import { ScrollView, View } from 'react-native';
-
-import { IconColor, IconName, IconSize } from '../../types';
 
 import { Icon } from './Icon';
 import type { IconProps } from './Icon.types';

--- a/packages/design-system-react-native/src/components/Icon/Icon.test.tsx
+++ b/packages/design-system-react-native/src/components/Icon/Icon.test.tsx
@@ -1,8 +1,7 @@
+import { IconColor, IconName, IconSize } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { render } from '@testing-library/react-native';
 import React from 'react';
-
-import { IconColor, IconName, IconSize } from '../../types';
 
 import { Icon } from './Icon';
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from './Icon.constants';

--- a/packages/design-system-react-native/src/components/IconAlert/IconAlert.stories.tsx
+++ b/packages/design-system-react-native/src/components/IconAlert/IconAlert.stories.tsx
@@ -1,8 +1,7 @@
-import { IconAlertSeverity } from '@metamask/design-system-shared';
+import { IconAlertSeverity, IconSize } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import React from 'react';
 
-import { IconSize } from '../../types';
 import {
   Box,
   BoxAlignItems,

--- a/packages/design-system-react-native/src/components/IconAlert/IconAlert.test.tsx
+++ b/packages/design-system-react-native/src/components/IconAlert/IconAlert.test.tsx
@@ -1,9 +1,8 @@
-import { IconAlertSeverity } from '@metamask/design-system-shared';
+import { IconAlertSeverity, IconSize } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { render, renderHook } from '@testing-library/react-native';
 import React from 'react';
 
-import { IconSize } from '../../types';
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from '../Icon/Icon.constants';
 
 import { IconAlert } from './IconAlert';

--- a/packages/design-system-react-native/src/components/KeyValueColumn/KeyValueColumn.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueColumn/KeyValueColumn.tsx
@@ -1,12 +1,12 @@
 import {
   ButtonIconSize,
   FontWeight,
+  IconColor,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-shared';
 import React from 'react';
 
-import { IconColor } from '../../types';
 import { BoxColumn } from '../BoxColumn';
 import { BoxRow } from '../BoxRow';
 import { ButtonIcon } from '../ButtonIcon';

--- a/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.tsx
@@ -1,6 +1,7 @@
 import {
   ButtonIconSize,
   FontWeight,
+  IconColor,
   KeyValueRowVariant,
   TextColor,
   TextVariant,
@@ -8,7 +9,6 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
 
-import { IconColor } from '../../types';
 import { Box } from '../Box';
 import { BoxRow } from '../BoxRow';
 import { ButtonIcon } from '../ButtonIcon';

--- a/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.test.tsx
+++ b/packages/design-system-react-native/src/components/SegmentButton/SegmentButton.test.tsx
@@ -1,4 +1,7 @@
 import {
+  IconColor,
+  IconName,
+  IconSize,
   SegmentButtonVariant,
   TextColor,
 } from '@metamask/design-system-shared';
@@ -6,7 +9,6 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { fireEvent, render, renderHook } from '@testing-library/react-native';
 import React from 'react';
 
-import { IconColor, IconName, IconSize } from '../../types';
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from '../Icon/Icon.constants';
 import { SegmentGroup } from '../SegmentGroup/SegmentGroup';
 

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.constants.ts
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.constants.ts
@@ -1,6 +1,4 @@
-import { SelectButtonEndArrow } from '@metamask/design-system-shared';
-
-import { IconName } from '../../types';
+import { IconName, SelectButtonEndArrow } from '@metamask/design-system-shared';
 
 export const MAP_SELECTBUTTON_END_ARROW_DIRECTION_TO_ICON_NAME: Record<
   (typeof SelectButtonEndArrow)[keyof typeof SelectButtonEndArrow],

--- a/packages/design-system-react-native/src/components/SelectButton/SelectButton.test.tsx
+++ b/packages/design-system-react-native/src/components/SelectButton/SelectButton.test.tsx
@@ -1,4 +1,7 @@
 import {
+  IconColor,
+  IconName,
+  IconSize,
   SelectButtonEndArrow,
   SelectButtonVariant,
   TextColor,
@@ -8,7 +11,6 @@ import { fireEvent, render, renderHook } from '@testing-library/react-native';
 import React from 'react';
 import { View } from 'react-native';
 
-import { IconColor, IconName, IconSize } from '../../types';
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from '../Icon/Icon.constants';
 
 import { SelectButton } from './SelectButton';

--- a/packages/design-system-react-native/src/types/index.ts
+++ b/packages/design-system-react-native/src/types/index.ts
@@ -3,8 +3,7 @@ export {
   AvatarBaseShape,
 } from '@metamask/design-system-shared';
 /**
- * TODO: Remove the following exports and update imports in components to import directly from `@metamask/design-system-shared` once all components have been migrated to React Native.
+ * TODO: Remove the following aliases and update imports in components to import directly from `@metamask/design-system-shared` once all components have been migrated to React Native.
  */
-export { IconColor, IconName, IconSize } from '@metamask/design-system-shared';
 export { AvatarBaseSize as AvatarNetworkSize } from '@metamask/design-system-shared';
 export { AvatarBaseSize as AvatarSize } from '@metamask/design-system-shared';

--- a/packages/design-system-react-native/src/types/index.ts
+++ b/packages/design-system-react-native/src/types/index.ts
@@ -1,9 +1,9 @@
+/**
+ * TODO: Remove the following aliases and update imports in components to import directly from `@metamask/design-system-shared` once all components have been migrated to React Native.
+ */
 export {
   AvatarBaseSize,
   AvatarBaseShape,
 } from '@metamask/design-system-shared';
-/**
- * TODO: Remove the following aliases and update imports in components to import directly from `@metamask/design-system-shared` once all components have been migrated to React Native.
- */
 export { AvatarBaseSize as AvatarNetworkSize } from '@metamask/design-system-shared';
 export { AvatarBaseSize as AvatarSize } from '@metamask/design-system-shared';

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.constants.ts
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.constants.ts
@@ -2,9 +2,9 @@ import {
   BannerAlertSeverity,
   BoxBackgroundColor,
   BoxBorderColor,
+  IconColor,
+  IconName,
 } from '@metamask/design-system-shared';
-
-import { IconColor, IconName } from '../../types';
 
 export const MAP_BANNER_ALERT_SEVERITY_ICON_NAME: Record<
   (typeof BannerAlertSeverity)[keyof typeof BannerAlertSeverity],

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.test.tsx
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.test.tsx
@@ -1,8 +1,6 @@
-import { BoxBackgroundColor } from '@metamask/design-system-shared';
+import { BoxBackgroundColor, IconColor } from '@metamask/design-system-shared';
 import { render } from '@testing-library/react';
 import React from 'react';
-
-import { IconColor } from '../../types';
 
 import { BannerAlert } from './BannerAlert';
 

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.tsx
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.tsx
@@ -1,7 +1,6 @@
-import { BannerAlertSeverity } from '@metamask/design-system-shared';
+import { BannerAlertSeverity, IconSize } from '@metamask/design-system-shared';
 import React, { forwardRef } from 'react';
 
-import { IconSize } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
 import { BannerBase } from '../BannerBase';
 import { Icon } from '../Icon';

--- a/packages/design-system-react/src/components/Icon/Icon.constants.ts
+++ b/packages/design-system-react/src/components/Icon/Icon.constants.ts
@@ -1,4 +1,4 @@
-import { IconSize } from '../../types';
+import { IconSize } from '@metamask/design-system-shared';
 
 export const TWCLASSMAP_ICON_SIZE_DIMENSION: Record<IconSize, string> = {
   [IconSize.Xs]: 'w-3 h-3', // 12px

--- a/packages/design-system-react/src/components/Icon/Icon.stories.tsx
+++ b/packages/design-system-react/src/components/Icon/Icon.stories.tsx
@@ -1,8 +1,12 @@
-import { TextVariant } from '@metamask/design-system-shared';
+import {
+  IconColor,
+  IconName,
+  IconSize,
+  TextVariant,
+} from '@metamask/design-system-shared';
 import type { StoryObj } from '@storybook/react-vite';
 import React, { useState } from 'react';
 
-import { IconName, IconSize, IconColor } from '../../types';
 import { Text } from '../Text/Text';
 
 import { Icon } from './Icon';

--- a/packages/design-system-react/src/components/Icon/Icon.test.tsx
+++ b/packages/design-system-react/src/components/Icon/Icon.test.tsx
@@ -1,7 +1,6 @@
+import { IconName, IconSize, IconColor } from '@metamask/design-system-shared';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-
-import { IconName, IconSize, IconColor } from '../../types';
 
 import { Icon } from './Icon';
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from './Icon.constants';

--- a/packages/design-system-react/src/components/Icon/Icon.tsx
+++ b/packages/design-system-react/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
+import { IconSize, IconColor } from '@metamask/design-system-shared';
 import React from 'react';
 
-import { IconSize, IconColor } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
 
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from './Icon.constants';

--- a/packages/design-system-react/src/components/Icon/index.ts
+++ b/packages/design-system-react/src/components/Icon/index.ts
@@ -1,3 +1,3 @@
-export { IconName, IconSize, IconColor } from '../../types';
+export { IconName, IconSize, IconColor } from '@metamask/design-system-shared';
 export { Icon } from './Icon';
 export type { IconProps } from './Icon.types';

--- a/packages/design-system-react/src/components/Tag/Tag.constants.ts
+++ b/packages/design-system-react/src/components/Tag/Tag.constants.ts
@@ -1,10 +1,9 @@
 import {
   BoxBackgroundColor,
+  IconColor,
   TagSeverity,
   TextColor,
 } from '@metamask/design-system-shared';
-
-import { IconColor } from '../../types';
 
 export const MAP_TAG_SEVERITY_BACKGROUND: Record<
   TagSeverity,

--- a/packages/design-system-react/src/components/Tag/Tag.figma.tsx
+++ b/packages/design-system-react/src/components/Tag/Tag.figma.tsx
@@ -1,10 +1,8 @@
 // import figma needs to remain as figma otherwise it breaks code connect
 // eslint-disable-next-line import-x/no-named-as-default
 import figma from '@figma/code-connect';
-import { TagSeverity } from '@metamask/design-system-shared';
+import { IconName, TagSeverity } from '@metamask/design-system-shared';
 import React from 'react';
-
-import { IconName } from '../../types';
 
 import { Tag } from './Tag';
 

--- a/packages/design-system-react/src/components/Tag/Tag.stories.tsx
+++ b/packages/design-system-react/src/components/Tag/Tag.stories.tsx
@@ -1,8 +1,6 @@
-import { TagSeverity } from '@metamask/design-system-shared';
+import { IconName, TagSeverity } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
-
-import { IconName } from '../../types';
 
 import README from './README.mdx';
 import { Tag } from './Tag';

--- a/packages/design-system-react/src/components/Tag/Tag.test.tsx
+++ b/packages/design-system-react/src/components/Tag/Tag.test.tsx
@@ -1,8 +1,7 @@
-import { TagSeverity } from '@metamask/design-system-shared';
+import { IconName, TagSeverity } from '@metamask/design-system-shared';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { IconName } from '../../types';
 import { TextColor } from '../Text';
 
 import { Tag } from './Tag';

--- a/packages/design-system-react/src/components/Tag/Tag.tsx
+++ b/packages/design-system-react/src/components/Tag/Tag.tsx
@@ -2,12 +2,12 @@ import {
   BoxAlignItems,
   BoxFlexDirection,
   FontWeight,
+  IconSize,
   TagSeverity,
   TextVariant,
 } from '@metamask/design-system-shared';
 import React, { forwardRef } from 'react';
 
-import { IconSize } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
 import { Box } from '../Box';
 import { Icon } from '../Icon';

--- a/packages/design-system-react/src/components/Tag/Tag.types.ts
+++ b/packages/design-system-react/src/components/Tag/Tag.types.ts
@@ -1,7 +1,7 @@
 import type { TagPropsShared } from '@metamask/design-system-shared';
+import type { IconName } from '@metamask/design-system-shared';
 import type { ComponentProps } from 'react';
 
-import type { IconName } from '../../types';
 import type { IconProps } from '../Icon';
 
 /**

--- a/packages/design-system-react/src/components/Toast/Toast.constants.ts
+++ b/packages/design-system-react/src/components/Toast/Toast.constants.ts
@@ -1,6 +1,8 @@
-import { ToastSeverity } from '@metamask/design-system-shared';
-
-import { IconColor, IconName } from '../../types';
+import {
+  IconColor,
+  IconName,
+  ToastSeverity,
+} from '@metamask/design-system-shared';
 
 export {
   TOAST_ANIMATION_DURATION,

--- a/packages/design-system-react/src/components/Toast/Toast.tsx
+++ b/packages/design-system-react/src/components/Toast/Toast.tsx
@@ -2,11 +2,11 @@ import {
   BoxBackgroundColor,
   BoxBorderColor,
   ButtonSize,
+  IconSize,
   ToastSeverity,
 } from '@metamask/design-system-shared';
 import React, { forwardRef } from 'react';
 
-import { IconSize } from '../../types';
 import { twMerge } from '../../utils/tw-merge';
 import { BannerBase } from '../BannerBase';
 import { Icon } from '../Icon';

--- a/packages/design-system-react/src/types/index.ts
+++ b/packages/design-system-react/src/types/index.ts
@@ -1,11 +1,10 @@
+/**
+ * TODO: Remove the following aliases and update imports in components to import directly from `@metamask/design-system-shared` once all components have been migrated to React Native.
+ */
 export {
   AvatarBaseSize,
   AvatarBaseShape,
 } from '@metamask/design-system-shared';
-/**
- * TODO: Remove the following exports and update imports in components to import directly from `@metamask/design-system-shared` once all components have been migrated to React Native.
- */
-export { IconColor, IconName, IconSize } from '@metamask/design-system-shared';
 export { AvatarBaseSize as AvatarNetworkSize } from '@metamask/design-system-shared';
 export { AvatarBaseSize as AvatarSize } from '@metamask/design-system-shared';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates React and React Native component imports so `IconColor`, `IconName`, and `IconSize` are imported directly from `@metamask/design-system-shared` instead of going through each package's local `../../types` re-export.

This keeps icon symbols aligned with the shared package as the single source of truth and removes the remaining package-local indirection for icon types/constants.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn eslint` on the changed files.
2. Run `git diff --check`.
3. Search for remaining `IconColor`, `IconName`, or `IconSize` imports from `../../types`.

## **Screenshots/Recordings**

N/A - import-only cleanup.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with no runtime or API behavior changes beyond where symbols are imported from.
> 
> **Overview**
> **Icon types now come straight from `@metamask/design-system-shared`** in both `design-system-react` and `design-system-react-native`. Components, tests, stories, and constants that used `IconColor`, `IconName`, or `IconSize` from each package’s `../../types` barrel now import those symbols from shared instead.
> 
> The local **`src/types/index.ts` re-exports for those three icon symbols are removed** (avatar aliases stay). On web, **`Icon`’s public barrel** re-exports `IconName`, `IconSize`, and `IconColor` from shared rather than from `../../types`.
> 
> No component behavior changes—this is import-path cleanup so shared is the single source of truth for icon enums/constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4efcfe744e46282b71b3ccdceb68ee32c39e5b76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->