### PR TITLE
chore: use shared avatar types

### DIFF
--- a/packages/design-system-react-native/src/components/AvatarNetwork/AvatarNetwork.stories.tsx
+++ b/packages/design-system-react-native/src/components/AvatarNetwork/AvatarNetwork.stories.tsx
@@ -1,7 +1,6 @@
+import { AvatarNetworkSize } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import { View } from 'react-native';
-
-import { AvatarNetworkSize } from '../../types';
 
 import { AvatarNetwork } from './AvatarNetwork';
 import { SAMPLE_AVATARNETWORK_URIS } from './AvatarNetwork.dev';

--- a/packages/design-system-react-native/src/components/AvatarNetwork/AvatarNetwork.tsx
+++ b/packages/design-system-react-native/src/components/AvatarNetwork/AvatarNetwork.tsx
@@ -1,8 +1,10 @@
-import { AvatarBaseShape } from '@metamask/design-system-shared';
+import {
+  AvatarBaseShape,
+  AvatarNetworkSize,
+} from '@metamask/design-system-shared';
 import React, { useState } from 'react';
 import type { ImageErrorEvent } from 'react-native';
 
-import { AvatarNetworkSize } from '../../types';
 import { AvatarBase } from '../AvatarBase';
 import { ImageOrSvg } from '../temp-components/ImageOrSvg';
 

--- a/packages/design-system-react-native/src/components/AvatarNetwork/index.ts
+++ b/packages/design-system-react-native/src/components/AvatarNetwork/index.ts
@@ -1,3 +1,3 @@
-export { AvatarNetworkSize } from '../../types';
+export { AvatarNetworkSize } from '@metamask/design-system-shared';
 export { AvatarNetwork } from './AvatarNetwork';
 export type { AvatarNetworkProps } from './AvatarNetwork.types';

--- a/packages/design-system-react-native/src/types/index.ts
+++ b/packages/design-system-react-native/src/types/index.ts
@@ -1,9 +1,0 @@
-/**
- * TODO: Remove the following aliases and update imports in components to import directly from `@metamask/design-system-shared` once all components have been migrated to React Native.
- */
-export {
-  AvatarBaseSize,
-  AvatarBaseShape,
-} from '@metamask/design-system-shared';
-export { AvatarBaseSize as AvatarNetworkSize } from '@metamask/design-system-shared';
-export { AvatarBaseSize as AvatarSize } from '@metamask/design-system-shared';

--- a/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.stories.tsx
+++ b/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.stories.tsx
@@ -1,7 +1,6 @@
+import { AvatarNetworkSize } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
-
-import { AvatarNetworkSize } from '../../types';
 
 import { AvatarNetwork } from './AvatarNetwork';
 import { SAMPLE_AVATARNETWORK_URIS } from './AvatarNetwork.dev';

--- a/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.test.tsx
+++ b/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.test.tsx
@@ -1,7 +1,7 @@
+import { AvatarNetworkSize } from '@metamask/design-system-shared';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React, { createRef } from 'react';
 
