### PR TITLE
fix(BannerBase): align spacing and action button with Figma (web and mobile)

### DIFF
--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -116,9 +116,9 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
 
       {shouldShowCloseButton && (
         <ButtonIcon
-          twClassName={closeButtonTwClassName}
+          twClassName={mergeTwClassName('-mt-1', closeButtonTwClassName)}
           iconName={IconName.Close}
-          size={ButtonIconSize.Sm}
+          size={ButtonIconSize.Md}
           accessibilityLabel={closeButtonAccessibilityLabel}
           onPress={onClose}
           {...resolvedCloseButtonProps}

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -4,6 +4,7 @@ import {
   BoxFlexDirection,
   ButtonIconSize,
   ButtonSize,
+  ButtonVariant,
   FontWeight,
   IconName,
   mergeTwClassName,
@@ -105,6 +106,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
               size={ButtonSize.Md}
               onPress={actionButtonOnPress}
               {...resolvedActionButtonProps}
+              variant={ButtonVariant.Secondary}
             >
               {actionButtonLabel}
             </Button>

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -61,7 +61,8 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
       alignItems={BoxAlignItems.Start}
       gap={4}
       backgroundColor={BoxBackgroundColor.BackgroundDefault}
-      padding={4}
+      paddingVertical={3}
+      paddingHorizontal={4}
       twClassName={mergeTwClassName('rounded-xl', twClassName)}
       {...props}
     >

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -51,10 +51,6 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
   const shouldShowCloseButton = Boolean(onClose);
   const shouldShowActionButton = Boolean(actionButtonOnPress);
 
-  const mergedCloseButtonTwClassName = closeButtonTwClassName
-    ? `ml-3 ${closeButtonTwClassName}`
-    : 'ml-3';
-
   return (
     <Box
       flexDirection={BoxFlexDirection.Row}
@@ -83,7 +79,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
           ))}
 
         {hasContent(description) && (
-          <Box twClassName={hasContent(title) ? 'mt-1' : undefined}>
+          <Box>
             {isTextContent(description) ? (
               <Text variant={TextVariant.BodySm} {...descriptionProps}>
                 {description}
@@ -104,7 +100,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
           ))}
 
         {shouldShowActionButton && (
-          <Box twClassName="mt-4">
+          <Box twClassName="mt-2">
             <Button
               size={ButtonSize.Md}
               onPress={actionButtonOnPress}
@@ -118,7 +114,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
 
       {shouldShowCloseButton && (
         <ButtonIcon
-          twClassName={mergedCloseButtonTwClassName}
+          twClassName={closeButtonTwClassName}
           iconName={IconName.Close}
           size={ButtonIconSize.Sm}
           accessibilityLabel={closeButtonAccessibilityLabel}

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -59,10 +59,10 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
     <Box
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Start}
-      gap={2}
+      gap={4}
       backgroundColor={BoxBackgroundColor.BackgroundDefault}
-      padding={3}
-      twClassName={mergeTwClassName('rounded-sm', twClassName)}
+      padding={4}
+      twClassName={mergeTwClassName('rounded-xl', twClassName)}
       {...props}
     >
       {startAccessory}

--- a/packages/design-system-react-native/src/components/BannerBase/README.md
+++ b/packages/design-system-react-native/src/components/BannerBase/README.md
@@ -76,7 +76,7 @@ Optional content rendered below the description. If a string is passed, BannerBa
 ### `actionButtonOnPress`
 
 Optional press handler for the action button.
-When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass additional props to the action `Button`; `variant` is not supported and defaults to primary.
+When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass additional props to the action `Button`; `variant` is not supported and defaults to secondary.
 
 | PROP                  | TYPE                                                               | REQUIRED                                                       | DEFAULT     |
 | --------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------- | ----------- |

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
@@ -112,8 +112,7 @@ describe('BannerBase', () => {
     );
 
     const closeButton = screen.getByTestId(closeButtonTestId);
-    expect(closeButton.className).toContain('ml-3');
-    expect(closeButton.className).toContain('self-start');
+    expect(closeButton.className).toContain('-mt-1');
     expect(closeButton.className).toContain('rotate-45');
   });
 

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
@@ -4,6 +4,7 @@ import {
   BoxFlexDirection,
   ButtonIconSize,
   ButtonSize,
+  ButtonVariant,
   FontWeight,
   IconName,
   TextVariant,
@@ -60,10 +61,11 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
         ref={ref}
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Start}
-        gap={2}
+        gap={4}
         backgroundColor={BoxBackgroundColor.BackgroundDefault}
-        padding={3}
-        className={twMerge('rounded-sm', className)}
+        paddingVertical={3}
+        paddingHorizontal={4}
+        className={twMerge('rounded-xl', className)}
         {...props}
       >
         {startAccessory}
@@ -83,7 +85,7 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
             ))}
 
           {hasContent(description) && (
-            <Box className={hasContent(title) ? 'mt-1' : undefined}>
+            <Box>
               {isTextContent(description) ? (
                 <Text variant={TextVariant.BodySm} {...descriptionProps}>
                   {description}
@@ -104,11 +106,12 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
             ))}
 
           {shouldShowActionButton && (
-            <Box className="mt-4">
+            <Box className="mt-2">
               <Button
                 size={ButtonSize.Md}
                 onClick={actionButtonOnClick}
                 {...resolvedActionButtonProps}
+                variant={ButtonVariant.Secondary}
               >
                 {actionButtonLabel}
               </Button>
@@ -118,9 +121,9 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
 
         {shouldShowCloseButton && (
           <ButtonIcon
-            className={twMerge('ml-3 self-start', closeButtonClassName)}
+            className={twMerge('-mt-1', closeButtonClassName)}
             iconName={IconName.Close}
-            size={ButtonIconSize.Sm}
+            size={ButtonIconSize.Md}
             ariaLabel={closeButtonAriaLabel}
             onClick={onClose}
             {...resolvedCloseButtonProps}

--- a/packages/design-system-react/src/components/BannerBase/README.mdx
+++ b/packages/design-system-react/src/components/BannerBase/README.mdx
@@ -142,7 +142,7 @@ Optional content rendered below the description. If a string is passed, BannerBa
 ### `actionButtonOnClick`
 
 Optional click handler for the action button.
-When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass additional props to the action `Button`; `variant` is not supported and defaults to primary.
+When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass additional props to the action `Button`; `variant` is not supported and defaults to secondary.
 
 <table>
   <thead>


### PR DESCRIPTION
## Summary

Align `BannerBase` layout with Figma across **web** (`design-system-react`) and **mobile** (`design-system-react-native`):

- `gap={4}`, asymmetric padding (`paddingVertical={3}`, `paddingHorizontal={4}`), and `rounded-xl`
- Remove redundant spacing (`description` `mt-1`, close button `ml-3`) now covered by row gap
- Set action button top margin to `mt-2` and default variant to `ButtonVariant.Secondary`
- Align close button with leading icon: `ButtonIconSize.Md` with `-mt-1` offset

## Loom
https://www.loom.com/share/81c15e28cd154f348cc140fa68eab611

## Before
<img width="417" height="155" alt="image" src="https://github.com/user-attachments/assets/8c5fa83e-04bc-463e-98ee-33d7e0a7111f" />
<img width="955" height="364" alt="image" src="https://github.com/user-attachments/assets/56426805-ab35-4fc8-b1e2-c6aed2193f32" />


## After
<img width="437" height="147" alt="image" src="https://github.com/user-attachments/assets/81f4829f-a624-4de1-b6c1-e430634fadb5" />
<img width="955" height="326" alt="image" src="https://github.com/user-attachments/assets/4488cf3e-8d97-47ee-9518-b295d403bfb1" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only layout and default button styling in a shared presentational component; no auth, data, or API contract changes beyond documented action-button variant default.
> 
> **Overview**
> Updates **`BannerBase`** in both **React** and **React Native** so banner chrome matches Figma: row **`gap={4}`**, **`paddingVertical={3}`** / **`paddingHorizontal={4}`** (replacing uniform padding), and **`rounded-xl`** instead of **`rounded-sm`**.
> 
> Spacing is simplified by dropping extra margins that duplicated row gap—description no longer gets **`mt-1`**, and the close control drops **`ml-3`** / **`self-start`** in favor of **`-mt-1`** with **`ButtonIconSize.Md`**. The optional action button uses **`mt-2`** (was **`mt-4`**) and is explicitly **`ButtonVariant.Secondary`**; docs and the web close-button test reflect the new defaults and classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220702a3c8e5d18e4b71f4ee53c5d97617ac4d57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->