### PR TITLE
fix(react-native): align BottomSheetHeader horizontal padding with Figma

### DIFF
--- a/packages/design-system-react-native/src/components/BottomSheetHeader/BottomSheetHeader.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetHeader/BottomSheetHeader.tsx
@@ -41,7 +41,7 @@ export const BottomSheetHeader: React.FC<BottomSheetHeaderProps> = ({
   return (
     <HeaderBase
       {...props}
-      style={[tw.style('px-4', twClassName), style]}
+      style={[tw.style('px-2', twClassName), style]}
       startAccessory={startAccessory}
       endAccessory={endAccessory}
     >


### PR DESCRIPTION
## Summary
- Update `BottomSheetHeader` default horizontal padding from `px-4` to `px-2` to match the Figma design spec.
- This also aligns `BottomSheetHeader` default horizontal padding to match `HeaderStandard`

## Test plan
- [x] Verify `BottomSheetHeader` in React Native Storybook renders with tighter horizontal padding
- [x] Confirm back/close button alignment still looks correct with the reduced padding
- [x] Run `yarn workspace @metamask/design-system-react-native run test` for BottomSheetHeader tests


Made with [Cursor](https://cursor.com)