### PR TITLE
chore: add Content Figma Code Connect

### DIFF
--- a/packages/design-system-react-native/src/components/Content/Content.figma.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.figma.tsx
@@ -1,0 +1,128 @@
+// import figma needs to remain as figma otherwise it breaks code connect
+// eslint-disable-next-line import-x/no-named-as-default
+import figma from '@figma/code-connect';
+import { ContentVerticalAlignment } from '@metamask/design-system-shared';
+import React from 'react';
+
+import { Content } from './Content';
+
+/**
+ * React Native implementation of Content (`figma.connect` for Figma Dev Mode).
+ *
+ * Root Figma props: `verticalAlignment`, `title`, `avatar`,
+ * `show description (Figma only)`, `description`,
+ * `show value (Figma only)`, `value`,
+ * `show subvalue (Figma only)`, `subvalue`,
+ * `show titleStartAccessory (Figma only)`, `titleStartAccessory`,
+ * `show titleEndAccessory (Figma only)`, `titleEndAccessory`,
+ * `show descriptionStartAccessory (Figma only)`, `descriptionStartAccessory`,
+ * `show descriptionEndAccessory (Figma only)`, `descriptionEndAccessory`,
+ * `show valueStartAccessory (Figma only)`, `valueStartAccessory`,
+ * `show valueEndAccessory (Figma only)`, `valueEndAccessory`,
+ * `show subvalueStartAccessory (Figma only)`, `subvalueStartAccessory`,
+ * `show subvalueEndAccessory (Figma only)`, `subvalueEndAccessory`.
+ *
+ * - **`show X (Figma only)`** boolean controls visibility in Figma only; in code,
+ *   pass `undefined` (omit the prop) to hide a slot.
+ * - **`action (Figma only)`** is visual-only in Figma; `Content` has no matching prop.
+ */
+figma.connect(
+  Content,
+  'https://www.figma.com/design/0GipXMImYPyEmNUvnyI5v8/%F0%9F%A6%8A-MMDS-Components?node-id=16063-21871',
+  {
+    props: {
+      verticalAlignment: figma.enum('verticalAlignment', {
+        center: ContentVerticalAlignment.Center,
+        top: ContentVerticalAlignment.Top,
+      }),
+      title: figma.string('title'),
+      avatar: figma.instance('avatar'),
+      description: figma.boolean('show description (Figma only)', {
+        true: figma.string('description'),
+        false: undefined,
+      }),
+      value: figma.boolean('show value (Figma only)', {
+        true: figma.string('value'),
+        false: undefined,
+      }),
+      subvalue: figma.boolean('show subvalue (Figma only)', {
+        true: figma.string('subvalue'),
+        false: undefined,
+      }),
+      titleStartAccessory: figma.boolean('show titleStartAccessory (Figma only)', {
+        true: figma.instance('titleStartAccessory'),
+        false: undefined,
+      }),
+      titleEndAccessory: figma.boolean('show titleEndAccessory (Figma only)', {
+        true: figma.instance('titleEndAccessory'),
+        false: undefined,
+      }),
+      descriptionStartAccessory: figma.boolean(
+        'show descriptionStartAccessory (Figma only)',
+        {
+          true: figma.instance('descriptionStartAccessory'),
+          false: undefined,
+        },
+      ),
+      descriptionEndAccessory: figma.boolean(
+        'show descriptionEndAccessory (Figma only)',
+        {
+          true: figma.instance('descriptionEndAccessory'),
+          false: undefined,
+        },
+      ),
+      valueStartAccessory: figma.boolean('show valueStartAccessory (Figma only)', {
+        true: figma.instance('valueStartAccessory'),
+        false: undefined,
+      }),
+      valueEndAccessory: figma.boolean('show valueEndAccessory (Figma only)', {
+        true: figma.instance('valueEndAccessory'),
+        false: undefined,
+      }),
+      subvalueStartAccessory: figma.boolean(
+        'show subvalueStartAccessory (Figma only)',
+        {
+          true: figma.instance('subvalueStartAccessory'),
+          false: undefined,
+        },
+      ),
+      subvalueEndAccessory: figma.boolean('show subvalueEndAccessory (Figma only)', {
+        true: figma.instance('subvalueEndAccessory'),
+        false: undefined,
+      }),
+    },
+    example: ({
+      verticalAlignment,
+      title,
+      avatar,
+      description,
+      value,
+      subvalue,
+      titleStartAccessory,
+      titleEndAccessory,
+      descriptionStartAccessory,
+      descriptionEndAccessory,
+      valueStartAccessory,
+      valueEndAccessory,
+      subvalueStartAccessory,
+      subvalueEndAccessory,
+    }) => (
+      <Content
+        verticalAlignment={verticalAlignment}
+        title={title}
+        avatar={avatar}
+        description={description}
+        value={value}
+        subvalue={subvalue}
+        titleStartAccessory={titleStartAccessory}
+        titleEndAccessory={titleEndAccessory}
+        descriptionStartAccessory={descriptionStartAccessory}
+        descriptionEndAccessory={descriptionEndAccessory}
+        valueStartAccessory={valueStartAccessory}
+        valueEndAccessory={valueEndAccessory}
+        subvalueStartAccessory={subvalueStartAccessory}
+        subvalueEndAccessory={subvalueEndAccessory}
+      />
+    ),
+  },
+);

