### PR TITLE
Release/47.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "46.0.0",
+  "version": "47.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix(design-system-react-native): right-align Content value and subvalue ([#1257](https://github.com/MetaMask/metamask-design-system/pull/1257))
+
 ## [0.30.1]
 
 ### Fixed

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.30.2]
 
-### Uncategorized
+### Fixed
 
-- fix(design-system-react-native): right-align Content value and subvalue ([#1257](https://github.com/MetaMask/metamask-design-system/pull/1257))
+- Fixed `Content` value and subvalue to right-align in list rows when token amounts and fiat equivalents differ in length, including in `ListItem` ([#1257](https://github.com/MetaMask/metamask-design-system/pull/1257))
 
 ## [0.30.1]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.2]
+
 ### Uncategorized
 
 - fix(design-system-react-native): right-align Content value and subvalue ([#1257](https://github.com/MetaMask/metamask-design-system/pull/1257))
@@ -526,7 +528,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.2...HEAD
+[0.30.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.1...@metamask/design-system-react-native@0.30.2
 [0.30.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.0...@metamask/design-system-react-native@0.30.1
 [0.30.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.29.0...@metamask/design-system-react-native@0.30.0
 [0.29.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.28.0...@metamask/design-system-react-native@0.29.0

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- fix: add missing peer dependency devDeps across monorepo workspaces ([#1228](https://github.com/MetaMask/metamask-design-system/pull/1228))
-
 ## [0.5.0]
 
 ### Changed

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: add missing peer dependency devDeps across monorepo workspaces ([#1228](https://github.com/MetaMask/metamask-design-system/pull/1228))
+
 ## [0.5.0]
 
 ### Changed


### PR DESCRIPTION
## Release 47.0.0

Patch release for React Native. Fixes trailing value/subvalue alignment in `Content` and `ListItem` list rows so token amounts and fiat equivalents flush to the right margin when their text lengths differ.

### 📦 Package Versions

- `@metamask/design-system-react-native`: **0.30.2**

### 📱 React Native Updates (0.30.2)

#### Fixed

- Fixed `Content` value and subvalue to right-align in list rows when token amounts and fiat equivalents differ in length, including in `ListItem` ([#1257](https://github.com/MetaMask/metamask-design-system/pull/1257))

### ⚠️ Breaking Changes

None.

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-react-native: patch (0.30.1 → 0.30.2) — layout bug fix, no API changes
- [x] Breaking changes documented with migration guidance — N/A
- [x] Migration guides updated with before/after examples — N/A
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples — N/A
- [ ] All unreleased changes are accounted for in changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and changelog updates; consumer impact is a documented visual layout patch with no API changes.
> 
> **Overview**
> **Release 47.0.0** cuts a monorepo release and ships **`@metamask/design-system-react-native` 0.30.2** (patch, 0.30.1 → 0.30.2). The diff is version bumps and changelog bookkeeping only—no component source in this PR.
> 
> The published **0.30.2** notes document a layout fix (from [#1257](https://github.com/MetaMask/metamask-design-system/pull/1257)): **`Content`** value/subvalue and **`ListItem`** rows now **right-align** trailing amounts when token and fiat strings differ in length. **No breaking changes** or API changes are called out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621aacff6d530278384f21bc140d3e46ad9dd903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->