### PR TITLE
fix(dsrn): resolve lint errors in ListItemSelect and ListItemMultiSelect

### DIFF
--- a/packages/design-system-react-native/src/components/ListItemMultiSelect/ListItemMultiSelect.test.tsx
+++ b/packages/design-system-react-native/src/components/ListItemMultiSelect/ListItemMultiSelect.test.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from '../Checkbox';
 import { ListItemMultiSelect } from './ListItemMultiSelect';
 
 const ROOT_TEST_ID = 'listitem-multiselect-root';
+const noopPress = () => undefined;
 
 describe('ListItemMultiSelect', () => {
   let tw: ReturnType<typeof useTailwind>;
@@ -22,7 +23,7 @@ describe('ListItemMultiSelect', () => {
         <ListItemMultiSelect
           title="Label"
           isSelected={false}
-          onPress={() => {}}
+          onPress={noopPress}
         />,
       );
       expect(getByText('Label')).toBeOnTheScreen();
@@ -35,7 +36,7 @@ describe('ListItemMultiSelect', () => {
         <ListItemMultiSelect
           title="Label"
           isSelected
-          onPress={() => {}}
+          onPress={noopPress}
           testID={ROOT_TEST_ID}
         />,
       );
@@ -51,7 +52,7 @@ describe('ListItemMultiSelect', () => {
         <ListItemMultiSelect
           title="Label"
           isSelected={false}
-          onPress={() => {}}
+          onPress={noopPress}
           testID={ROOT_TEST_ID}
         />,
       );
@@ -67,7 +68,7 @@ describe('ListItemMultiSelect', () => {
         <ListItemMultiSelect
           title="Label"
           isSelected={false}
-          onPress={() => {}}
+          onPress={noopPress}
         />,
       );
       expect(getByRole('checkbox')).toBeOnTheScreen();
@@ -75,7 +76,7 @@ describe('ListItemMultiSelect', () => {
 
     it('marks checkbox as checked when isSelected is true', () => {
       const { getByRole } = render(
-        <ListItemMultiSelect title="Label" isSelected onPress={() => {}} />,
+        <ListItemMultiSelect title="Label" isSelected onPress={noopPress} />,
       );
       expect(getByRole('checkbox').props.accessibilityState?.checked).toBe(
         true,
@@ -87,7 +88,7 @@ describe('ListItemMultiSelect', () => {
         <ListItemMultiSelect
           title="Label"
           isSelected={false}
-          onPress={() => {}}
+          onPress={noopPress}
         />,
       );
 
@@ -131,7 +132,7 @@ describe('ListItemMultiSelect', () => {
           title="Label"
           isSelected
           twClassName="rounded-lg"
-          onPress={() => {}}
+          onPress={noopPress}
           testID={ROOT_TEST_ID}
         />,
       );
@@ -147,7 +148,7 @@ describe('ListItemMultiSelect', () => {
           title="Label"
           isSelected={false}
           twClassName="rounded-lg"
-          onPress={() => {}}
+          onPress={noopPress}
           testID={ROOT_TEST_ID}
         />,
       );

--- a/packages/design-system-react-native/src/components/ListItemMultiSelect/ListItemMultiSelect.tsx
+++ b/packages/design-system-react-native/src/components/ListItemMultiSelect/ListItemMultiSelect.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 
 import { Checkbox } from '../Checkbox';
 import { ListItem } from '../ListItem';
+
 import type { ListItemMultiSelectProps } from './ListItemMultiSelect.types';
+
+const noopChange = () => undefined;
 
 const mergeTwClassName = (base: string, extra?: string) =>
   extra ? `${base} ${extra}` : base;
@@ -24,7 +27,7 @@ export const ListItemMultiSelect = ({
       endAccessory={
         <Checkbox
           isSelected={isSelected}
-          onChange={() => {}}
+          onChange={noopChange}
           label=""
           pointerEvents="none"
         />

--- a/packages/design-system-react-native/src/components/ListItemSelect/ListItemSelect.test.tsx
+++ b/packages/design-system-react-native/src/components/ListItemSelect/ListItemSelect.test.tsx
@@ -8,6 +8,7 @@ import { IconName } from '../Icon';
 import { ListItemSelect } from './ListItemSelect';
 
 const ROOT_TEST_ID = 'listitem-select-root';
+const noopPress = () => undefined;
 
 describe('ListItemSelect', () => {
   let tw: ReturnType<typeof useTailwind>;
@@ -22,7 +23,7 @@ describe('ListItemSelect', () => {
         <ListItemSelect
           title="Label"
           isSelected={false}
-          onPress={() => {}}
+          onPress={noopPress}
           testID={ROOT_TEST_ID}
         />,
       );
@@ -33,9 +34,11 @@ describe('ListItemSelect', () => {
   describe('when isSelected is false', () => {
     it('does not render check icon by default', () => {
       const { root } = render(
-        <ListItemSelect title="Label" isSelected={false} onPress={() => {}} />,
+        <ListItemSelect title="Label" isSelected={false} onPress={noopPress} />,
       );
-      expect(() => root.findByProps({ name: IconName.Check })).toThrow();
+      expect(() => root.findByProps({ name: IconName.Check })).toThrow(
+        'No instances found with props',
+      );
     });
 
     it('renders custom endAccessory', () => {
@@ -43,7 +46,7 @@ describe('ListItemSelect', () => {
         <ListItemSelect
           title="Label"
           isSelected={false}
-          onPress={() => {}}
+          onPress={noopPress}
           endAccessory={<Text>Custom</Text>}
         />,
       );
@@ -56,10 +59,12 @@ describe('ListItemSelect', () => {
           title="Label"
           isSelected={false}
           showSelectedIcon
-          onPress={() => {}}
+          onPress={noopPress}
         />,
       );
-      expect(() => root.findByProps({ name: IconName.Check })).toThrow();
+      expect(() => root.findByProps({ name: IconName.Check })).toThrow(
+        'No instances found with props',
+      );
     });
   });
 
@@ -69,7 +74,7 @@ describe('ListItemSelect', () => {
         <ListItemSelect
           title="Label"
           isSelected
-          onPress={() => {}}
+          onPress={noopPress}
           testID={ROOT_TEST_ID}
         />,
       );
@@ -84,7 +89,7 @@ describe('ListItemSelect', () => {
           title="Label"
           isSelected
           showSelectedIcon
-          onPress={() => {}}
+          onPress={noopPress}
         />,
       );
       expect(root.findByProps({ name: IconName.Check })).toBeDefined();
@@ -95,12 +100,14 @@ describe('ListItemSelect', () => {
         <ListItemSelect
           title="Label"
           isSelected
-          onPress={() => {}}
+          onPress={noopPress}
           endAccessory={<Text>Custom</Text>}
         />,
       );
       expect(getByText('Custom')).toBeOnTheScreen();
-      expect(() => root.findByProps({ name: IconName.Check })).toThrow();
+      expect(() => root.findByProps({ name: IconName.Check })).toThrow(
+        'No instances found with props',
+      );
     });
   });
 
@@ -127,7 +134,7 @@ describe('ListItemSelect', () => {
           title="Label"
           isSelected
           twClassName="rounded-lg"
-          onPress={() => {}}
+          onPress={noopPress}
           testID={ROOT_TEST_ID}
         />,
       );
@@ -143,7 +150,7 @@ describe('ListItemSelect', () => {
           title="Label"
           isSelected={false}
           twClassName="rounded-lg"
-          onPress={() => {}}
+          onPress={noopPress}
           testID={ROOT_TEST_ID}
         />,
       );

--- a/packages/design-system-react-native/src/components/ListItemSelect/ListItemSelect.tsx
+++ b/packages/design-system-react-native/src/components/ListItemSelect/ListItemSelect.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Icon, IconColor, IconName, IconSize } from '../Icon';
 import { ListItem } from '../ListItem';
+
 import type { ListItemSelectProps } from './ListItemSelect.types';
 
 const mergeTwClassName = (base: string, extra?: string) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Fixes ESLint failures in the `ListItemSelect` and `ListItemMultiSelect` components introduced on the feature branch.

Changes:
- Replace empty arrow functions (`() => {}`) with `noopPress` / `noopChange` helpers that return `undefined`, matching existing patterns in stories and other tests
- Add blank lines between parent and local type import groups for `import-x/order`
- Add error messages to `toThrow()` assertions to satisfy `jest/require-to-throw-message`

## **Related issues**

Fixes CI lint errors in:
- `ListItemMultiSelect.test.tsx`
- `ListItemMultiSelect.tsx`
- `ListItemSelect.test.tsx`
- `ListItemSelect.tsx`

## **Manual testing steps**

1. Run ESLint on the affected files:
   ```bash
   npx eslint packages/design-system-react-native/src/components/ListItemMultiSelect/ListItemMultiSelect.test.tsx packages/design-system-react-native/src/components/ListItemMultiSelect/ListItemMultiSelect.tsx packages/design-system-react-native/src/components/ListItemSelect/ListItemSelect.test.tsx packages/design-system-react-native/src/components/ListItemSelect/ListItemSelect.tsx
   ```
2. Run unit tests:
   ```bash
   yarn workspace @metamask/design-system-react-native run jest packages/design-system-react-native/src/components/ListItemMultiSelect/ListItemMultiSelect.test.tsx packages/design-system-react-native/src/components/ListItemSelect/ListItemSelect.test.tsx
   ```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e76b4a0b-fcdf-43f7-83f9-b25fb767f4f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e76b4a0b-fcdf-43f7-83f9-b25fb767f4f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

