### PR TITLE
chore: refresh Wallet Home example

### DIFF
--- a/apps/storybook-react-native/stories/WalletHome.stories.tsx
+++ b/apps/storybook-react-native/stories/WalletHome.stories.tsx
@@ -1,41 +1,44 @@
 import {
   AvatarAccount,
-  AvatarAccountVariant,
-  AvatarBaseShape,
+  AvatarAccountSize,
   AvatarToken,
   AvatarTokenSize,
-  BadgeCount,
-  BadgeWrapper,
   BadgeNetwork,
+  BadgeWrapper,
   Box,
   BoxAlignItems,
   BoxBackgroundColor,
-  BoxBorderColor,
   BoxFlexDirection,
   BoxFlexWrap,
-  BoxJustifyContent,
   Button,
-  ButtonBase,
-  ButtonIcon,
   ButtonSize,
   ButtonVariant,
+  Card,
   FontWeight,
+  HeaderRoot,
   Icon,
-  IconName,
   IconColor,
+  IconName,
+  IconSize,
+  ListItem,
+  MainActionButton,
+  SectionDivider,
+  SectionHeader,
+  SelectButton,
+  SelectButtonEndArrow,
+  SelectButtonVariant,
+  SensitiveText,
+  SensitiveTextLength,
   Text,
   TextButton,
   TextColor,
   TextVariant,
-  BadgeWrapperPosition,
-  BadgeStatus,
-  BadgeStatusStatus,
-  IconSize,
+  TitleHub,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import type { Meta, StoryObj } from '@storybook/react-native';
-import React from 'react';
-import { ScrollView, Pressable } from 'react-native';
+import React, { useState } from 'react';
+import { ScrollView } from 'react-native';
 
 const meta: Meta = {
   title: 'Examples/Wallet Home',
@@ -45,490 +48,550 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj;
 
+const BNB_NETWORK_URI =
+  'https://assets.coingecko.com/coins/images/825/small/bnb-icon2_2x.png';
+const ETH_NETWORK_URI =
+  'https://assets.coingecko.com/coins/images/279/small/ethereum.png';
+const BTC_TOKEN_URI =
+  'https://assets.coingecko.com/coins/images/1/small/bitcoin.png';
+
+const noopPress = () => undefined;
+
+const TOP_TRADERS = [
+  {
+    address: '0xb7981234567890abcdef1234567890abcdef12',
+    profit: '+$754.5K',
+  },
+  {
+    address: '0xe8db9876543210fedcba9876543210fedcba98',
+    profit: '+$307.2K',
+  },
+  {
+    address: '0xa1c24567890123456789012345678901234567',
+    profit: '+$198.4K',
+  },
+] as const;
+
+const formatTraderAddress = (address: string) => `${address.slice(0, 6)}...`;
+
+type TopTraderCardProps = {
+  address: string;
+  profit: string;
+};
+
+const TopTraderCard: React.FC<TopTraderCardProps> = ({ address, profit }) => (
+  <Card twClassName="w-40 shrink-0 border-0 bg-section p-3 rounded-xl">
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      gap={3}
+      twClassName="mb-3"
+    >
+      <AvatarAccount address={address} size={AvatarAccountSize.Lg} />
+      <Box flexDirection={BoxFlexDirection.Column} twClassName="min-w-0 flex-1">
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          numberOfLines={1}
+        >
+          {formatTraderAddress(address)}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.SuccessDefault}
+          numberOfLines={1}
+        >
+          {profit}
+        </Text>
+      </Box>
+    </Box>
+    <Button
+      variant={ButtonVariant.Primary}
+      size={ButtonSize.Sm}
+      isFullWidth
+      onPress={noopPress}
+    >
+      Follow
+    </Button>
+  </Card>
+);
+
+type TokenRowProps = {
+  name: string;
+  symbol: string;
+  tokenUri: string;
+  networkUri: string;
+  networkName: string;
+  marketPrice: string;
+  changePercent?: string;
+  isPositiveChange?: boolean;
+  earnLabel?: boolean;
+  fiatValue: string;
+  tokenAmount: string;
+  isVerified?: boolean;
+  isBalanceHidden: boolean;
+};
+
+const TokenAvatar: React.FC<{
+  name: string;
+  tokenUri: string;
+  networkUri: string;
+  networkName: string;
+}> = ({ name, tokenUri, networkUri, networkName }) => (
+  <BadgeWrapper
+    badge={<BadgeNetwork name={networkName} src={{ uri: networkUri }} />}
+  >
+    <AvatarToken
+      name={name}
+      src={{ uri: tokenUri }}
+      size={AvatarTokenSize.Lg}
+    />
+  </BadgeWrapper>
+);
+
+const VerifiedBadge = () => (
+  <Icon
+    name={IconName.VerifiedFilled}
+    size={IconSize.Sm}
+    color={IconColor.InfoDefault}
+  />
+);
+
+const TokenRow: React.FC<TokenRowProps> = ({
+  name,
+  symbol,
+  tokenUri,
+  networkUri,
+  networkName,
+  marketPrice,
+  changePercent,
+  isPositiveChange = false,
+  earnLabel = false,
+  fiatValue,
+  tokenAmount,
+  isVerified = true,
+  isBalanceHidden,
+}) => (
+  <ListItem
+    isInteractive
+    onPress={noopPress}
+    avatar={
+      <TokenAvatar
+        name={symbol}
+        tokenUri={tokenUri}
+        networkUri={networkUri}
+        networkName={networkName}
+      />
+    }
+    title={name}
+    titleProps={{ fontWeight: FontWeight.Medium }}
+    titleEndAccessory={isVerified ? <VerifiedBadge /> : undefined}
+    description={
+      earnLabel ? (
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={1}
+        >
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {marketPrice}
+          </Text>
+          <TextButton onPress={noopPress}>Earn</TextButton>
+        </Box>
+      ) : (
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={1}
+        >
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {marketPrice}
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            color={
+              isPositiveChange
+                ? TextColor.SuccessDefault
+                : TextColor.ErrorDefault
+            }
+          >
+            {changePercent}
+          </Text>
+        </Box>
+      )
+    }
+    value={
+      <SensitiveText
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        isHidden={isBalanceHidden}
+        length={String(fiatValue.length)}
+      >
+        {fiatValue}
+      </SensitiveText>
+    }
+    subvalue={
+      <SensitiveText
+        variant={TextVariant.BodySm}
+        color={TextColor.TextAlternative}
+        isHidden={isBalanceHidden}
+        length={String(tokenAmount.length)}
+      >
+        {tokenAmount}
+      </SensitiveText>
+    }
+  />
+);
+
+type PerpetualRowProps = {
+  title: string;
+  description: string;
+  value: string;
+  subvalue: string;
+  tokenUri: string;
+  tokenName: string;
+  isBalanceHidden: boolean;
+  subvalueColor?: TextColor;
+  isSubvalueSensitive?: boolean;
+};
+
+const PerpetualRow: React.FC<PerpetualRowProps> = ({
+  title,
+  description,
+  value,
+  subvalue,
+  tokenUri,
+  tokenName,
+  isBalanceHidden,
+  subvalueColor = TextColor.TextAlternative,
+  isSubvalueSensitive = true,
+}) => (
+  <ListItem
+    isInteractive
+    onPress={noopPress}
+    avatar={
+      <AvatarToken
+        name={tokenName}
+        src={{ uri: tokenUri }}
+        size={AvatarTokenSize.Lg}
+      />
+    }
+    title={title}
+    titleProps={{ fontWeight: FontWeight.Medium }}
+    description={description}
+    descriptionProps={{ color: TextColor.TextAlternative }}
+    value={
+      <SensitiveText
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        isHidden={isBalanceHidden}
+        length={String(value.length)}
+      >
+        {value}
+      </SensitiveText>
+    }
+    subvalue={
+      isSubvalueSensitive ? (
+        <SensitiveText
+          variant={TextVariant.BodySm}
+          color={subvalueColor}
+          isHidden={isBalanceHidden}
+          length={String(subvalue.length)}
+        >
+          {subvalue}
+        </SensitiveText>
+      ) : (
+        subvalue
+      )
+    }
+    subvalueProps={
+      isSubvalueSensitive
+        ? undefined
+        : {
+            color: subvalueColor,
+            variant: TextVariant.BodySm,
+          }
+    }
+  />
+);
+
 const WalletHome: React.FC = () => {
   const tw = useTailwind();
+  const [isBalanceHidden, setIsBalanceHidden] = useState(false);
+
+  const toggleBalanceVisibility = () => {
+    setIsBalanceHidden((hidden) => !hidden);
+  };
 
   return (
     <ScrollView style={tw`flex-1 bg-default`}>
-      {/* Container */}
       <Box
         backgroundColor={BoxBackgroundColor.BackgroundDefault}
-        paddingVertical={4}
-        twClassName="w-full"
+        twClassName="w-full pb-4"
       >
         {/* Header */}
-        <Box
-          padding={4}
-          borderColor={BoxBorderColor.BorderMuted}
-          twClassName="border-b"
+        <HeaderRoot
+          endButtonIconProps={[
+            {
+              iconName: IconName.Menu,
+              accessibilityLabel: 'Menu',
+              onPress: noopPress,
+            },
+            {
+              iconName: IconName.Wallet,
+              accessibilityLabel: 'Wallet',
+              onPress: noopPress,
+            },
+            {
+              iconName: IconName.Scan,
+              accessibilityLabel: 'Scan',
+              onPress: noopPress,
+            },
+          ]}
         >
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Between}
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="flex-1 overflow-hidden"
-            >
-              <AvatarAccount
-                shape={AvatarBaseShape.Square}
-                variant={AvatarAccountVariant.Maskicon}
-                address="0x1234567890123456789012345678901234567890"
-              />
-              <Box marginLeft={2} twClassName="flex-1">
-                <Text variant={TextVariant.HeadingMd} numberOfLines={1}>
-                  DeFi Account
-                </Text>
-              </Box>
-              <ButtonIcon
-                iconName={IconName.ArrowDown}
-                accessibilityLabel="Switch Account"
-              />
-            </Box>
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              marginLeft={2}
-            >
-              <ButtonIcon iconName={IconName.Copy} accessibilityLabel="Copy" />
-              <ButtonIcon
-                iconName={IconName.Global}
-                accessibilityLabel="Network"
-              />
-              <BadgeWrapper
-                badge={<BadgeCount count={10} max={9} />}
-                position={BadgeWrapperPosition.TopRight}
-              >
-                <ButtonIcon
-                  iconName={IconName.Menu}
-                  accessibilityLabel="Menu"
-                />
-              </BadgeWrapper>
-            </Box>
+          <Box alignItems={BoxAlignItems.Center} twClassName="min-w-0 flex-1">
+            <SelectButton
+              value="Account 1 with a very long name that should be truncated"
+              placeholder="Select account"
+              variant={SelectButtonVariant.Tertiary}
+              endArrowDirection={SelectButtonEndArrow.Down}
+              onPress={noopPress}
+              accessibilityLabel="Switch Account"
+              textProps={{
+                variant: TextVariant.BodyMd,
+                color: TextColor.TextDefault,
+                numberOfLines: 1,
+                ellipsizeMode: 'tail',
+              }}
+              twClassName="min-w-0 max-w-full -ml-2"
+            />
           </Box>
-        </Box>
+        </HeaderRoot>
 
         {/* Balance */}
-        <Box padding={4}>
-          <Text variant={TextVariant.DisplayMd}>$10,528.46</Text>
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-          >
-            <Icon name={IconName.Arrow2Up} color={IconColor.SuccessDefault} />
-            <Text color={TextColor.TextAlternative}>$367.00 (+0.66%)</Text>
-          </Box>
+        <Box paddingHorizontal={4} paddingTop={2} paddingBottom={2}>
+          <TitleHub
+            title=""
+            amount={
+              <SensitiveText
+                variant={TextVariant.DisplayLg}
+                isHidden={isBalanceHidden}
+                length={SensitiveTextLength.Medium}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  isBalanceHidden ? 'Show balance' : 'Hide balance'
+                }
+                onPress={toggleBalanceVisibility}
+              >
+                $283.36
+              </SensitiveText>
+            }
+            bottomLabel="-$5.2 (-1.80%)"
+            bottomLabelProps={{ color: TextColor.ErrorDefault }}
+          />
         </Box>
 
-        {/* Actions */}
-        <Box flexDirection={BoxFlexDirection.Row} gap={3} padding={4}>
-          <ButtonBase twClassName="h-20 flex-1 rounded-lg bg-muted px-0 py-4">
-            <Box
-              flexDirection={BoxFlexDirection.Column}
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Center}
-            >
-              <Icon name={IconName.Bank} />
-              <Text fontWeight={FontWeight.Medium}>Buy/Sell</Text>
-            </Box>
-          </ButtonBase>
-          <ButtonBase twClassName="h-20 flex-1 rounded-lg bg-muted px-0 py-4">
-            <Box
-              flexDirection={BoxFlexDirection.Column}
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Center}
-            >
-              <Icon name={IconName.SwapHorizontal} />
-              <Text fontWeight={FontWeight.Medium}>Swap</Text>
-            </Box>
-          </ButtonBase>
-          <ButtonBase twClassName="h-20 flex-1 rounded-lg bg-muted px-0 py-4">
-            <Box
-              flexDirection={BoxFlexDirection.Column}
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Center}
-            >
-              <Icon name={IconName.Receive} />
-              <Text fontWeight={FontWeight.Medium}>Receive</Text>
-            </Box>
-          </ButtonBase>
-          <ButtonBase twClassName="h-20 flex-1 rounded-lg bg-muted px-0 py-4">
-            <Box
-              flexDirection={BoxFlexDirection.Column}
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Center}
-            >
-              <Icon name={IconName.Send} />
-              <Text fontWeight={FontWeight.Medium}>Send</Text>
-            </Box>
-          </ButtonBase>
+        {/* Primary actions */}
+        <Box flexDirection={BoxFlexDirection.Row} gap={2} padding={4}>
+          <MainActionButton
+            iconName={IconName.AttachMoney}
+            label="Buy"
+            twClassName="flex-1"
+            onPress={noopPress}
+          />
+          <MainActionButton
+            iconName={IconName.SwapVertical}
+            label="Swap"
+            twClassName="flex-1"
+            onPress={noopPress}
+          />
+          <MainActionButton
+            iconName={IconName.Send}
+            label="Send"
+            twClassName="flex-1"
+            onPress={noopPress}
+          />
+          <MainActionButton
+            iconName={IconName.Received}
+            label="Receive"
+            twClassName="flex-1"
+            onPress={noopPress}
+          />
         </Box>
 
