### PR TITLE
feat: Added HeaderSubpage to DSRN

### DIFF
--- a/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react-native';
+import React from 'react';
+
+import EthSVG from '../../assets/token-icons/eth.svg';
+import { AvatarToken, AvatarTokenSize } from '../AvatarToken';
+import { Box } from '../Box';
+import { IconName } from '../Icon';
+
+import { HeaderSubpage } from './HeaderSubpage';
+import type { HeaderSubpageProps } from './HeaderSubpage.types';
+
+const ETH_TITLE = 'Ethereum';
+const ETH_DESCRIPTION = 'ETH';
+
+const StoryHeaderAvatar = () => (
+  <AvatarToken src={EthSVG} size={AvatarTokenSize.Lg} name={ETH_TITLE} />
+);
+
+const meta: Meta<HeaderSubpageProps> = {
+  title: 'Components/HeaderSubpage',
+  component: HeaderSubpage,
+  args: {
+    avatar: <StoryHeaderAvatar />,
+    title: ETH_TITLE,
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Primary identity label in the header row.',
+    },
+    description: {
+      control: 'text',
+      description:
+        'Secondary line below the title (ListItem `description`, not `subtitle`).',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Box twClassName="w-full bg-background-default">
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<HeaderSubpageProps>;
+
+export const Default: Story = {};
+
+export const Description: Story = {
+  args: {
+    description: ETH_DESCRIPTION,
+  },
+};
+
+export const OnBack: Story = {
+  args: {
+    description: ETH_DESCRIPTION,
+    onBack: () => null,
+  },
+};
+
+export const OnClose: Story = {
+  args: {
+    description: ETH_DESCRIPTION,
+    onClose: () => null,
+  },
+};
+
+export const BackAndClose: Story = {
+  args: {
+    description: ETH_DESCRIPTION,
+    onBack: () => null,
+    onClose: () => null,
+  },
+};
+
+export const EndButtonIconProps: Story = {
+  args: {
+    description: ETH_DESCRIPTION,
+    onBack: () => null,
+    onClose: () => null,
+    endButtonIconProps: [
+      {
+        iconName: IconName.Search,
+        onPress: () => null,
+      },
+    ],
+  },
+};

--- a/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -1,0 +1,507 @@
+// Third party dependencies.
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { fireEvent, render, renderHook } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// External dependencies.
+import { IconName } from '../Icon';
+
+// Internal dependencies.
+import { HeaderSubpage } from './HeaderSubpage';
+
+const CONTAINER_TEST_ID = 'header-subpage-container';
+const TITLE_TEST_ID = 'header-subpage-title';
+const DESCRIPTION_TEST_ID = 'header-subpage-description';
+const AVATAR_TEST_ID = 'header-subpage-avatar';
+const BACK_BUTTON_TEST_ID = 'header-subpage-back-button';
+const CLOSE_BUTTON_TEST_ID = 'header-subpage-close-button';
+const START_ACCESSORY_TEST_ID = 'header-subpage-start-accessory';
+const END_ACCESSORY_TEST_ID = 'header-subpage-end-accessory';
+const CUSTOM_START_BUTTON_TEST_ID = 'header-subpage-custom-start-button';
+const END_SEARCH_BUTTON_TEST_ID = 'header-subpage-end-search';
+
+describe('HeaderSubpage', () => {
+  let tw: ReturnType<typeof useTailwind>;
+
+  beforeAll(() => {
+    tw = renderHook(() => useTailwind()).result.current;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('content', () => {
+    describe('when title is provided', () => {
+      it('renders string title', () => {
+        const { getByText } = render(<HeaderSubpage title="Test Title" />);
+
+        expect(getByText('Test Title')).toBeOnTheScreen();
+      });
+
+      it('forwards titleProps to title Text', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Test Title"
+            titleProps={{ testID: TITLE_TEST_ID }}
+          />,
+        );
+
+        expect(getByTestId(TITLE_TEST_ID)).toBeOnTheScreen();
+      });
+    });
+
+    describe('when description is provided', () => {
+      it('renders string description', () => {
+        const { getByText } = render(
+          <HeaderSubpage title="Test Title" description="Test Description" />,
+        );
+
+        expect(getByText('Test Description')).toBeOnTheScreen();
+      });
+
+      it('forwards descriptionProps to description Text', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Test Title"
+            description="Test Description"
+            descriptionProps={{ testID: DESCRIPTION_TEST_ID }}
+          />,
+        );
+
+        expect(getByTestId(DESCRIPTION_TEST_ID)).toBeOnTheScreen();
+      });
+    });
+
+    describe('when avatar is provided', () => {
+      it('renders avatar node', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Test Title"
+            avatar={<Text testID={AVATAR_TEST_ID}>Avatar</Text>}
+          />,
+        );
+
+        expect(getByTestId(AVATAR_TEST_ID)).toBeOnTheScreen();
+      });
+    });
+
+    describe('when testID is provided', () => {
+      it('forwards testID to root ListItem', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage title="Test Title" testID={CONTAINER_TEST_ID} />,
+        );
+
+        expect(getByTestId(CONTAINER_TEST_ID)).toBeOnTheScreen();
+      });
+    });
+  });
+
+  describe('resolvedStartAccessory', () => {
+    describe('when onBack is provided', () => {
+      it('renders back ButtonIcon', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            onBack={jest.fn()}
+            backButtonProps={{ testID: BACK_BUTTON_TEST_ID }}
+          />,
+        );
+
+        expect(getByTestId(BACK_BUTTON_TEST_ID)).toBeOnTheScreen();
+      });
+
+      it('calls onBack on press', () => {
+        const onBack = jest.fn();
+        const { getByTestId } = render(
+          <HeaderSubpage title="Title" onBack={onBack} />,
+        );
+
+        fireEvent.press(getByTestId('button-icon'));
+
+        expect(onBack).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when backButtonProps is provided', () => {
+      it('renders back ButtonIcon', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            backButtonProps={{
+              onPress: jest.fn(),
+              testID: BACK_BUTTON_TEST_ID,
+            }}
+          />,
+        );
+
+        expect(getByTestId(BACK_BUTTON_TEST_ID)).toBeOnTheScreen();
+      });
+
+      it('calls backButtonProps.onPress on press', () => {
+        const onPress = jest.fn();
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            backButtonProps={{ onPress, testID: BACK_BUTTON_TEST_ID }}
+          />,
+        );
+
+        fireEvent.press(getByTestId(BACK_BUTTON_TEST_ID));
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+      });
+
+      it('prefers backButtonProps.onPress over onBack', () => {
+        const onBack = jest.fn();
+        const onPress = jest.fn();
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            onBack={onBack}
+            backButtonProps={{ onPress, testID: BACK_BUTTON_TEST_ID }}
+          />,
+        );
+
+        fireEvent.press(getByTestId(BACK_BUTTON_TEST_ID));
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+        expect(onBack).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when startButtonIconProps is provided', () => {
+      it('renders custom start ButtonIcon', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            startButtonIconProps={{
+              iconName: IconName.Menu,
+              onPress: jest.fn(),
+              testID: CUSTOM_START_BUTTON_TEST_ID,
+            }}
+          />,
+        );
+
+        expect(getByTestId(CUSTOM_START_BUTTON_TEST_ID)).toBeOnTheScreen();
+      });
+
+      it('takes priority over onBack', () => {
+        const { getByTestId, queryByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            onBack={jest.fn()}
+            backButtonProps={{ testID: BACK_BUTTON_TEST_ID }}
+            startButtonIconProps={{
+              iconName: IconName.Menu,
+              onPress: jest.fn(),
+              testID: CUSTOM_START_BUTTON_TEST_ID,
+            }}
+          />,
+        );
+
+        expect(getByTestId(CUSTOM_START_BUTTON_TEST_ID)).toBeOnTheScreen();
+        expect(queryByTestId(BACK_BUTTON_TEST_ID)).not.toBeOnTheScreen();
+      });
+    });
+
+    describe('when startAccessory is provided', () => {
+      it('takes priority over startButtonIconProps', () => {
+        const { getByTestId, queryByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            startAccessory={<Text testID={START_ACCESSORY_TEST_ID}>Start</Text>}
+            startButtonIconProps={{
+              iconName: IconName.Menu,
+              onPress: jest.fn(),
+              testID: CUSTOM_START_BUTTON_TEST_ID,
+            }}
+          />,
+        );
+
+        expect(getByTestId(START_ACCESSORY_TEST_ID)).toBeOnTheScreen();
+        expect(
+          queryByTestId(CUSTOM_START_BUTTON_TEST_ID),
+        ).not.toBeOnTheScreen();
+      });
+    });
+
+    describe('when no start props are provided', () => {
+      it('omits start accessory', () => {
+        const { queryByTestId } = render(<HeaderSubpage title="Title" />);
+
+        expect(queryByTestId(BACK_BUTTON_TEST_ID)).not.toBeOnTheScreen();
+        expect(
+          queryByTestId(CUSTOM_START_BUTTON_TEST_ID),
+        ).not.toBeOnTheScreen();
+        expect(queryByTestId(START_ACCESSORY_TEST_ID)).not.toBeOnTheScreen();
+      });
+    });
+  });
+
+  describe('resolvedEndAccessory', () => {
+    describe('when onClose is provided', () => {
+      it('renders close ButtonIcon', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            onClose={jest.fn()}
+            closeButtonProps={{ testID: CLOSE_BUTTON_TEST_ID }}
+          />,
+        );
+
+        expect(getByTestId(CLOSE_BUTTON_TEST_ID)).toBeOnTheScreen();
+      });
+
+      it('calls onClose on press', () => {
+        const onClose = jest.fn();
+        const { getByTestId } = render(
+          <HeaderSubpage title="Title" onClose={onClose} />,
+        );
+
+        fireEvent.press(getByTestId('button-icon'));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when closeButtonProps is provided', () => {
+      it('renders close ButtonIcon', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            closeButtonProps={{
+              onPress: jest.fn(),
+              testID: CLOSE_BUTTON_TEST_ID,
+            }}
+          />,
+        );
+
+        expect(getByTestId(CLOSE_BUTTON_TEST_ID)).toBeOnTheScreen();
+      });
+
+      it('prefers closeButtonProps.onPress over onClose', () => {
+        const onClose = jest.fn();
+        const onPress = jest.fn();
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            onClose={onClose}
+            closeButtonProps={{ onPress, testID: CLOSE_BUTTON_TEST_ID }}
+          />,
+        );
+
+        fireEvent.press(getByTestId(CLOSE_BUTTON_TEST_ID));
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+        expect(onClose).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when endButtonIconProps is provided', () => {
+      it('renders end ButtonIcons', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            endButtonIconProps={[
+              {
+                iconName: IconName.Search,
+                onPress: jest.fn(),
+                testID: END_SEARCH_BUTTON_TEST_ID,
+              },
+            ]}
+          />,
+        );
+
+        expect(getByTestId(END_SEARCH_BUTTON_TEST_ID)).toBeOnTheScreen();
+      });
+
+      it('appends icons after close shortcut', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            onClose={jest.fn()}
+            closeButtonProps={{ testID: CLOSE_BUTTON_TEST_ID }}
+            endButtonIconProps={[
+              {
+                iconName: IconName.Search,
+                onPress: jest.fn(),
+                testID: END_SEARCH_BUTTON_TEST_ID,
+              },
+            ]}
+          />,
+        );
+
+        expect(getByTestId(CLOSE_BUTTON_TEST_ID)).toBeOnTheScreen();
+        expect(getByTestId(END_SEARCH_BUTTON_TEST_ID)).toBeOnTheScreen();
+      });
+
+      it('omits end accessory when array is empty', () => {
+        const { queryByTestId } = render(
+          <HeaderSubpage title="Title" endButtonIconProps={[]} />,
+        );
+
+        expect(queryByTestId(CLOSE_BUTTON_TEST_ID)).not.toBeOnTheScreen();
+        expect(queryByTestId(END_SEARCH_BUTTON_TEST_ID)).not.toBeOnTheScreen();
+      });
+    });
+
+    describe('when endAccessory is provided', () => {
+      it('takes priority over close shortcuts', () => {
+        const { getByTestId, queryByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            onClose={jest.fn()}
+            closeButtonProps={{ testID: CLOSE_BUTTON_TEST_ID }}
+            endAccessory={<Text testID={END_ACCESSORY_TEST_ID}>End</Text>}
+          />,
+        );
+
+        expect(getByTestId(END_ACCESSORY_TEST_ID)).toBeOnTheScreen();
+        expect(queryByTestId(CLOSE_BUTTON_TEST_ID)).not.toBeOnTheScreen();
+      });
+    });
+
+    describe('when no end props are provided', () => {
+      it('omits end accessory', () => {
+        const { queryByTestId } = render(<HeaderSubpage title="Title" />);
+
+        expect(queryByTestId(CLOSE_BUTTON_TEST_ID)).not.toBeOnTheScreen();
+        expect(queryByTestId(END_ACCESSORY_TEST_ID)).not.toBeOnTheScreen();
+      });
+    });
+  });
+
+  describe('includesTopInset', () => {
+    beforeEach(() => {
+      jest.mocked(useSafeAreaInsets).mockReturnValue({
+        top: 50,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      });
+    });
+
+    describe('when includesTopInset is true', () => {
+      it('applies marginTop from safe area insets', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            testID={CONTAINER_TEST_ID}
+            includesTopInset
+          />,
+        );
+
+        expect(getByTestId(CONTAINER_TEST_ID)).toHaveStyle({ marginTop: 50 });
+      });
+    });
+
+    describe('when includesTopInset is false', () => {
+      it('omits marginTop from safe area insets', () => {
+        const { getByTestId } = render(
+          <HeaderSubpage title="Title" testID={CONTAINER_TEST_ID} />,
+        );
+
+        expect(getByTestId(CONTAINER_TEST_ID)).not.toHaveStyle({
+          marginTop: 50,
+        });
+      });
+    });
+  });
+
+  describe('twClassName', () => {
+    it('merges default header shell classes on root ListItem', () => {
+      const { getByTestId } = render(
+        <HeaderSubpage title="Title" testID={CONTAINER_TEST_ID} />,
+      );
+
+      expect(getByTestId(CONTAINER_TEST_ID)).toHaveStyle(
+        tw.style('px-4 py-3', 'h-14 px-2 py-0 justify-center'),
+      );
+    });
+
+    it('merges caller classes with default shell classes', () => {
+      const { getByTestId } = render(
+        <HeaderSubpage
+          title="Title"
+          testID={CONTAINER_TEST_ID}
+          twClassName="border-b border-muted"
+        />,
+      );
+
+      expect(getByTestId(CONTAINER_TEST_ID)).toHaveStyle(
+        tw.style(
+          'px-4 py-3',
+          'h-14 px-2 py-0 justify-center',
+          'border-b border-muted',
+        ),
+      );
+    });
+  });
+
+  describe('style', () => {
+    it('merges caller style with root ListItem styles', () => {
+      const customStyle = { backgroundColor: 'red' };
+      const { getByTestId } = render(
+        <HeaderSubpage
+          title="Title"
+          testID={CONTAINER_TEST_ID}
+          style={customStyle}
+        />,
+      );
+
+      expect(getByTestId(CONTAINER_TEST_ID)).toHaveStyle([
+        tw.style('px-4 py-3', 'h-14 px-2 py-0 justify-center'),
+        customStyle,
+      ]);
+    });
+
+    describe('when includesTopInset is true', () => {
+      beforeEach(() => {
+        jest.mocked(useSafeAreaInsets).mockReturnValue({
+          top: 50,
+          bottom: 0,
+          left: 0,
+          right: 0,
+        });
+      });
+
+      it('merges marginTop with caller style', () => {
+        const customStyle = { backgroundColor: 'red' };
+        const { getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            testID={CONTAINER_TEST_ID}
+            includesTopInset
+            style={customStyle}
+          />,
+        );
+
+        expect(getByTestId(CONTAINER_TEST_ID)).toHaveStyle([
+          { marginTop: 50 },
+          customStyle,
+        ]);
+      });
+    });
+  });
+
+  describe('accessoryGap', () => {
+    describe('when accessoryGap is provided', () => {
+      it('renders start accessory and content', () => {
+        const { getByText, getByTestId } = render(
+          <HeaderSubpage
+            title="Title"
+            accessoryGap={0}
+            onBack={jest.fn()}
+            backButtonProps={{ testID: BACK_BUTTON_TEST_ID }}
+          />,
+        );
+
+        expect(getByText('Title')).toBeOnTheScreen();
+        expect(getByTestId(BACK_BUTTON_TEST_ID)).toBeOnTheScreen();
+      });
+    });
+  });
+});

