### PR TITLE
fix: allow disabled prop to pass through to button element

### DIFF
--- a/packages/design-system-react/src/components/TextButton/TextButton.tsx
+++ b/packages/design-system-react/src/components/TextButton/TextButton.tsx
@@ -28,7 +28,7 @@ export const TextButton = forwardRef<HTMLButtonElement, TextButtonProps>(
       onClick,
       asChild,
       type = 'button',
-      ...rest
+      ...props
     },
     ref,
   ) => {
@@ -40,11 +40,11 @@ export const TextButton = forwardRef<HTMLButtonElement, TextButtonProps>(
     );
 
     const textButtonContent = asChild ? (
-      <Slot ref={ref} onClick={onClick} {...rest}>
+      <Slot ref={ref} onClick={onClick} {...props}>
         {children}
       </Slot>
     ) : (
-      <button ref={ref} type={type} onClick={onClick} {...rest}>
+      <button ref={ref} type={type} onClick={onClick} {...props}>
         {children}
       </button>
     );

--- a/packages/design-system-react/src/components/TextButton/TextButton.types.ts
+++ b/packages/design-system-react/src/components/TextButton/TextButton.types.ts
@@ -7,7 +7,7 @@ export type TextButtonProps = TextButtonPropsShared &
   Omit<TextProps, 'asChild' | 'children' | 'color'> &
   Omit<
     ComponentProps<'button'>,
-    'children' | 'color' | 'disabled' | 'onClick'
+    'children' | 'color' | 'onClick'
   > & {
     /**
      * Called when the user clicks the label. Primary interaction for this control.

--- a/packages/design-system-react/src/components/TextButton/TextButton.types.ts
+++ b/packages/design-system-react/src/components/TextButton/TextButton.types.ts
@@ -5,10 +5,7 @@ import type { TextProps } from '../Text';
 
 export type TextButtonProps = TextButtonPropsShared &
   Omit<TextProps, 'asChild' | 'children' | 'color'> &
-  Omit<
-    ComponentProps<'button'>,
-    'children' | 'color' | 'onClick'
-  > & {
+  Omit<ComponentProps<'button'>, 'children' | 'color' | 'onClick'> & {
     /**
      * Called when the user clicks the label. Primary interaction for this control.
      */


### PR DESCRIPTION
## **Description**

Removes `disabled` from the `Omit` in `TextButtonProps` so consumers can pass the native `disabled` attribute down to the underlying `<button>` element. Also renames the destructured catch-all from `...rest` to `...props` per monorepo conventions.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Render a `TextButton` with `disabled` prop and verify the button is disabled.
2. Confirm disabled styling and non-interactivity behave as expected.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.