-        {/* Tabs */}
+        {/* Secondary actions */}
         <Box
+          flexDirection={BoxFlexDirection.Row}
+          flexWrap={BoxFlexWrap.Wrap}
+          gap={2}
           paddingHorizontal={4}
-          borderColor={BoxBorderColor.BorderMuted}
-          twClassName="border-b"
+          paddingBottom={2}
         >
-          <Box flexDirection={BoxFlexDirection.Row}>
-            <Pressable
-              style={tw`flex-1 items-center justify-center border-b-2 border-default pb-2 pt-1`}
-            >
-              <Text fontWeight={FontWeight.Medium}>Tokens</Text>
-            </Pressable>
-            <Pressable
-              style={tw`flex-1 flex-row items-center justify-center pb-2 pt-1`}
-            >
-              <Text
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextAlternative}
-              >
-                DeFi
-              </Text>
-              <Box marginLeft={1}>
-                <BadgeStatus status={BadgeStatusStatus.New} />
-              </Box>
-            </Pressable>
-            <Pressable style={tw`flex-1 items-center justify-center pb-2 pt-1`}>
-              <Text
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextAlternative}
-              >
-                NFTs
-              </Text>
-            </Pressable>
-            <Pressable style={tw`flex-1 items-center justify-center pb-2 pt-1`}>
-              <Text
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextAlternative}
-              >
-                Activity
-              </Text>
-            </Pressable>
-          </Box>
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Sm}
+            startIconName={IconName.Candlestick}
+            onPress={null}
+          >
+            Perpetuals
+          </Button>
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Sm}
+            startIconName={IconName.Predictions}
+            onPress={null}
+          >
+            Predictions
+          </Button>
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Sm}
+            startIconName={IconName.Coin}
+            onPress={null}
+          >
+            Stocks
+          </Button>
         </Box>
 