-import { AvatarNetworkSize } from '../../types';
 import {
   TWCLASSMAP_AVATARBASE_SIZE_DIMENSION,
   TWCLASSMAP_AVATARBASE_SIZE_BORDER,

--- a/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.tsx
+++ b/packages/design-system-react/src/components/AvatarNetwork/AvatarNetwork.tsx
@@ -1,7 +1,9 @@
-import { AvatarBaseShape } from '@metamask/design-system-shared';
+import {
+  AvatarBaseShape,
+  AvatarNetworkSize,
+} from '@metamask/design-system-shared';
 import React, { forwardRef, useState } from 'react';
 
-import { AvatarNetworkSize } from '../../types';
 import { AvatarBase } from '../AvatarBase';
 
 import type { AvatarNetworkProps } from './AvatarNetwork.types';

--- a/packages/design-system-react/src/components/AvatarNetwork/index.ts
+++ b/packages/design-system-react/src/components/AvatarNetwork/index.ts
@@ -1,3 +1,3 @@
-export { AvatarNetworkSize } from '../../types';
+export { AvatarNetworkSize } from '@metamask/design-system-shared';
 export { AvatarNetwork } from './AvatarNetwork';
 export type { AvatarNetworkProps } from './AvatarNetwork.types';

--- a/packages/design-system-react/src/types/index.ts
+++ b/packages/design-system-react/src/types/index.ts
@@ -1,13 +1,6 @@
 /**
- * TODO: Remove the following aliases and update imports in components to import directly from `@metamask/design-system-shared` once all components have been migrated to React Native.
+ * TODO: Align react native and react types and move to shared types package
  */
-export {
-  AvatarBaseSize,
-  AvatarBaseShape,
-} from '@metamask/design-system-shared';
-export { AvatarBaseSize as AvatarNetworkSize } from '@metamask/design-system-shared';
-export { AvatarBaseSize as AvatarSize } from '@metamask/design-system-shared';
-
 /**
  * Text - textAlign
  */

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -109,8 +109,11 @@ export {
 // Button types (ADR-0003 + ADR-0004)
 export { ButtonVariant, type ButtonPropsShared } from './types/Button';
 
-// AvatarNetwork types (ADR-0004)
-export { type AvatarNetworkPropsShared } from './types/AvatarNetwork';
+// AvatarNetwork types (ADR-0003 + ADR-0004)
+export {
+  AvatarNetworkSize,
+  type AvatarNetworkPropsShared,
+} from './types/AvatarNetwork';
 
 // AvatarToken types (ADR-0003 + ADR-0004)
 export {

--- a/packages/design-system-shared/src/types/AvatarNetwork/AvatarNetwork.types.ts
+++ b/packages/design-system-shared/src/types/AvatarNetwork/AvatarNetwork.types.ts
@@ -1,8 +1,11 @@
+import { AvatarBaseSize } from '../AvatarBase/AvatarBase.types';
+
+export const AvatarNetworkSize = AvatarBaseSize;
+export type AvatarNetworkSize = AvatarBaseSize;
+
 /**
- * AvatarNetwork component shared props (ADR-0004)
+ * AvatarNetwork component shared props (ADR-0003 + ADR-0004)
  * Platform-independent properties shared across React and React Native.
- * Note: AvatarNetworkSize is not included here because it inherits from
- * AvatarBaseSize which will be migrated separately (DSYS-473).
  */
 export type AvatarNetworkPropsShared = {
   /**
@@ -16,4 +19,10 @@ export type AvatarNetworkPropsShared = {
    * fails to load. If not provided, the first letter of name is used.
    */
   fallbackText?: string;
+  /**
+   * Optional prop to control the size of the avatar network.
+   *
+   * @default AvatarNetworkSize.Md
+   */
+  size?: AvatarNetworkSize;
 };

--- a/packages/design-system-shared/src/types/AvatarNetwork/index.ts
+++ b/packages/design-system-shared/src/types/AvatarNetwork/index.ts
@@ -1,1 +1,4 @@
-export { type AvatarNetworkPropsShared } from './AvatarNetwork.types';
+export {
+  AvatarNetworkSize,
+  type AvatarNetworkPropsShared,
+} from './AvatarNetwork.types';


### PR DESCRIPTION
## **Description**

Adds `AvatarNetworkSize` to `@metamask/design-system-shared` as the AvatarNetwork-specific alias of `AvatarBaseSize`, then updates AvatarNetwork in React and React Native to source that named export directly from shared.

This removes the remaining avatar exports from the local `src/types/index.ts` barrels (`AvatarBaseSize`, `AvatarBaseShape`, `AvatarNetworkSize`, and `AvatarSize`) while preserving the existing public `AvatarNetworkSize` export name for consumers through the component package exports.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn workspace @metamask/design-system-react exec jest src/components/AvatarNetwork/AvatarNetwork.test.tsx --runInBand --coverage=false`
2. Run `yarn workspace @metamask/design-system-react-native exec jest src/components/AvatarNetwork/AvatarNetwork.test.tsx --runInBand --coverage=false`
3. Run `yarn workspace @metamask/design-system-shared build`
4. Run `yarn workspace @metamask/design-system-react build`
5. Run `yarn workspace @metamask/design-system-react-native build`

## **Screenshots/Recordings**

Not applicable. This is an import source cleanup with no visual changes.

### **Before**

Not applicable.

### **After**

Not applicable.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type and import-path refactor with preserved public exports; no auth, data, or rendering logic changes.
> 
> **Overview**
> **AvatarNetwork** sizing is centralized in `@metamask/design-system-shared`: `AvatarNetworkSize` is defined there as an alias of `AvatarBaseSize`, exported from the shared package, and **`size`** is added to **`AvatarNetworkPropsShared`**.
> 
> React and React Native **AvatarNetwork** implementations, stories, tests, and package **`index`** re-exports now import **`AvatarNetworkSize`** from shared instead of local **`src/types`** barrels. The remaining avatar re-exports (`AvatarBaseSize`, `AvatarBaseShape`, `AvatarNetworkSize`, `AvatarSize`) are **removed** from **`design-system-react`** and **`design-system-react-native`** `types/index.ts`; consumers can still get **`AvatarNetworkSize`** from the component package export path.
> 
> No runtime or visual behavior change—import paths and shared type ownership only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f994f26cb66e54b1c13b1fe8e0fff39b16a06c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->