### PR TITLE
fix(design-system-react-native): right-align Content value and subvalue

### DIFF
--- a/packages/design-system-react-native/src/components/Content/Content.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.tsx
@@ -1,4 +1,5 @@
 import {
+  BoxAlignItems,
   BoxFlexDirection,
   ContentVerticalAlignment,
   FontWeight,
@@ -95,11 +96,11 @@ export const Content: React.FC<ContentProps> = ({
       {/* Value and subvalue Column */}
       {value || subvalue ? (
         <BoxColumn
+          alignItems={BoxAlignItems.End}
           twClassName="min-w-0"
           bottomAccessory={
             subvalue ? (
               <BoxRow
-                twClassName="w-full"
                 startAccessory={subvalueStartAccessory}
                 endAccessory={subvalueEndAccessory}
                 gap={1}
@@ -120,7 +121,6 @@ export const Content: React.FC<ContentProps> = ({
         >
           {value ? (
             <BoxRow
-              twClassName="w-full"
               startAccessory={valueStartAccessory}
               endAccessory={valueEndAccessory}
               gap={1}


### PR DESCRIPTION
## **Description**

`ListItem` (via `Content`) renders value and subvalue in a trailing column. That column used full-width rows with default start alignment, so when the two lines differed in length—common in activity rows like `-4.6862 mUSD` / `-$4.69`—they left-aligned with each other instead of flushing to the right edge.

This change right-aligns the value column by:
- Setting `alignItems={BoxAlignItems.End}` on the value/subvalue `BoxColumn`
- Removing `w-full` from the value and subvalue `BoxRow`s so each row shrink-wraps to its content

**Why:** Trailing amounts in list rows should align to the right margin, matching design intent and improving readability when token amounts and fiat equivalents differ in length.

**Solution:** Align the trailing column to the end so both value and subvalue share a clean flush-right edge. This applies anywhere `Content` or `ListItem` renders value/subvalue, not just Activity.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run React Native Storybook: `yarn storybook:ios` (or `yarn storybook:android`)
2. Open **Components/Content → Subvalue** and confirm `1.234 ETH` / `~$2,500` are right-aligned (trailing characters line up on the right)
3. Open **Components/ListItem** and set `value` and `subvalue` to strings of different lengths (e.g. value: `-4.6862 mUSD`, subvalue: `-$4.69`) — confirm both lines flush to the right edge
4. Verify rows with only `value` (no subvalue) still look correct
5. Verify rows with value/subvalue accessories (`valueStartAccessory`, `valueEndAccessory`, etc.) remain grouped and right-aligned
6. (Optional) Confirm in the mobile Activity screen that transaction amounts and fiat equivalents align to the right margin

## **Screenshots/Recordings**

### **Before**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-22 at 10 03 05" src="https://github.com/user-attachments/assets/81e7dada-01e2-4182-aea7-4ee227867e6f" />

### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-22 at 10 01 43" src="https://github.com/user-attachments/assets/f3907bf3-a326-437d-b1f2-3a028d4501b2" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentational layout change in a shared design-system component with no auth, data, or API impact.
> 
> **Overview**
> **Right-aligns the trailing value/subvalue column** in React Native `Content` (and `ListItem` rows that use it) so token amounts and fiat lines share a flush-right edge when their text lengths differ.
> 
> The value/subvalue `BoxColumn` now uses `alignItems={BoxAlignItems.End}`, and full-width `w-full` was removed from the value and subvalue `BoxRow`s so each row sizes to its content instead of stretching left.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822338394a8e640ae078dbb4dd9170c0d84ffd04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->