-        {/* Token List */}
-        <Box>
+        <SectionDivider />
+
+        {/* Tokens */}
+        <SectionHeader
+          title="Tokens"
+          isInteractive
+          onPress={noopPress}
+          accessibilityLabel="View all tokens"
+        />
+
+        <TokenRow
+          name="BNB"
+          symbol="BNB"
+          tokenUri={BNB_NETWORK_URI}
+          networkUri={BNB_NETWORK_URI}
+          networkName="BNB Chain"
+          marketPrice="$552.91"
+          changePercent="-2.74%"
+          fiatValue="$44.32"
+          tokenAmount="0.08016 BNB"
+          isBalanceHidden={isBalanceHidden}
+        />
+
+        <TokenRow
+          name="MetaMask USD"
+          symbol="MUSD"
+          tokenUri="https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png"
+          networkUri={ETH_NETWORK_URI}
+          networkName="Ethereum"
+          marketPrice="$0.9993"
+          changePercent="-0.05%"
+          fiatValue="$31.95"
+          tokenAmount="31.97626 MUSD"
+          isBalanceHidden={isBalanceHidden}
+        />
+
+        <TokenRow
+          name="Ethereum"
+          symbol="ETH"
+          tokenUri={ETH_NETWORK_URI}
+          networkUri={ETH_NETWORK_URI}
+          networkName="Ethereum"
+          marketPrice="$1,566.71"
+          changePercent="-4.78%"
+          fiatValue="$28.95"
+          tokenAmount="0.01848 ETH"
+          isBalanceHidden={isBalanceHidden}
+        />
+
+        <TokenRow
+          name="USD Coin (Native)"
+          symbol="USDC"
+          tokenUri="https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png"
+          networkUri={ETH_NETWORK_URI}
+          networkName="Ethereum"
+          marketPrice="$0.9997"
+          earnLabel
+          fiatValue="$26.50"
+          tokenAmount="26.51007 USDC"
+          isBalanceHidden={isBalanceHidden}
+        />
+
+        <SectionDivider />
+
+        {/* Perpetuals */}
+        <SectionHeader
+          title="Perpetuals"
+          isInteractive
+          onPress={noopPress}
+          accessibilityLabel="View all perpetuals"
+        >
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Between}
-            padding={4}
+            gap={1}
           >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
