### PR TITLE
feat: Added SegmentedControl to DSRN

### DIFF
--- a/packages/design-system-react-native/src/components/FilterButton/FilterButton.test.tsx
+++ b/packages/design-system-react-native/src/components/FilterButton/FilterButton.test.tsx
@@ -1,4 +1,5 @@
 import {
+  ButtonBaseSize,
   IconColor,
   IconName,
   IconSize,
@@ -11,6 +12,7 @@ import React from 'react';
 
 import { FilterButtonGroup } from '../FilterButtonGroup/FilterButtonGroup';
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from '../Icon/Icon.constants';
+import { SegmentedControl } from '../SegmentedControl/SegmentedControl';
 
 import { FilterButton } from './FilterButton';
 
@@ -424,6 +426,45 @@ describe('FilterButton', () => {
 
       expect(getByTestId('filter-a')).toHaveStyle(tw`bg-transparent`);
       expect(getByTestId('filter-b')).toHaveStyle(tw`bg-icon-default`);
+    });
+  });
+
+  describe('when group context provides size and isEqualWidth', () => {
+    it('uses group size when child omits size', () => {
+      const { getByTestId } = render(
+        <SegmentedControl
+          value="a"
+          onChange={noopPress}
+          size={ButtonBaseSize.Md}
+          testID="group"
+        >
+          <FilterButton value="a" testID="filter-a" onPress={noopPress}>
+            A
+          </FilterButton>
+        </SegmentedControl>,
+      );
+
+      expect(getByTestId('filter-a')).toHaveStyle(tw`h-10`);
+    });
+
+    it('uses group isEqualWidth when isFullWidth is true', () => {
+      const { getByTestId } = render(
+        <SegmentedControl
+          value="a"
+          onChange={noopPress}
+          testID="group"
+          isFullWidth
+        >
+          <FilterButton value="a" testID="filter-a" onPress={noopPress}>
+            A
+          </FilterButton>
+          <FilterButton value="b" testID="filter-b" onPress={noopPress}>
+            B
+          </FilterButton>
+        </SegmentedControl>,
+      );
+
+      expect(getByTestId('filter-a')).toHaveStyle(tw`w-full`);
     });
   });
 });