--- a/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.tsx
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.tsx
@@ -1,0 +1,126 @@
+// Third party dependencies.
+import { mergeTwClassName } from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React, { useMemo } from 'react';
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// External dependencies.
+import { ButtonIcon, ButtonIconSize } from '../ButtonIcon';
+import type { ButtonIconProps } from '../ButtonIcon';
+import { IconName } from '../Icon';
+import { ListItem } from '../ListItem';
+
+// Internal dependencies.
+import type { HeaderSubpageProps } from './HeaderSubpage.types';
+
+const renderEndButtonIcons = (endButtonIconProps: ButtonIconProps[]) =>
+  endButtonIconProps
+    .map((iconProps, originalIndex) => ({
+      iconProps,
+      originalIndex,
+    }))
+    .reverse()
+    .map(({ iconProps, originalIndex }) => (
+      <ButtonIcon
+        key={`end-button-icon-${originalIndex}`}
+        size={ButtonIconSize.Md}
+        {...iconProps}
+      />
+    ));
+
+export const HeaderSubpage: React.FC<HeaderSubpageProps> = ({
+  onBack,
+  backButtonProps,
+  onClose,
+  closeButtonProps,
+  startButtonIconProps,
+  endButtonIconProps,
+  startAccessory,
+  endAccessory,
+  includesTopInset = false,
+  twClassName = '',
+  style,
+  accessoryGap = 2,
+  testID,
+  ...listItemProps
+}) => {
+  const tw = useTailwind();
+  const insets = useSafeAreaInsets();
+
+  const resolvedStartAccessory = useMemo(() => {
+    if (startAccessory) {
+      return startAccessory;
+    }
+
+    if (startButtonIconProps) {
+      return <ButtonIcon size={ButtonIconSize.Md} {...startButtonIconProps} />;
+    }
+
+    if (onBack || backButtonProps) {
+      return (
+        <ButtonIcon
+          iconName={IconName.ArrowLeft}
+          size={ButtonIconSize.Md}
+          {...(backButtonProps ?? {})}
+          onPress={backButtonProps?.onPress ?? onBack}
+        />
+      );
+    }
+
+    return undefined;
+  }, [startAccessory, startButtonIconProps, onBack, backButtonProps]);
+
+  const resolvedEndButtonIconProps = useMemo(() => {
+    const props: ButtonIconProps[] = [];
+
+    if (onClose || closeButtonProps) {
+      props.push({
+        iconName: IconName.Close,
+        ...(closeButtonProps || {}),
+        onPress: closeButtonProps?.onPress ?? onClose,
+      });
+    }
+
+    if (endButtonIconProps) {
+      props.push(...endButtonIconProps);
+    }
+
+    return props.length > 0 ? props : undefined;
+  }, [endButtonIconProps, onClose, closeButtonProps]);
+
+  const resolvedEndAccessory = useMemo(() => {
+    if (endAccessory) {
+      return endAccessory;
+    }
+
+    if (resolvedEndButtonIconProps && resolvedEndButtonIconProps.length > 0) {
+      const icons = renderEndButtonIcons(resolvedEndButtonIconProps);
+
+      if (resolvedEndButtonIconProps.length > 1) {
+        return <View style={tw.style('flex-row gap-2')}>{icons}</View>;
+      }
+
+      return icons;
+    }
+
+    return undefined;
+  }, [endAccessory, resolvedEndButtonIconProps, tw]);
+
+  return (
+    <ListItem
+      {...listItemProps}
+      testID={testID}
+      startAccessory={resolvedStartAccessory}
+      endAccessory={resolvedEndAccessory}
+      accessoryGap={accessoryGap}
+      twClassName={mergeTwClassName(
+        'h-14 px-2 py-0 justify-center',
+        twClassName,
+      )}
+      style={[includesTopInset && { marginTop: insets.top }, style]}
+    />
+  );
+};
+
+HeaderSubpage.displayName = 'HeaderSubpage';