+            <SensitiveText
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.ErrorDefault}
+              isHidden={isBalanceHidden}
+              length="13"
             >
-              <Button
-                size={ButtonSize.Sm}
-                variant={ButtonVariant.Secondary}
-                endIconName={IconName.ArrowDown}
-              >
-                Popular networks
-              </Button>
-            </Box>
-            <Box flexDirection={BoxFlexDirection.Row} gap={2}>
-              <ButtonIcon
-                iconName={IconName.Filter}
-                accessibilityLabel="Filter"
-              />
-              <ButtonIcon
-                iconName={IconName.MoreVertical}
-                accessibilityLabel="More"
-              />
-            </Box>
+              -$0.33 (-9.4%)
+            </SensitiveText>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              fontWeight={FontWeight.Medium}
+            >
+              Unrealized P&L
+            </Text>
           </Box>
+        </SectionHeader>
+        <PerpetualRow
+          title="BTC 3x long"
+          description="0.00017 BTC"
+          value="$10.11"
+          subvalue="-$0.33 (-9.4%)"
+          tokenUri={BTC_TOKEN_URI}
+          tokenName="BTC"
+          isBalanceHidden={isBalanceHidden}
+          subvalueColor={TextColor.ErrorDefault}
+        />
+        <PerpetualRow
+          title="Limit long"
+          description="0.0002 BTC"
+          value="$50,000"
+          subvalue="Limit price"
+          tokenUri={BTC_TOKEN_URI}
+          tokenName="BTC"
+          isBalanceHidden={isBalanceHidden}
+          isSubvalueSensitive={false}
+        />
 