--- a/packages/design-system-react-native/src/components/FilterButton/FilterButton.tsx
+++ b/packages/design-system-react-native/src/components/FilterButton/FilterButton.tsx
@@ -21,7 +21,8 @@ export const FilterButton = ({
   isSelected = false,
   variant,
   isLoading = false,
-  size = ButtonBaseSize.Sm,
+  size,
+  isFullWidth,
   twClassName = '',
   style,
   onPress,
@@ -32,6 +33,11 @@ export const FilterButton = ({
 
   const effectiveVariant =
     variant ?? filterButtonGroup?.variant ?? FilterButtonVariant.Primary;
+
+  const effectiveSize = size ?? filterButtonGroup?.size ?? ButtonBaseSize.Sm;
+
+  const effectiveIsFullWidth =
+    isFullWidth ?? filterButtonGroup?.isEqualWidth ?? false;
 
   const effectiveIsSelected = usesGroupSelection
     ? filterButtonGroup.value === value
@@ -68,7 +74,8 @@ export const FilterButton = ({
   return (
     <ButtonBase
       {...buttonBaseRest}
-      size={size}
+      size={effectiveSize}
+      isFullWidth={effectiveIsFullWidth}
       isLoading={isLoading}
       children={children}
       onPress={handlePress}

--- a/packages/design-system-react-native/src/components/SegmentedControl/README.md
+++ b/packages/design-system-react-native/src/components/SegmentedControl/README.md
@@ -1,0 +1,203 @@
+# SegmentedControl
+
+SegmentedControl is a controlled horizontal control for switching between a fixed set of options. Compose it with **`FilterButton`** children and use it when the parent owns a single string **`value`**. For scrollable filter rows without a bordered container, use **`FilterButtonGroup`** instead.
+
+```tsx
+import { useState } from 'react';
+import {
+  FilterButton,
+  SegmentedControl,
+} from '@metamask/design-system-react-native';
+
+const [value, setValue] = useState('reaches');
+
+<SegmentedControl value={value} onChange={setValue}>
+  <FilterButton value="reaches" onPress={() => {}}>
+    Price reaches
+  </FilterButton>
+  <FilterButton value="change" onPress={() => {}}>
+    Price change
+  </FilterButton>
+</SegmentedControl>;
+```
+
+## Props
+
+### `value`
+
+The selected segment value. Must match the **`value`** prop of the active **`FilterButton`**.
+
+| TYPE     | REQUIRED | DEFAULT |
+| -------- | -------- | ------- |
+| `string` | Yes      | N/A     |
+
+```tsx
+import { useState } from 'react';
+import {
+  FilterButton,
+  SegmentedControl,
+} from '@metamask/design-system-react-native';
+
+const [value, setValue] = useState('a');
+
+<SegmentedControl value={value} onChange={setValue}>
+  <FilterButton value="a" onPress={() => {}}>
+    A
+  </FilterButton>
+  <FilterButton value="b" onPress={() => {}}>
+    B
+  </FilterButton>
+</SegmentedControl>;
+```
+
+### `onChange`
+
+Called with the next segment value when the user selects a participating **`FilterButton`**.
+
+| TYPE                      | REQUIRED | DEFAULT |
+| ------------------------- | -------- | ------- |
+| `(value: string) => void` | Yes      | N/A     |
+
+```tsx
+import { useState } from 'react';
+import {
+  FilterButton,
+  SegmentedControl,
+} from '@metamask/design-system-react-native';
+
+const [value, setValue] = useState('a');
+
+<SegmentedControl value={value} onChange={(nextValue) => setValue(nextValue)}>
+  <FilterButton value="a" onPress={() => {}}>
+    A
+  </FilterButton>
+  <FilterButton value="b" onPress={() => {}}>
+    B
+  </FilterButton>
+</SegmentedControl>;
+```
+
+### `size`
+
+Size of the control and all child **`FilterButton`** segments. Also sets the container border radius.
+
+Available sizes:
+
+- `ButtonBaseSize.Sm` (32px segment height, 12px container radius)
+- `ButtonBaseSize.Md` (40px segment height, 16px container radius)
+- `ButtonBaseSize.Lg` (48px segment height, 16px container radius)
+
+| TYPE             | REQUIRED | DEFAULT             |
+| ---------------- | -------- | ------------------- |
+| `ButtonBaseSize` | No       | `ButtonBaseSize.Sm` |
+
+```tsx
+import { useState } from 'react';
+import {
+  ButtonBaseSize,
+  FilterButton,
+  SegmentedControl,
+} from '@metamask/design-system-react-native';
+
+const [value, setValue] = useState('a');
+
+<SegmentedControl value={value} onChange={setValue} size={ButtonBaseSize.Md}>
+  <FilterButton value="a" onPress={() => {}}>
+    A
+  </FilterButton>
+  <FilterButton value="b" onPress={() => {}}>
+    B
+  </FilterButton>
+</SegmentedControl>;
+```
+
+### `isFullWidth`
+
+When true, the control stretches to the width of its parent and segments share equal width.
+
+| TYPE      | REQUIRED | DEFAULT |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
+```tsx
+import { useState } from 'react';
+import {
+  FilterButton,
+  SegmentedControl,
+} from '@metamask/design-system-react-native';
+
+const [value, setValue] = useState('a');
+
+<SegmentedControl value={value} onChange={setValue} isFullWidth>
+  <FilterButton value="a" onPress={() => {}}>
+    A
+  </FilterButton>
+  <FilterButton value="b" onPress={() => {}}>
+    B
+  </FilterButton>
+</SegmentedControl>;
+```
+
+### `twClassName`
+
+Use the `twClassName` prop to add Tailwind CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+| TYPE     | REQUIRED | DEFAULT     |
+| -------- | -------- | ----------- |
+| `string` | No       | `undefined` |
+
+```tsx
+import { useState } from 'react';
+import {
+  FilterButton,
+  SegmentedControl,
+} from '@metamask/design-system-react-native';
+
+const [value, setValue] = useState('a');
+
+// Add additional styles
+<SegmentedControl value={value} onChange={setValue} twClassName="mt-4">
+  <FilterButton value="a" onPress={() => {}}>
+    A
+  </FilterButton>
+  <FilterButton value="b" onPress={() => {}}>
+    B
+  </FilterButton>
+</SegmentedControl>;
+```
+
+### `style`
+
+Use the `style` prop to customize the component's appearance with React Native styles. For consistent styling, prefer using `twClassName` with Tailwind classes when possible. Use `style` with `tw.style()` for conditionals or dynamic values.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `StyleProp<ViewStyle>` | No       | `undefined` |
+
+```tsx
+import { useState } from 'react';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  FilterButton,
+  SegmentedControl,
+} from '@metamask/design-system-react-native';
+
+const [value, setValue] = useState('a');
+const tw = useTailwind();
+
+<SegmentedControl value={value} onChange={setValue} style={tw.style('mt-2')}>
+  <FilterButton value="a" onPress={() => {}}>
+    A
+  </FilterButton>
+  <FilterButton value="b" onPress={() => {}}>
+    B
+  </FilterButton>
+</SegmentedControl>;
+```
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.constants.ts
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.constants.ts
@@ -1,0 +1,14 @@
+import { ButtonBaseSize } from '@metamask/design-system-shared';
+
+export const TWCLASSMAP_SEGMENTEDCONTROL_BORDER_RADIUS: Record<
+  ButtonBaseSize,
+  string
+> = {
+  [ButtonBaseSize.Sm]: 'rounded-xl',
+  [ButtonBaseSize.Md]: 'rounded-2xl',
+  [ButtonBaseSize.Lg]: 'rounded-2xl',
+};
+
+export const getSegmentedControlBorderRadiusTwClass = (
+  size: ButtonBaseSize,
+): string => TWCLASSMAP_SEGMENTEDCONTROL_BORDER_RADIUS[size];

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,140 @@
+import { ButtonBaseSize } from '@metamask/design-system-shared';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import React, { useEffect, useState } from 'react';
+import { View } from 'react-native';
+
+import { Box } from '../Box';
+import { FilterButton } from '../FilterButton';
+
+import { SegmentedControl } from './SegmentedControl';
+import type { SegmentedControlProps } from './SegmentedControl.types';
+
+const noopPress = () => undefined;
+
+const meta: Meta<SegmentedControlProps> = {
+  title: 'Components/SegmentedControl',
+  component: SegmentedControl,
+  argTypes: {
+    value: {
+      control: 'text',
+      description:
+        'Selected segment value matching a child FilterButton value.',
+    },
+    size: {
+      control: 'select',
+      options: Object.keys(ButtonBaseSize),
+      mapping: ButtonBaseSize,
+      description: 'Size of the control and child FilterButton segments.',
+    },
+    isFullWidth: {
+      control: 'boolean',
+      description:
+        'When true, stretches to the parent width with equal-width segments.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ padding: 16, alignItems: 'flex-start' }}>
+        <Story />
+      </View>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<SegmentedControlProps>;
+
+const ControlledSegmentedControl = ({
+  value: valueArg = 'reaches',
+  ...args
+}: Partial<SegmentedControlProps>) => {
+  const [value, setValue] = useState(valueArg);
+
+  useEffect(() => {
+    setValue(valueArg);
+  }, [valueArg]);
+
+  return (
+    <SegmentedControl {...args} value={value} onChange={setValue}>
+      <FilterButton value="reaches" onPress={noopPress}>
+        Price reaches
+      </FilterButton>
+      <FilterButton value="change" onPress={noopPress}>
+        Price change
+      </FilterButton>
+    </SegmentedControl>
+  );
+};
+
+export const Default: Story = {
+  args: {
+    value: 'reaches',
+    size: ButtonBaseSize.Sm,
+    isFullWidth: false,
+  },
+  render: (args) => <ControlledSegmentedControl {...args} />,
+};
+
+export const Size: Story = {
+  render: () => {
+    const [smValue, setSmValue] = useState('reaches');
+    const [mdValue, setMdValue] = useState('reaches');
+    const [lgValue, setLgValue] = useState('reaches');
+
+    return (
+      <Box gap={6}>
+        <SegmentedControl
+          value={smValue}
+          onChange={setSmValue}
+          size={ButtonBaseSize.Sm}
+        >
+          <FilterButton value="reaches" onPress={noopPress}>
+            Small
+          </FilterButton>
+          <FilterButton value="change" onPress={noopPress}>
+            Segment
+          </FilterButton>
+        </SegmentedControl>
+        <SegmentedControl
+          value={mdValue}
+          onChange={setMdValue}
+          size={ButtonBaseSize.Md}
+        >
+          <FilterButton value="reaches" onPress={noopPress}>
+            Medium
+          </FilterButton>
+          <FilterButton value="change" onPress={noopPress}>
+            Segment
+          </FilterButton>
+        </SegmentedControl>
+        <SegmentedControl
+          value={lgValue}
+          onChange={setLgValue}
+          size={ButtonBaseSize.Lg}
+        >
+          <FilterButton value="reaches" onPress={noopPress}>
+            Large
+          </FilterButton>
+          <FilterButton value="change" onPress={noopPress}>
+            Segment
+          </FilterButton>
+        </SegmentedControl>
+      </Box>
+    );
+  },
+};
+
+export const IsFullWidth: Story = {
+  args: {
+    isFullWidth: true,
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ padding: 16, alignSelf: 'stretch' }}>
+        <Story />
+      </View>
+    ),
+  ],
+  render: (args) => <ControlledSegmentedControl {...args} />,
+};

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,226 @@
+import { ButtonBaseSize } from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { fireEvent, render, renderHook } from '@testing-library/react-native';
+import React, { useState } from 'react';
+
+import { FilterButton } from '../FilterButton';
+
+import { SegmentedControl } from './SegmentedControl';
+import type { SegmentedControlProps } from './SegmentedControl.types';
+
+const GROUP_TEST_ID = 'segmented-control';
+const FILTER_A_TEST_ID = 'filter-a';
+const FILTER_B_TEST_ID = 'filter-b';
+
+const noopPress = () => undefined;
+
+const defaultSegments = (
+  <>
+    <FilterButton value="a" testID={FILTER_A_TEST_ID} onPress={noopPress}>
+      A
+    </FilterButton>
+    <FilterButton value="b" testID={FILTER_B_TEST_ID} onPress={noopPress}>
+      B
+    </FilterButton>
+  </>
+);
+
+const renderSegmentedControl = (
+  props: Partial<SegmentedControlProps> = {},
+  segments = defaultSegments,
+) =>
+  render(
+    <SegmentedControl
+      value="a"
+      onChange={noopPress}
+      testID={GROUP_TEST_ID}
+      {...props}
+    >
+      {segments}
+    </SegmentedControl>,
+  );
+
+describe('SegmentedControl', () => {
+  let tw: ReturnType<typeof useTailwind>;
+
+  beforeAll(() => {
+    tw = renderHook(() => useTailwind()).result.current;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when rendering children', () => {
+    it('renders filter button labels on the screen', () => {
+      const { getByText } = renderSegmentedControl();
+
+      expect(getByText('A')).toBeOnTheScreen();
+      expect(getByText('B')).toBeOnTheScreen();
+    });
+  });
+
+  describe('when isFullWidth is false', () => {
+    it('applies shrink-wrap container styles', () => {
+      const { getByTestId } = renderSegmentedControl(
+        {},
+        <FilterButton value="a" onPress={noopPress}>
+          A
+        </FilterButton>,
+      );
+
+      expect(getByTestId(GROUP_TEST_ID)).toHaveStyle(
+        tw.style(
+          'self-start flex-row items-center gap-1 border border-muted p-1 rounded-xl',
+        ),
+      );
+    });
+
+    describe('when twClassName is provided', () => {
+      it('merges twClassName after default container styles', () => {
+        const { getByTestId } = renderSegmentedControl(
+          { twClassName: 'px-4' },
+          <FilterButton value="a" onPress={noopPress}>
+            A
+          </FilterButton>,
+        );
+
+        expect(getByTestId(GROUP_TEST_ID)).toHaveStyle(
+          tw.style(
+            'self-start flex-row items-center gap-1 border border-muted p-1 rounded-xl px-4',
+          ),
+        );
+      });
+    });
+
+    describe('when size is provided', () => {
+      it.each([
+        [ButtonBaseSize.Sm, 'rounded-xl'],
+        [ButtonBaseSize.Md, 'rounded-2xl'],
+        [ButtonBaseSize.Lg, 'rounded-2xl'],
+      ] as const)(
+        'applies %s container border radius',
+        (size, borderRadiusClass) => {
+          const { getByTestId } = renderSegmentedControl(
+            { size },
+            <FilterButton value="a" onPress={noopPress}>
+              A
+            </FilterButton>,
+          );
+
+          expect(getByTestId(GROUP_TEST_ID)).toHaveStyle(
+            tw.style(borderRadiusClass),
+          );
+        },
+      );
+
+      it('propagates size to child filter buttons', () => {
+        const { getByTestId } = renderSegmentedControl({
+          size: ButtonBaseSize.Md,
+        });
+
+        expect(getByTestId(FILTER_A_TEST_ID)).toHaveStyle(tw`h-10`);
+      });
+    });
+  });
+
+  describe('when isFullWidth is true', () => {
+    it('applies self-stretch on the container', () => {
+      const { getByTestId } = renderSegmentedControl(
+        { isFullWidth: true },
+        <FilterButton value="a" onPress={noopPress}>
+          A
+        </FilterButton>,
+      );
+
+      expect(getByTestId(GROUP_TEST_ID)).toHaveStyle(tw.style('self-stretch'));
+    });
+
+    it('applies full width to child filter buttons', () => {
+      const { getByTestId } = renderSegmentedControl({ isFullWidth: true });
+
+      expect(getByTestId(FILTER_A_TEST_ID)).toHaveStyle(tw`w-full`);
+      expect(getByTestId(FILTER_B_TEST_ID)).toHaveStyle(tw`w-full`);
+    });
+  });
+
+  describe('when coordinating filter button selection', () => {
+    it('applies secondary variant styling to the selected segment', () => {
+      const { getByTestId } = renderSegmentedControl(
+        {},
+        <FilterButton value="a" testID={FILTER_A_TEST_ID} onPress={noopPress}>
+          A
+        </FilterButton>,
+      );
+
+      expect(getByTestId(FILTER_A_TEST_ID)).toHaveStyle(tw`bg-muted`);
+    });
+
+    it('reflects selection from value for participating filter buttons', () => {
+      const { getByTestId } = renderSegmentedControl({ value: 'b' });
+
+      expect(getByTestId(FILTER_A_TEST_ID)).toHaveStyle(tw`bg-transparent`);
+      expect(getByTestId(FILTER_B_TEST_ID)).toHaveStyle(tw`bg-muted`);
+    });
+
+    it('calls onChange when a different filter button is pressed', () => {
+      const onChange = jest.fn();
+      const { getByText } = renderSegmentedControl({ onChange });
+
+      fireEvent.press(getByText('B'));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith('b');
+    });
+
+    it('does not call onChange when the active filter button is pressed again', () => {
+      const onChange = jest.fn();
+      const { getByText } = renderSegmentedControl({ onChange });
+
+      fireEvent.press(getByText('A'));
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('updates selection when parent state changes after onChange', () => {
+      const ControlledFixture = () => {
+        const [value, setValue] = useState('a');
+
+        return (
+          <SegmentedControl
+            value={value}
+            onChange={setValue}
+            testID={GROUP_TEST_ID}
+          >
+            {defaultSegments}
+          </SegmentedControl>
+        );
+      };
+
+      const { getByText, getByTestId } = render(<ControlledFixture />);
+
+      expect(getByTestId(FILTER_A_TEST_ID)).toHaveStyle(tw`bg-muted`);
+
+      fireEvent.press(getByText('B'));
+
+      expect(getByTestId(FILTER_B_TEST_ID)).toHaveStyle(tw`bg-muted`);
+      expect(getByTestId(FILTER_A_TEST_ID)).toHaveStyle(tw`bg-transparent`);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('exposes tablist role on the container', () => {
+      const { getByTestId } = renderSegmentedControl(
+        {},
+        <FilterButton value="a" onPress={noopPress}>
+          A
+        </FilterButton>,
+      );
+
+      expect(getByTestId(GROUP_TEST_ID)).toHaveProp(
+        'accessibilityRole',
+        'tablist',
+      );
+    });
+  });
+});

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,65 @@
+import {
+  ButtonBaseSize,
+  FilterButtonGroupContext,
+  FilterButtonVariant,
+  mergeTwClassName,
+} from '@metamask/design-system-shared';
+import React, { Children, useMemo } from 'react';
+
+import { Box } from '../Box';
+
+import { getSegmentedControlBorderRadiusTwClass } from './SegmentedControl.constants';
+import type { SegmentedControlProps } from './SegmentedControl.types';
+
+export const SegmentedControl = ({
+  value,
+  onChange,
+  size = ButtonBaseSize.Sm,
+  isFullWidth = false,
+  children,
+  twClassName,
+  style,
+  ...rest
+}: SegmentedControlProps) => {
+  const contextValue = useMemo(
+    () => ({
+      value,
+      onChange,
+      variant: FilterButtonVariant.Secondary,
+      size,
+      isEqualWidth: isFullWidth,
+    }),
+    [value, onChange, size, isFullWidth],
+  );
+
+  const widthClass = isFullWidth ? 'self-stretch' : 'self-start';
+
+  return (
+    <FilterButtonGroupContext.Provider value={contextValue}>
+      <Box
+        {...rest}
+        accessibilityRole="tablist"
+        twClassName={mergeTwClassName(
+          mergeTwClassName(
+            `${widthClass} flex-row items-center gap-1 border border-muted p-1`,
+            getSegmentedControlBorderRadiusTwClass(size),
+          ),
+          twClassName,
+        )}
+        style={style}
+      >
+        {Children.map(children, (child, index) =>
+          isFullWidth ? (
+            <Box key={index} twClassName="flex-1">
+              {child}
+            </Box>
+          ) : (
+            <React.Fragment key={index}>{child}</React.Fragment>
+          ),
+        )}
+      </Box>
+    </FilterButtonGroupContext.Provider>
+  );
+};
+
+SegmentedControl.displayName = 'SegmentedControl';

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.types.ts
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.types.ts
@@ -1,0 +1,13 @@
+import type { SegmentedControlPropsShared } from '@metamask/design-system-shared';
+import type { ViewProps } from 'react-native';
+
+/**
+ * SegmentedControl component props.
+ */
+export type SegmentedControlProps = SegmentedControlPropsShared &
+  ViewProps & {
+    /**
+     * Optional twrnc classes merged into the root container after defaults.
+     */
+    twClassName?: string;
+  };

--- a/packages/design-system-react-native/src/components/SegmentedControl/index.ts
+++ b/packages/design-system-react-native/src/components/SegmentedControl/index.ts
@@ -1,0 +1,2 @@
+export { SegmentedControl } from './SegmentedControl';
+export type { SegmentedControlProps } from './SegmentedControl.types';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -289,3 +289,6 @@ export type { TagProps } from './Tag';
 
 export { SectionHeader } from './SectionHeader';
 export type { SectionHeaderProps } from './SectionHeader';
+
+export { SegmentedControl } from './SegmentedControl';
+export type { SegmentedControlProps } from './SegmentedControl';

--- a/packages/design-system-shared/src/contexts/FilterButtonGroup/FilterButtonGroup.context.test.ts
+++ b/packages/design-system-shared/src/contexts/FilterButtonGroup/FilterButtonGroup.context.test.ts
@@ -1,6 +1,7 @@
 import { createElement, useContext } from 'react';
 import { act, create } from 'react-test-renderer';
 
+import { ButtonBaseSize } from '../../types/ButtonBase/ButtonBase.types';
 import { FilterButtonVariant } from '../../types/FilterButton/FilterButton.types';
 
 import type { FilterButtonGroupContextValue } from '.';
@@ -97,6 +98,40 @@ describe('FilterButtonGroupContext', () => {
       expect(root.toJSON()).toMatchObject({
         type: 'span',
         children: ['secondary'],
+      });
+    });
+
+    it('exposes optional size and isEqualWidth when set', () => {
+      const providerValue: FilterButtonGroupContextValue = {
+        value: 'a',
+        onChange: jest.fn(),
+        size: ButtonBaseSize.Md,
+        isEqualWidth: true,
+      };
+
+      function Consumer() {
+        const ctx = useContext(FilterButtonGroupContext);
+        return createElement(
+          'span',
+          null,
+          `${ctx?.size ?? 'none'}-${ctx?.isEqualWidth ? 'equal' : 'auto'}`,
+        );
+      }
+
+      let root!: ReturnType<typeof create>;
+      act(() => {
+        root = create(
+          createElement(
+            FilterButtonGroupContext.Provider,
+            { value: providerValue },
+            createElement(Consumer),
+          ),
+        );
+      });
+
+      expect(root.toJSON()).toMatchObject({
+        type: 'span',
+        children: ['md-equal'],
       });
     });
   });

--- a/packages/design-system-shared/src/contexts/FilterButtonGroup/FilterButtonGroup.context.ts
+++ b/packages/design-system-shared/src/contexts/FilterButtonGroup/FilterButtonGroup.context.ts
@@ -1,11 +1,14 @@
 import { createContext } from 'react';
 
+import type { ButtonBaseSize } from '../../types/ButtonBase/ButtonBase.types';
 import type { FilterButtonVariant } from '../../types/FilterButton/FilterButton.types';
 
 export type FilterButtonGroupContextValue = {
   value: string;
   onChange: (nextValue: string) => void;
   variant?: FilterButtonVariant;
+  size?: ButtonBaseSize;
+  isEqualWidth?: boolean;
 };
 
 export const FilterButtonGroupContext =

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -239,6 +239,9 @@ export {
 // FilterButtonGroup types (ADR-0003 + ADR-0004)
 export { type FilterButtonGroupPropsShared } from './types/FilterButtonGroup';
 
+// SegmentedControl types (ADR-0004)
+export { type SegmentedControlPropsShared } from './types/SegmentedControl';
+
 // FilterButtonGroup context (ADR-0003 + ADR-0004)
 export {
   FilterButtonGroupContext,

--- a/packages/design-system-shared/src/types/SegmentedControl/SegmentedControl.types.ts
+++ b/packages/design-system-shared/src/types/SegmentedControl/SegmentedControl.types.ts
@@ -1,0 +1,28 @@
+import type { ButtonBaseSize } from '../ButtonBase/ButtonBase.types';
+
+/**
+ * SegmentedControl component shared props (ADR-0004).
+ * Controlled-only: parent owns `value` and updates it from `onChange`.
+ */
+export type SegmentedControlPropsShared = {
+  /**
+   * Selected segment value; must match a child `FilterButton` `value`.
+   */
+  value: string;
+  /**
+   * Called when the user selects a segment (via a participating `FilterButton`).
+   */
+  onChange: (value: string) => void;
+  /**
+   * Size of the control and child filter buttons.
+   *
+   * @default ButtonBaseSize.Sm
+   */
+  size?: ButtonBaseSize;
+  /**
+   * When true, the control stretches to the width of its parent and segments share equal width.
+   *
+   * @default false
+   */
+  isFullWidth?: boolean;
+};

--- a/packages/design-system-shared/src/types/SegmentedControl/index.ts
+++ b/packages/design-system-shared/src/types/SegmentedControl/index.ts
@@ -1,0 +1,1 @@
+export { type SegmentedControlPropsShared } from './SegmentedControl.types';


### PR DESCRIPTION
## **Description**

Adds **`SegmentedControl`** to `@metamask/design-system-react-native` — a controlled segmented picker for switching between a fixed set of options.

It follows the same composition model as **`FilterButtonGroup`** (`FilterButton` children with `value` / `onPress`), but is tailored for bordered, inline segment UIs:

- Wraps segments in a container with **1px `border-muted`** and **4px padding**
- Always uses **`FilterButton` secondary variant** via context
- Supports group-level **`size`** (propagates to child buttons and maps container border radius: `sm` → 12px, `md`/`lg` → 16px)
- Supports **`isFullWidth`** (`false` by default for shrink-wrap; `true` for edge-to-edge equal-width segments)
- Exposes **`accessibilityRole="tablist"`** on the container

Also extends **`FilterButtonGroupContext`** with optional `size` and `isEqualWidth`, and updates **`FilterButton`** to read those values from context when present.

Shared types live in `@metamask/design-system-shared` (`SegmentedControlPropsShared`). React web is out of scope for this PR (same as `FilterButtonGroup`).

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-882

## **Manual testing steps**

1. Run React Native Storybook: `yarn storybook:ios` or `yarn storybook:android`
2. Open **Components/SegmentedControl**
3. **Default** — confirm shrink-wrap layout, secondary variant styling, and segment selection updates on tap
4. **Size** — confirm sm / md / lg variants (button height and container border radius)
5. **IsFullWidth** — confirm control stretches edge-to-edge with equal-width segments
6. Run unit tests: `yarn workspace @metamask/design-system-react-native run jest --testPathPattern="SegmentedControl.test|FilterButton.test"`

## **Screenshots/Recordings**

### **Before**

N/A — new component

### **After**

https://github.com/user-attachments/assets/bb018d95-9466-4f8a-b787-b7293fde9699

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.