--- a/packages/design-system-react-native/src/components/Content/Content.figma.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.figma.tsx
@@ -49,10 +49,13 @@ figma.connect(
         true: figma.string('subvalue'),
         false: undefined,
       }),
-      titleStartAccessory: figma.boolean('show titleStartAccessory (Figma only)', {
-        true: figma.instance('titleStartAccessory'),
-        false: undefined,
-      }),
+      titleStartAccessory: figma.boolean(
+        'show titleStartAccessory (Figma only)',
+        {
+          true: figma.instance('titleStartAccessory'),
+          false: undefined,
+        },
+      ),
       titleEndAccessory: figma.boolean('show titleEndAccessory (Figma only)', {
         true: figma.instance('titleEndAccessory'),
         false: undefined,
@@ -71,10 +74,13 @@ figma.connect(
           false: undefined,
         },
       ),
-      valueStartAccessory: figma.boolean('show valueStartAccessory (Figma only)', {
-        true: figma.instance('valueStartAccessory'),
-        false: undefined,
-      }),
+      valueStartAccessory: figma.boolean(
+        'show valueStartAccessory (Figma only)',
+        {
+          true: figma.instance('valueStartAccessory'),
+          false: undefined,
+        },
+      ),
       valueEndAccessory: figma.boolean('show valueEndAccessory (Figma only)', {
         true: figma.instance('valueEndAccessory'),
         false: undefined,
@@ -86,10 +92,13 @@ figma.connect(
           false: undefined,
         },
       ),
-      subvalueEndAccessory: figma.boolean('show subvalueEndAccessory (Figma only)', {
-        true: figma.instance('subvalueEndAccessory'),
-        false: undefined,
-      }),
+      subvalueEndAccessory: figma.boolean(
+        'show subvalueEndAccessory (Figma only)',
+        {
+          true: figma.instance('subvalueEndAccessory'),
+          false: undefined,
+        },
+      ),
     },
     example: ({
       verticalAlignment,


### PR DESCRIPTION
## **Description**

Adds `Content.figma.tsx` Code Connect for the React Native `Content` component, connecting it to the Figma branch component ([node 16063-21871](https://www.figma.com/design/0GipXMImYPyEmNUvnyI5v8/%F0%9F%A6%8A-MMDS-Components?node-id=16063-21871)).

This also includes Figma component property updates made on the branch to align with the code API and enable the slot architecture introduced in Code Connect 1.4.8 (PR #1260):

**Figma component changes (branch `0GipXMImYPyEmNUvnyI5v8`):**
- Renamed `contentStartAccessory` (INSTANCE_SWAP) → `avatar` to match the code prop name
- Renamed 8 boolean accessory properties to `show X (Figma only)` convention
- Added 8 INSTANCE_SWAP properties (`titleStartAccessory`, `titleEndAccessory`, `descriptionStartAccessory`, `descriptionEndAccessory`, `valueStartAccessory`, `valueEndAccessory`, `subvalueStartAccessory`, `subvalueEndAccessory`) with Icon Md as default and info/question as preferred values
- Bound all 16 icon instance layers (both `verticalAlignment` variants) to their respective INSTANCE_SWAP properties

**Code Connect mappings:**
- `figma.instance('avatar')` → `avatar` prop
- `figma.boolean('show X (Figma only)', { true: figma.instance('X'), false: undefined })` for all 8 accessory slots
- `figma.boolean('show X (Figma only)', { true: figma.string('X'), false: undefined })` for `description`, `value`, `subvalue`
- `figma.enum('verticalAlignment', ...)` → `ContentVerticalAlignment`
- `figma.string('title')` → `title`
- `action (Figma only)` intentionally omitted (no code prop equivalent)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Merge the Figma branch `0GipXMImYPyEmNUvnyI5v8` into the main MMDS Figma file
2. Refresh Figma token: `figma connect login`
3. Run `yarn figma:connect:publish:react-native` to publish Code Connect
4. Open the Content component in Figma Dev Mode — verify the React Native code snippet shows correct props including instance slots for accessories

## **Screenshots/Recordings**

### **Before**

No Code Connect for Content component.

### **After**

Content component Code Connect published with full prop mapping including INSTANCE_SWAP slots for all 8 accessory positions.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and design-tool integration only; no runtime component or app behavior changes.
> 
> **Overview**
> Adds **`Content.figma.tsx`** so Figma Dev Mode can show React Native **`Content`** snippets linked to the MMDS branch node **16063-21871**.
> 
> The **`figma.connect`** mapping wires **`verticalAlignment`**, **`title`**, **`avatar`**, optional text slots (**`description`**, **`value`**, **`subvalue`**) via **`show X (Figma only)`** booleans, and eight accessory slots via **`figma.instance`** with the same show/hide pattern. **`action (Figma only)`** is documented as Figma-only with no code prop. The **`example`** block mirrors the full prop surface for published snippets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a821e6304b3c93361d1e2efe214e3337de7cf99c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->