-          {/* Ethereum */}
-          <Pressable
-            style={({ pressed }) =>
-              tw.style(
-                'w-full flex-row items-center justify-between px-4 py-2',
-                pressed && 'bg-pressed',
-              )
-            }
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="flex-1 overflow-hidden"
-            >
-              <BadgeWrapper
-                badge={
-                  <BadgeNetwork
-                    name="Ethereum"
-                    src={{
-                      uri: 'https://assets.coingecko.com/coins/images/279/small/ethereum.png',
-                    }}
-                  />
-                }
-              >
-                <AvatarToken
-                  name="ETH"
-                  src={{
-                    uri: 'https://assets.coingecko.com/coins/images/279/small/ethereum.png',
-                  }}
-                  size={AvatarTokenSize.Md}
-                />
-              </BadgeWrapper>
-              <Box
-                flexDirection={BoxFlexDirection.Column}
-                marginLeft={4}
-                twClassName="flex-1 overflow-hidden"
-              >
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  flexWrap={BoxFlexWrap.Wrap}
-                  alignItems={BoxAlignItems.Center}
-                >
-                  <Text
-                    fontWeight={FontWeight.Medium}
-                    numberOfLines={1}
-                    twClassName="mr-2"
-                  >
-                    Ethereum •
-                  </Text>
-                  <TextButton>Earn</TextButton>
-                </Box>
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  alignItems={BoxAlignItems.Center}
-                >
-                  <Icon
-                    name={IconName.Arrow2Up}
-                    color={IconColor.SuccessDefault}
-                    size={IconSize.Sm}
-                  />
-                  <Text
-                    color={TextColor.TextAlternative}
-                    variant={TextVariant.BodySm}
-                  >
-                    +85.88%
-                  </Text>
-                </Box>
-              </Box>
-            </Box>
-            <Box twClassName="items-end">
-              <Text>$8,509.44</Text>
-              <Text
-                color={TextColor.TextAlternative}
-                variant={TextVariant.BodySm}
-              >
-                0.7107 ETH
-              </Text>
-            </Box>
-          </Pressable>
+        <SectionDivider />
 
