### PR TITLE
fix(BannerAlert): remove left border and padding override

### DIFF
--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.constants.ts
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.constants.ts
@@ -1,7 +1,6 @@
 import {
   BannerAlertSeverity,
   BoxBackgroundColor,
-  BoxBorderColor,
   IconColor,
   IconName,
 } from '@metamask/design-system-shared';
@@ -34,14 +33,4 @@ export const MAP_BANNER_ALERT_SEVERITY_BACKGROUND_COLOR: Record<
   success: BoxBackgroundColor.SuccessMuted,
   warning: BoxBackgroundColor.WarningMuted,
   danger: BoxBackgroundColor.ErrorMuted,
-};
-
-export const MAP_BANNER_ALERT_SEVERITY_BORDER_COLOR: Record<
-  (typeof BannerAlertSeverity)[keyof typeof BannerAlertSeverity],
-  BoxBorderColor
-> = {
-  info: BoxBorderColor.PrimaryDefault,
-  success: BoxBorderColor.SuccessDefault,
-  warning: BoxBorderColor.WarningDefault,
-  danger: BoxBorderColor.ErrorDefault,
 };

--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.test.tsx
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.test.tsx
@@ -3,7 +3,6 @@ import {
   IconColor,
   IconName,
 } from '@metamask/design-system-shared';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { render } from '@testing-library/react-native';
 import React from 'react';
 
@@ -13,7 +12,6 @@ import { BannerAlert } from './BannerAlert';
 
 import { BannerAlertSeverity } from '.';
 
-jest.mock('@metamask/design-system-twrnc-preset');
 jest.mock('../BannerBase', () => ({
   BannerBase: jest.fn(() => null),
 }));
@@ -22,14 +20,9 @@ const ICON_TEST_ID = 'banner-alert-icon';
 
 describe('BannerAlert', () => {
   const mockBannerBase = BannerBase as jest.Mock;
-  const mockTwStyle = jest.fn((...args) => args.filter(Boolean));
 
   beforeEach(() => {
     mockBannerBase.mockClear();
-    mockTwStyle.mockClear();
-    (useTailwind as jest.Mock).mockReturnValue({
-      style: mockTwStyle,
-    });
   });
 
   it('uses info severity styles by default', () => {
@@ -39,7 +32,6 @@ describe('BannerAlert', () => {
 
     const props = mockBannerBase.mock.calls[0][0];
     expect(props.backgroundColor).toBe(BoxBackgroundColor.PrimaryMuted);
-    expect(props.paddingLeft).toBe(2);
 
     expect(props.startAccessory.props.name).toBe(IconName.Info);
     expect(props.startAccessory.props.color).toBe(IconColor.PrimaryDefault);
@@ -83,7 +75,7 @@ describe('BannerAlert', () => {
     },
   );
 
-  it('applies border styling and passes style prop', () => {
+  it('passes style prop through to BannerBase', () => {
     const customStyle = { marginTop: 8 };
     render(
       <BannerAlert
@@ -93,14 +85,7 @@ describe('BannerAlert', () => {
       />,
     );
 
-    // Verify tw.style was called with correct border classes for info severity
-    expect(mockTwStyle).toHaveBeenCalledWith(
-      'border-l-4 border-primary-default',
-    );
-
-    // Verify style array was passed to BannerBase with tw.style result and custom style
     const props = mockBannerBase.mock.calls[0][0];
-    expect(Array.isArray(props.style)).toBe(true);
-    expect(props.style[1]).toBe(customStyle);
+    expect(props.style).toBe(customStyle);
   });
 });

--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.tsx
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.tsx
@@ -1,5 +1,4 @@
 import { BannerAlertSeverity, IconSize } from '@metamask/design-system-shared';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
 
 import { BannerBase } from '../BannerBase';
@@ -9,21 +8,17 @@ import {
   MAP_BANNER_ALERT_SEVERITY_BACKGROUND_COLOR,
   MAP_BANNER_ALERT_SEVERITY_ICON_COLOR,
   MAP_BANNER_ALERT_SEVERITY_ICON_NAME,
-  MAP_BANNER_ALERT_SEVERITY_BORDER_COLOR,
 } from './BannerAlert.constants';
 import type { BannerAlertProps } from './BannerAlert.types';
 
 export const BannerAlert: React.FC<BannerAlertProps> = ({
   severity = BannerAlertSeverity.Info,
   iconProps,
-  style,
   ...props
 }) => {
-  const tw = useTailwind();
   const iconName = MAP_BANNER_ALERT_SEVERITY_ICON_NAME[severity];
   const iconColor = MAP_BANNER_ALERT_SEVERITY_ICON_COLOR[severity];
   const backgroundColor = MAP_BANNER_ALERT_SEVERITY_BACKGROUND_COLOR[severity];
-  const borderColorClass = MAP_BANNER_ALERT_SEVERITY_BORDER_COLOR[severity];
   return (
     <BannerBase
       startAccessory={
@@ -35,8 +30,6 @@ export const BannerAlert: React.FC<BannerAlertProps> = ({
         />
       }
       backgroundColor={backgroundColor}
-      paddingLeft={2}
-      style={[tw.style(`border-l-4 ${borderColorClass}`), style]}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- Remove the severity-colored left border (`border-l-4`) from React Native `BannerAlert` to match Figma
- Remove the `paddingLeft={2}` override so `BannerAlert` inherits `BannerBase` default padding
- Clean up unused border color constants and update unit tests

## Test plan
- [x] `npx jest BannerAlert.test.tsx --coverage=false` (6 tests passing)
- [x] Verify BannerAlert severity variants in React Native Storybook
- [x] Confirm visual alignment with [Figma BannerAlert](https://www.figma.com/design/0GipXMImYPyEmNUvnyI5v8/refactor--BannerBase---BannerAlert?node-id=16610-22779)

## Loom
https://www.loom.com/share/906b343a2e65414d9cc2f4881722bfd1

## Before
<img width="448" height="170" alt="image" src="https://github.com/user-attachments/assets/0036a188-3c49-4102-a563-5fd8f1c3b49b" />

## After
<img width="442" height="164" alt="image" src="https://github.com/user-attachments/assets/a2c30bbc-5204-4e44-9455-a7f836d1d6c1" />


Made with [Cursor](https://cursor.com)