### PR TITLE
fix(react-native): update BottomSheetFooter padding

### DIFF
--- a/packages/design-system-react-native/src/components/BottomSheetFooter/BottomSheetFooter.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetFooter/BottomSheetFooter.tsx
@@ -34,7 +34,7 @@ export const BottomSheetFooter: React.FC<BottomSheetFooterProps> = ({
       style={[
         tw.style(
           isHorizontal ? 'flex-row' : 'flex-col',
-          'px-4 pb-4',
+          'px-4 py-0',
           twClassName,
         ),
         style,

--- a/packages/design-system-react-native/src/components/BottomSheetFooter/BottomSheetFooter.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetFooter/BottomSheetFooter.tsx
@@ -34,7 +34,7 @@ export const BottomSheetFooter: React.FC<BottomSheetFooterProps> = ({
       style={[
         tw.style(
           isHorizontal ? 'flex-row' : 'flex-col',
-          'px-2 py-1',
+          'px-4 pb-4',
           twClassName,
         ),
         style,


### PR DESCRIPTION
## Summary
- Update `BottomSheetFooter` container padding from `px-2 py-1` to `px-4 py-0` to match Figma spacing of 16px on sides and 0 top and bottom.

[Loom](https://www.loom.com/share/76d8118651d84d85b0c495fb22729f80)

Before
<img width="396" height="806" alt="image" src="https://github.com/user-attachments/assets/2b51dfe9-67ea-4efe-8172-b80dad96a044" />

After
<img width="399" height="847" alt="image" src="https://github.com/user-attachments/assets/73cd06c0-231d-4d3d-aaf7-8448c0894590" />