-          {/* Unibright */}
-          <Pressable
-            style={({ pressed }) =>
-              tw.style(
-                'w-full flex-row items-center justify-between px-4 py-2',
-                pressed && 'bg-pressed',
-              )
-            }
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="flex-1 overflow-hidden"
-            >
-              <BadgeWrapper
-                badge={
-                  <BadgeNetwork
-                    name="Ethereum"
-                    src={{
-                      uri: 'https://assets.coingecko.com/coins/images/279/small/ethereum.png',
-                    }}
-                  />
-                }
-              >
-                <AvatarToken
-                  name="UBT"
-                  src={{
-                    uri: 'https://s2.coinmarketcap.com/static/img/coins/64x64/2758.png',
-                  }}
-                  size={AvatarTokenSize.Md}
-                />
-              </BadgeWrapper>
-              <Box
-                flexDirection={BoxFlexDirection.Column}
-                marginLeft={4}
-                twClassName="flex-1 overflow-hidden"
-              >
-                <Text fontWeight={FontWeight.Medium} numberOfLines={1}>
-                  Unibright
-                </Text>
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  alignItems={BoxAlignItems.Center}
-                >
-                  <Icon
-                    name={IconName.Arrow2Up}
-                    color={IconColor.SuccessDefault}
-                    size={IconSize.Sm}
-                  />
-                  <Text
-                    color={TextColor.TextAlternative}
-                    variant={TextVariant.BodySm}
-                  >
-                    +85.88%
-                  </Text>
-                </Box>
-              </Box>
-            </Box>
-            <Box twClassName="items-end">
-              <Text>$1,293.50</Text>
-              <Text
-                color={TextColor.TextAlternative}
-                variant={TextVariant.BodySm}
-              >
-                0.058 UBT
-              </Text>
-            </Box>
-          </Pressable>
-
-          {/* Hopr */}
-          <Pressable
-            style={({ pressed }) =>
-              tw.style(
-                'w-full flex-row items-center justify-between px-4 py-2',
-                pressed && 'bg-pressed',
-              )
-            }
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="flex-1 overflow-hidden"
-            >
-              <BadgeWrapper
-                badge={
-                  <BadgeNetwork
-                    name="Ethereum"
-                    src={{
-                      uri: 'https://assets.coingecko.com/coins/images/279/small/ethereum.png',
-                    }}
-                  />
-                }
-              >
-                <AvatarToken
-                  name="HOPR"
-                  src={{
-                    uri: 'https://s2.coinmarketcap.com/static/img/coins/64x64/6520.png',
-                  }}
-                  size={AvatarTokenSize.Md}
-                />
-              </BadgeWrapper>
-              <Box
-                flexDirection={BoxFlexDirection.Column}
-                marginLeft={4}
-                twClassName="flex-1 overflow-hidden"
-              >
-                <Text fontWeight={FontWeight.Medium} numberOfLines={1}>
-                  Hopr
-                </Text>
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  alignItems={BoxAlignItems.Center}
-                >
-                  <Icon
-                    name={IconName.Arrow2Up}
-                    color={IconColor.SuccessDefault}
-                    size={IconSize.Sm}
-                  />
-                  <Text
-                    color={TextColor.TextAlternative}
-                    variant={TextVariant.BodySm}
-                  >
-                    +85.88%
-                  </Text>
-                </Box>
-              </Box>
-            </Box>
-            <Box twClassName="items-end">
-              <Text>$550.00</Text>
-              <Text
-                color={TextColor.TextAlternative}
-                variant={TextVariant.BodySm}
-              >
-                12.44 HOPR
-              </Text>
-            </Box>
-          </Pressable>
-
-          {/* USDC */}
-          <Pressable
-            style={({ pressed }) =>
-              tw.style(
-                'w-full flex-row items-center justify-between px-4 py-2',
-                pressed && 'bg-pressed',
-              )
-            }
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="flex-1 overflow-hidden"
-            >
-              <BadgeWrapper
-                badge={
-                  <BadgeNetwork
-                    name="Ethereum"
-                    src={{
-                      uri: 'https://assets.coingecko.com/coins/images/279/small/ethereum.png',
-                    }}
-                  />
-                }
-              >
-                <AvatarToken
-                  name="USDC"
-                  src={{
-                    uri: 'https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png',
-                  }}
-                  size={AvatarTokenSize.Md}
-                />
-              </BadgeWrapper>
-              <Box
-                flexDirection={BoxFlexDirection.Column}
-                marginLeft={4}
-                twClassName="flex-1 overflow-hidden"
-              >
-                <Text fontWeight={FontWeight.Medium} numberOfLines={1}>
-                  USDC Coin
-                </Text>
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  alignItems={BoxAlignItems.Center}
-                >
-                  <Icon
-                    name={IconName.Arrow2Down}
-                    color={IconColor.ErrorDefault}
-                    size={IconSize.Sm}
-                  />
-                  <Text
-                    color={TextColor.TextAlternative}
-                    variant={TextVariant.BodySm}
-                  >
-                    -7.80%
-                  </Text>
-                </Box>
-              </Box>
-            </Box>
-            <Box twClassName="items-end">
-              <Text>$110.20</Text>
-              <Text
-                color={TextColor.TextAlternative}
-                variant={TextVariant.BodySm}
-              >
-                0.7107 USDC
-              </Text>
-            </Box>
-          </Pressable>
-        </Box>
+        {/* Weekly Top Traders */}
+        <SectionHeader
+          title="Weekly Top Traders"
+          isInteractive
+          onPress={noopPress}
+          accessibilityLabel="View all top traders"
+          twClassName="mb-2"
+        />
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={tw`gap-3 px-4 pb-4`}
+        >
+          {TOP_TRADERS.map((trader) => (
+            <TopTraderCard
+              key={trader.address}
+              address={trader.address}
+              profit={trader.profit}
+            />
+          ))}
+        </ScrollView>
       </Box>
     </ScrollView>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR refreshes the React Native `Examples/Wallet Home` Storybook story to better mirror the mobile wallet home screen and showcase more design-system components.

