### PR TITLE
fix: move react-native-worklets to devDependencies in storybook-react-native

### DIFF
--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -27,8 +27,7 @@
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
-    "react-native-web": "^0.21.0",
-    "react-native-worklets": "patch:react-native-worklets@npm%3A0.5.1#~/.yarn/patches/react-native-worklets-npm-0.5.1-dcf1422a19.patch"
+    "react-native-web": "^0.21.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -43,6 +42,7 @@
     "@storybook/addon-ondevice-actions": "10.4.4",
     "@storybook/addon-ondevice-backgrounds": "10.4.4",
     "@storybook/addon-ondevice-controls": "patch:@storybook/addon-ondevice-controls@npm%3A10.4.4#~/.yarn/patches/@storybook-addon-ondevice-controls-npm-10.4.4-6e8c0f15d9.patch",
+    "react-native-worklets": "patch:react-native-worklets@npm%3A0.5.1#~/.yarn/patches/react-native-worklets-npm-0.5.1-dcf1422a19.patch",
     "@storybook/addon-ondevice-notes": "10.4.4",
     "@storybook/react": "^10.4.2",
     "@storybook/react-native": "10.4.4",


### PR DESCRIPTION
## **Description**

`@metamask/create-release-branch` validates `dependencies` and `peerDependencies` against a strict allowlist (semver ranges, `workspace:^`, and `npm:` redirections). The `patch:` Yarn protocol is not in that allowlist, so `yarn create-release-branch` was failing with:

> The value of "dependencies" in the manifest for "@metamask/storybook-react-native" must be a valid dependencies field

This moves `react-native-worklets` from `dependencies` to `devDependencies` in `apps/storybook-react-native/package.json`. Since `@metamask/storybook-react-native` is a private workspace app (not a published package), Yarn installs all dependency fields regardless — there is no functional difference. This also matches the existing `@storybook/addon-ondevice-controls` entry, which already uses a `patch:` specifier in `devDependencies`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn create-release-branch` from the repo root
2. Confirm it no longer errors with the manifest validation failure for `@metamask/storybook-react-native`

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.