--- a/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+
+import type { ButtonIconProps } from '../ButtonIcon';
+import type { ListItemProps } from '../ListItem';
+
+/**
+ * HeaderSubpage component props.
+ *
+ * Subpage navigation row built on {@link ListItem} with optional back/close
+ * shortcuts matching {@link HeaderStandard}.
+ */
+export type HeaderSubpageProps = Omit<
+  ListItemProps,
+  'startAccessory' | 'endAccessory' | 'isInteractive' | 'children'
+> & {
+  /**
+   * Callback when the back button is pressed.
+   * If provided, a back button will be rendered as the start accessory.
+   */
+  onBack?: () => void;
+  /**
+   * Additional props to pass to the back ButtonIcon.
+   * If provided, a back button will be rendered with these props spread.
+   */
+  backButtonProps?: Omit<ButtonIconProps, 'iconName'>;
+  /**
+   * Callback when the close button is pressed.
+   * If provided, a close button will be added to the end accessories.
+   */
+  onClose?: () => void;
+  /**
+   * Additional props to pass to the close ButtonIcon.
+   * If provided, a close button will be added with these props spread.
+   */
+  closeButtonProps?: Omit<ButtonIconProps, 'iconName'>;
+  /**
+   * Optional ButtonIcon props to render as the start accessory.
+   * Only used if `startAccessory` is not provided.
+   */
+  startButtonIconProps?: ButtonIconProps;
+  /**
+   * Optional array of ButtonIcon props to render as additional end accessories.
+   * Rendered in reverse order (first item appears rightmost).
+   * Only used if `endAccessory` is not provided.
+   */
+  endButtonIconProps?: ButtonIconProps[];
+  /**
+   * Optional content before the ListItem content row.
+   * Takes priority over `startButtonIconProps` and back shortcuts.
+   */
+  startAccessory?: ReactNode;
+  /**
+   * Optional content after the ListItem content row.
+   * Takes priority over `endButtonIconProps` and close shortcuts.
+   */
+  endAccessory?: ReactNode;
+  /**
+   * When true, applies top safe-area inset as `marginTop` on the root ListItem.
+   *
+   * @default false
+   */
+  includesTopInset?: boolean;
+};