**Wallet Home story**
- Replaces custom `Pressable`/`ButtonBase` layouts with `HeaderRoot`, `TitleHub`, `MainActionButton`, `FilterButtonGroup`, `ListItem`, `SectionDivider`, and `SensitiveText`
- Aligns content with mobile home patterns (account header, balance, primary/secondary actions, tabs, token list)
- Adds balance privacy toggling via `SensitiveText` (`onPress`) and the eye icon

**FilterButton fix**
- Sets explicit selected/unselected text and icon colors so Primary variant labels remain readable on the white selected pill in dark mode (fixes invisible label when using string children)

## **Related issues**

Fixes: N/A will somewhat help testing pure black

## **Manual testing steps**

1. Run React Native Storybook (`yarn storybook:ios` or `yarn storybook:android`)
2. Open **Examples → Wallet Home**
3. Confirm layout matches mobile home: account header, balance, Buy/Swap/Send/Receive actions, secondary feature pills, tabs, and token list
4. Tap the balance or eye icon and verify `SensitiveText` toggles between `$283.36` and bullet masking
5. Select the **DeFi** tab and confirm the label is visible on the selected pill (not a blank white button)
6. Run FilterButton tests: `yarn workspace @metamask/design-system-react-native run test --testPathPattern=FilterButton.test`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Mobile Current / MMDS Before /  MMDS After**

<img width="200" alt="Screenshot 2026-06-25 at 6 53 58 PM" src="https://github.com/user-attachments/assets/38ce6e58-c104-423e-9628-c8ffd61001ad" /><img width="200" alt="Screenshot 2026-06-25 at 6 53 17 PM" src="https://github.com/user-attachments/assets/c46dde14-0a8b-46f0-a4cc-9f35984ba01d" /><img width="200" alt="Screenshot 2026-06-25 at 6 53 42 PM" src="https://github.com/user-attachments/assets/03b10e80-1c09-4126-a664-a73a436b0b09" />

### **Before **

https://github.com/user-attachments/assets/9abcbf33-a00f-4bfd-a672-b51a41a3c848

### **After**

https://github.com/user-attachments/assets/e909b0de-56ec-4859-a489-6d6079ad1d47

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)