### PR TITLE
Release 46.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "45.0.0",
+  "version": "46.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.30.1]
 
-### Uncategorized
+### Fixed
 
-- fix(design-system-react-native): mark BottomSheetDialog pan callbacks as worklets ([#1253](https://github.com/MetaMask/metamask-design-system/pull/1253))
-- docs: Standardize docs and stories for Tag ([#1221](https://github.com/MetaMask/metamask-design-system/pull/1221))
-- chore: Polish tag and align Code Connect documentation ([#1236](https://github.com/MetaMask/metamask-design-system/pull/1236))
+- Fixed `BottomSheetDialog` pan callbacks to run on the UI thread, resolving broken slow-drag gesture ([#1253](https://github.com/MetaMask/metamask-design-system/pull/1253))
+- Fixed `Tag` gap between icon and label from 4px to 2px to match design spec ([#1236](https://github.com/MetaMask/metamask-design-system/pull/1236))
 
 ## [0.30.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix(design-system-react-native): mark BottomSheetDialog pan callbacks as worklets ([#1253](https://github.com/MetaMask/metamask-design-system/pull/1253))
+- docs: Standardize docs and stories for Tag ([#1221](https://github.com/MetaMask/metamask-design-system/pull/1221))
+- chore: Polish tag and align Code Connect documentation ([#1236](https://github.com/MetaMask/metamask-design-system/pull/1236))
+
 ## [0.30.0]
 
 ### Added

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1]
+
 ### Uncategorized
 
 - fix(design-system-react-native): mark BottomSheetDialog pan callbacks as worklets ([#1253](https://github.com/MetaMask/metamask-design-system/pull/1253))
@@ -521,7 +523,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.1...HEAD
+[0.30.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.0...@metamask/design-system-react-native@0.30.1
 [0.30.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.29.0...@metamask/design-system-react-native@0.30.0
 [0.29.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.28.0...@metamask/design-system-react-native@0.29.0
 [0.28.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.27.0...@metamask/design-system-react-native@0.28.0

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1]
+
 ### Uncategorized
 
 - docs: Standardize docs and stories for Tag ([#1221](https://github.com/MetaMask/metamask-design-system/pull/1221))
@@ -376,7 +378,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.27.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.27.1...HEAD
+[0.27.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.27.0...@metamask/design-system-react@0.27.1
 [0.27.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.26.0...@metamask/design-system-react@0.27.0
 [0.26.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.25.0...@metamask/design-system-react@0.26.0
 [0.25.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.24.0...@metamask/design-system-react@0.25.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,10 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.27.1]
 
-### Uncategorized
+### Fixed
 
-- docs: Standardize docs and stories for Tag ([#1221](https://github.com/MetaMask/metamask-design-system/pull/1221))
-- chore: Polish tag and align Code Connect documentation ([#1236](https://github.com/MetaMask/metamask-design-system/pull/1236))
+- Fixed `Tag` gap between icon and label from 4px to 2px to match design spec ([#1236](https://github.com/MetaMask/metamask-design-system/pull/1236))
 
 ## [0.27.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- docs: Standardize docs and stories for Tag ([#1221](https://github.com/MetaMask/metamask-design-system/pull/1221))
+- chore: Polish tag and align Code Connect documentation ([#1236](https://github.com/MetaMask/metamask-design-system/pull/1236))
+
 ## [0.27.0]
 
 ### Added

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- fix: add missing peer dependency devDeps across monorepo workspaces ([#1228](https://github.com/MetaMask/metamask-design-system/pull/1228))
-
 ## [0.5.0]
 
 ### Changed

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: add missing peer dependency devDeps across monorepo workspaces ([#1228](https://github.com/MetaMask/metamask-design-system/pull/1228))
+
 ## [0.5.0]
 
 ### Changed


### PR DESCRIPTION
## Release 46.0.0

Patch fixes for `BottomSheetDialog` slow-drag gesture regression in React Native and `Tag` gap alignment across both platforms.

### 📦 Package Versions

- `@metamask/design-system-react`: **0.27.1**
- `@metamask/design-system-react-native`: **0.30.1**

### 🌐 React Web Updates (0.27.1)

#### Fixed

- Fixed `Tag` gap between icon and label from 4px to 2px to match design spec ([#1236](https://github.com/MetaMask/metamask-design-system/pull/1236))

### 📱 React Native Updates (0.30.1)

#### Fixed

- Fixed `BottomSheetDialog` pan callbacks to run on the UI thread, resolving broken slow-drag gesture ([#1253](https://github.com/MetaMask/metamask-design-system/pull/1253))
- Fixed `Tag` gap between icon and label from 4px to 2px to match design spec ([#1236](https://github.com/MetaMask/metamask-design-system/pull/1236))

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-react: patch (0.27.0 → 0.27.1) - bug fix
  - [x] design-system-react-native: patch (0.30.0 → 0.30.1) - bug fix
- [ ] Breaking changes documented with migration guidance
- [ ] Migration guides updated with before/after examples (if breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release; documented fixes are patch-level UI/gesture behavior with no API or breaking changes in this diff.
> 
> **Overview**
> **Release 46.0.0** cuts patch publishes for the design-system packages already merged on main—no new component or source changes in this diff.
> 
> The monorepo root version moves **45.0.0 → 46.0.0**. **`@metamask/design-system-react`** is bumped **0.27.0 → 0.27.1** with changelog **0.27.1** documenting the **`Tag`** icon–label gap fix (4px → 2px). **`@metamask/design-system-react-native`** goes **0.30.0 → 0.30.1** with changelog **0.30.1** for the same **`Tag`** spacing fix plus **`BottomSheetDialog`** pan callbacks running on the UI thread (slow-drag gesture). Changelog compare links and **`[Unreleased]`** anchors are updated for both packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d44d43c2dc856833464032647e6d38d00374747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->