--- a/packages/design-system-react-native/src/components/HeaderSubpage/README.md
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/README.md
@@ -1,0 +1,301 @@
+# HeaderSubpage
+
+HeaderSubpage is a subpage navigation row with optional back and close actions. It composes [ListItem](../ListItem/README.md) for left-aligned identity content (avatar, title, description) and applies header shell styling (`h-14`, optional safe-area inset). Use [HeaderStandard](../HeaderStandard/README.md) for centered-title headers. Use [TitleSubpage](../TitleSubpage/README.md) for the rich title block below this row (amount, bottom label, and similar).
+
+```tsx
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  HeaderSubpage,
+} from '@metamask/design-system-react-native';
+
+<HeaderSubpage
+  avatar={<AvatarToken name="Ethereum" size={AvatarTokenSize.Lg} />}
+  title="Ethereum"
+  description="ETH"
+  onBack={() => navigation.goBack()}
+  onClose={() => navigation.pop()}
+/>;
+```
+
+## Props
+
+Inherits [ListItem](../ListItem/README.md) / [Content](../Content/README.md) props (`value`, `verticalAlignment`, `testID`, and other root `View` props). `isInteractive` and `children` are not supported. Secondary text uses **`description`** (ListItem), not `subtitle` ([HeaderStandard](../HeaderStandard/README.md) / [TitleSubpage](../TitleSubpage/README.md)).
+
+### `title`
+
+Primary identity label in the header row. Pass a string for default [Content](../Content/README.md) body styling, or a node for custom content.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage title="Ethereum" onBack={goBack} />
+
+<HeaderSubpage
+  title={<Text variant={TextVariant.HeadingSm}>Custom title</Text>}
+  onBack={goBack}
+/>
+```
+
+### `titleProps`
+
+Props forwarded to the design-system `Text` component when `title` is a string.
+
+| TYPE                 | REQUIRED | DEFAULT     |
+| -------------------- | -------- | ----------- |
+| `Partial<TextProps>` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage
+  title="Ethereum"
+  titleProps={{ testID: 'header-subpage-title' }}
+  onBack={goBack}
+/>
+```
+
+### `description`
+
+Secondary line below the title. Pass a string for default [Content](../Content/README.md) body styling, or a node for custom content.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage title="Ethereum" description="ETH" onBack={goBack} />
+```
+
+### `descriptionProps`
+
+Props forwarded to `Text` when `description` is a string.
+
+| TYPE                 | REQUIRED | DEFAULT     |
+| -------------------- | -------- | ----------- |
+| `Partial<TextProps>` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage
+  title="Ethereum"
+  description="ETH"
+  descriptionProps={{ testID: 'header-subpage-description' }}
+  onBack={goBack}
+/>
+```
+
+### `avatar`
+
+Leading visual in the identity row (for example a token avatar). Use `AvatarToken` at `AvatarTokenSize.Lg` (40×40) for the default layout.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage
+  avatar={<AvatarToken name="Ethereum" size={AvatarTokenSize.Lg} />}
+  title="Ethereum"
+  description="ETH"
+  onBack={goBack}
+/>
+```
+
+### `onBack`
+
+If set, renders a start [ButtonIcon](../ButtonIcon/README.md) with a back arrow. The press handler is `backButtonProps.onPress` when both are provided.
+
+| TYPE         | REQUIRED | DEFAULT     |
+| ------------ | -------- | ----------- |
+| `() => void` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage title="Ethereum" onBack={() => navigation.goBack()} />
+```
+
+### `backButtonProps`
+
+Props for the back `ButtonIcon` (excluding `iconName`, which is fixed). Supplying this object also shows the back button; use `onPress` for the handler if `onBack` is not used.
+
+| TYPE                                | REQUIRED | DEFAULT     |
+| ----------------------------------- | -------- | ----------- |
+| `Omit<ButtonIconProps, 'iconName'>` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage
+  title="Ethereum"
+  backButtonProps={{
+    onPress: goBack,
+    testID: 'header-subpage-back',
+    accessibilityLabel: 'Go back',
+  }}
+/>
+```
+
+### `onClose`
+
+If set, appends a close `ButtonIcon` to the end actions.
+
+| TYPE         | REQUIRED | DEFAULT     |
+| ------------ | -------- | ----------- |
+| `() => void` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage title="Ethereum" onClose={() => navigation.pop()} />
+```
+
+### `closeButtonProps`
+
+Props for the close `ButtonIcon` (excluding `iconName`). `onPress` takes precedence over `onClose` when both are set.
+
+| TYPE                                | REQUIRED | DEFAULT     |
+| ----------------------------------- | -------- | ----------- |
+| `Omit<ButtonIconProps, 'iconName'>` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage
+  title="Ethereum"
+  closeButtonProps={{ onPress: close, testID: 'header-subpage-close' }}
+/>
+```
+
+### `startButtonIconProps`
+
+Optional [ButtonIcon](../ButtonIcon/README.md) props for the start accessory. Used only when `startAccessory` is not provided. Takes priority over `onBack` / `backButtonProps`.
+
+| TYPE              | REQUIRED | DEFAULT     |
+| ----------------- | -------- | ----------- |
+| `ButtonIconProps` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage
+  title="Ethereum"
+  startButtonIconProps={{
+    iconName: IconName.Menu,
+    onPress: openMenu,
+    testID: 'header-subpage-menu',
+  }}
+/>
+```
+
+### `endButtonIconProps`
+
+Optional array of [ButtonIcon](../ButtonIcon/README.md) props appended after the close shortcut. Rendered in reverse order (first item appears rightmost). Used only when `endAccessory` is not provided.
+
+| TYPE                | REQUIRED | DEFAULT     |
+| ------------------- | -------- | ----------- |
+| `ButtonIconProps[]` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage
+  title="Ethereum"
+  onBack={goBack}
+  onClose={close}
+  endButtonIconProps={[{ iconName: IconName.Search, onPress: openSearch }]}
+/>
+```
+
+### `startAccessory`
+
+Custom start content. Takes priority over `startButtonIconProps` and back shortcuts.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage
+  title="Ethereum"
+  startAccessory={<CustomBackControl onPress={goBack} />}
+/>
+```
+
+### `endAccessory`
+
+Custom end content. Takes priority over `endButtonIconProps` and close shortcuts.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+<HeaderSubpage
+  title="Ethereum"
+  endAccessory={<CustomCloseControl onPress={close} />}
+/>
+```
+
+### `includesTopInset`
+
+When `true`, applies the device top safe-area inset as `marginTop` on the root ListItem so the header clears the notch.
+
+| TYPE      | REQUIRED | DEFAULT |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
+```tsx
+<HeaderSubpage title="Ethereum" onBack={goBack} includesTopInset />
+```
+
+### `accessoryGap`
+
+Gap between row shell accessories and inner content. Uses design-system spacing tokens (`BoxSpacing`); `2` is 8px.
+
+| TYPE         | REQUIRED | DEFAULT |
+| ------------ | -------- | ------- |
+| `BoxSpacing` | No       | `2`     |
+
+```tsx
+<HeaderSubpage title="Ethereum" accessoryGap={2} onBack={goBack} />
+```
+
+### `twClassName`
+
+Use the `twClassName` prop to add Tailwind CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+Default shell classes include `h-14 px-2 py-0 justify-center` (overriding ListItem padding for header density).
+
+| TYPE     | REQUIRED | DEFAULT     |
+| -------- | -------- | ----------- |
+| `string` | No       | `undefined` |
+
+```tsx
+import { HeaderSubpage } from '@metamask/design-system-react-native';
+
+// Add additional styles
+<HeaderSubpage title="Ethereum" twClassName="border-b border-muted" onBack={goBack} />
+
+// Override default styles
+<HeaderSubpage title="Ethereum" twClassName="px-4" onBack={goBack} />
+```
+
+### `style`
+
+Use the `style` prop to customize the component's appearance with React Native styles. For consistent styling, prefer using `twClassName` with Tailwind classes when possible. Use `style` with `tw.style()` for conditionals or dynamic values.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `StyleProp<ViewStyle>` | No       | `undefined` |
+
+```tsx
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+
+export const HeaderSubpageExample = () => {
+  const tw = useTailwind();
+
+  return (
+    <HeaderSubpage
+      title="Ethereum"
+      style={tw.style('bg-background-default')}
+      onBack={goBack}
+    />
+  );
+};
+```
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react-native/src/components/HeaderSubpage/index.ts
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/index.ts
@@ -1,0 +1,2 @@
+export { HeaderSubpage } from './HeaderSubpage';
+export type { HeaderSubpageProps } from './HeaderSubpage.types';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -149,6 +149,9 @@ export type {
   UseHeaderStandardAnimatedReturn,
 } from './HeaderStandardAnimated';
 
+export { HeaderSubpage } from './HeaderSubpage';
+export type { HeaderSubpageProps } from './HeaderSubpage';
+
 export { HeaderStandardCenterColumn } from './temp-components/HeaderStandardCenterColumn';
 export type {
   HeaderStandardCenterColumnFields,


### PR DESCRIPTION
## **Description**

Adds `HeaderSubpage` to `@metamask/design-system-react-native` — a fixed **h-14 subpage navigation row** for screens that need a back/close header with left-aligned identity content (avatar, title, description).

**Why:** Subpage screens (e.g. token detail) need a nav bar that shows identity content in a list-row layout, not the centered title pattern of `HeaderStandard`. `TitleSubpage` covers the rich title block below the nav row, but there was no dedicated header component for the navigation bar itself.

**What it does:**
- Composes **`ListItem`** (not `HeaderBase`) for identity content via `avatar`, `title`, `description`, and other Content props
- Resolves **back / close** actions with **`HeaderStandard` parity** (`onBack`, `onClose`, `*ButtonProps`, `startButtonIconProps`, `endButtonIconProps`, `startAccessory`, `endAccessory`)
- Applies header shell styling: `h-14 px-2 py-0 justify-center`, optional `includesTopInset`, and `accessoryGap` defaulting to `2`
- Does **not** support `isInteractive` or `children` — nav row only; compose with `TitleSubpage` below for amount/bottom-label rows

**Deliverables:**
- Component implementation, types, and package export
- 31 unit tests with 100% coverage on `HeaderSubpage.tsx`
- Storybook stories (`Default`, `Description`, `OnBack`, `OnClose`, `BackAndClose`, `EndButtonIconProps`)
- README aligned with RN component documentation template

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-881

## **Manual testing steps**

1. Run React Native Storybook: `yarn storybook:ios` or `yarn storybook:android`
2. Open **Components → HeaderSubpage**
3. Verify **Default** — ETH avatar, title, no nav buttons
4. Verify **Description** — title + `ETH` description line
5. Verify **OnBack** / **OnClose** / **BackAndClose** — back and close `ButtonIcon` actions render and are tappable
6. Verify **EndButtonIconProps** — close + search icons render together on the end side
7. Optionally compose on a test screen with `TitleSubpage` below `HeaderSubpage` to confirm the intended subpage layout

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

https://github.com/user-attachments/assets/30aae024-d210-41b8-8374-2766f1f96612

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.