### PR TITLE
feat(BannerAlert): add Neutral severity variant

### DIFF
--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.constants.ts
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.constants.ts
@@ -9,6 +9,7 @@ export const MAP_BANNER_ALERT_SEVERITY_ICON_NAME: Record<
   (typeof BannerAlertSeverity)[keyof typeof BannerAlertSeverity],
   IconName
 > = {
+  neutral: IconName.Info,
   info: IconName.Info,
   success: IconName.Confirmation,
   warning: IconName.Danger,
@@ -19,6 +20,7 @@ export const MAP_BANNER_ALERT_SEVERITY_ICON_COLOR: Record<
   (typeof BannerAlertSeverity)[keyof typeof BannerAlertSeverity],
   IconColor
 > = {
+  neutral: IconColor.IconDefault,
   info: IconColor.PrimaryDefault,
   success: IconColor.SuccessDefault,
   warning: IconColor.WarningDefault,
@@ -29,6 +31,7 @@ export const MAP_BANNER_ALERT_SEVERITY_BACKGROUND_COLOR: Record<
   (typeof BannerAlertSeverity)[keyof typeof BannerAlertSeverity],
   BoxBackgroundColor
 > = {
+  neutral: BoxBackgroundColor.BackgroundSection,
   info: BoxBackgroundColor.PrimaryMuted,
   success: BoxBackgroundColor.SuccessMuted,
   warning: BoxBackgroundColor.WarningMuted,

--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -88,6 +88,13 @@ export const Severity: Story = {
       >
         This is a success banner.
       </BannerAlert>
+      <BannerAlert
+        {...args}
+        severity={BannerAlertSeverity.Neutral}
+        title="Neutral"
+      >
+        This is a neutral banner.
+      </BannerAlert>
     </View>
   ),
   args: {

--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -64,8 +64,22 @@ export const Default: Story = {
 export const Severity: Story = {
   render: (args) => (
     <View style={{ gap: 8 }}>
+      <BannerAlert
+        {...args}
+        severity={BannerAlertSeverity.Neutral}
+        title="Neutral"
+      >
+        This is a neutral banner.
+      </BannerAlert>
       <BannerAlert {...args} severity={BannerAlertSeverity.Info} title="Info">
         This is an info banner.
+      </BannerAlert>
+      <BannerAlert
+        {...args}
+        severity={BannerAlertSeverity.Success}
+        title="Success"
+      >
+        This is a success banner.
       </BannerAlert>
       <BannerAlert
         {...args}
@@ -80,20 +94,6 @@ export const Severity: Story = {
         title="Danger"
       >
         This is a danger banner.
-      </BannerAlert>
-      <BannerAlert
-        {...args}
-        severity={BannerAlertSeverity.Success}
-        title="Success"
-      >
-        This is a success banner.
-      </BannerAlert>
-      <BannerAlert
-        {...args}
-        severity={BannerAlertSeverity.Neutral}
-        title="Neutral"
-      >
-        This is a neutral banner.
       </BannerAlert>
     </View>
   ),

--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.test.tsx
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.test.tsx
@@ -63,6 +63,12 @@ describe('BannerAlert', () => {
       iconColor: IconColor.ErrorDefault,
       backgroundColor: BoxBackgroundColor.ErrorMuted,
     },
+    {
+      severity: BannerAlertSeverity.Neutral,
+      iconName: IconName.Info,
+      iconColor: IconColor.IconDefault,
+      backgroundColor: BoxBackgroundColor.BackgroundSection,
+    },
   ])(
     'applies expected icon and background for $severity severity',
     ({ severity, iconName, iconColor, backgroundColor }) => {

--- a/packages/design-system-react-native/src/components/BannerAlert/README.md
+++ b/packages/design-system-react-native/src/components/BannerAlert/README.md
@@ -30,6 +30,7 @@ Optional semantic severity used to choose icon and background styles.
 
 Supported values:
 
+- `BannerAlertSeverity.Neutral`
 - `BannerAlertSeverity.Info`
 - `BannerAlertSeverity.Success`
 - `BannerAlertSeverity.Warning`

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.constants.ts
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.constants.ts
@@ -9,6 +9,7 @@ export const MAP_BANNER_ALERT_SEVERITY_ICON_NAME: Record<
   (typeof BannerAlertSeverity)[keyof typeof BannerAlertSeverity],
   IconName
 > = {
+  neutral: IconName.Info,
   info: IconName.Info,
   success: IconName.Confirmation,
   warning: IconName.Danger,
@@ -19,6 +20,7 @@ export const MAP_BANNER_ALERT_SEVERITY_ICON_COLOR: Record<
   (typeof BannerAlertSeverity)[keyof typeof BannerAlertSeverity],
   IconColor
 > = {
+  neutral: IconColor.IconDefault,
   info: IconColor.PrimaryDefault,
   success: IconColor.SuccessDefault,
   warning: IconColor.WarningDefault,
@@ -29,6 +31,7 @@ export const MAP_BANNER_ALERT_SEVERITY_BACKGROUND_COLOR: Record<
   (typeof BannerAlertSeverity)[keyof typeof BannerAlertSeverity],
   BoxBackgroundColor
 > = {
+  neutral: BoxBackgroundColor.BackgroundSection,
   info: BoxBackgroundColor.PrimaryMuted,
   success: BoxBackgroundColor.SuccessMuted,
   warning: BoxBackgroundColor.WarningMuted,

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -95,6 +95,13 @@ export const Severity: Story = {
       >
         This is a success banner.
       </BannerAlert>
+      <BannerAlert
+        {...args}
+        severity={BannerAlertSeverity.Neutral}
+        title="Neutral"
+      >
+        This is a neutral banner.
+      </BannerAlert>
     </div>
   ),
   args: {

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -71,8 +71,22 @@ export const Default: Story = {
 export const Severity: Story = {
   render: (args: BannerAlertProps) => (
     <div className="space-y-2">
+      <BannerAlert
+        {...args}
+        severity={BannerAlertSeverity.Neutral}
+        title="Neutral"
+      >
+        This is a neutral banner.
+      </BannerAlert>
       <BannerAlert {...args} severity={BannerAlertSeverity.Info} title="Info">
         This is an info banner.
+      </BannerAlert>
+      <BannerAlert
+        {...args}
+        severity={BannerAlertSeverity.Success}
+        title="Success"
+      >
+        This is a success banner.
       </BannerAlert>
       <BannerAlert
         {...args}
@@ -87,20 +101,6 @@ export const Severity: Story = {
         title="Danger"
       >
         This is a danger banner.
-      </BannerAlert>
-      <BannerAlert
-        {...args}
-        severity={BannerAlertSeverity.Success}
-        title="Success"
-      >
-        This is a success banner.
-      </BannerAlert>
-      <BannerAlert
-        {...args}
-        severity={BannerAlertSeverity.Neutral}
-        title="Neutral"
-      >
-        This is a neutral banner.
       </BannerAlert>
     </div>
   ),

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.test.tsx
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.test.tsx
@@ -46,6 +46,11 @@ describe('BannerAlert', () => {
       iconColor: IconColor.ErrorDefault,
       backgroundColor: BoxBackgroundColor.ErrorMuted,
     },
+    {
+      severity: BannerAlertSeverity.Neutral,
+      iconColor: IconColor.IconDefault,
+      backgroundColor: BoxBackgroundColor.BackgroundSection,
+    },
   ])(
     'applies expected icon and background for $severity severity',
     ({ severity, iconColor, backgroundColor }) => {

--- a/packages/design-system-react/src/components/BannerAlert/README.mdx
+++ b/packages/design-system-react/src/components/BannerAlert/README.mdx
@@ -57,6 +57,7 @@ Optional semantic severity used to choose icon and background styles.
 
 Supported values:
 
+- `BannerAlertSeverity.Neutral`
 - `BannerAlertSeverity.Info`
 - `BannerAlertSeverity.Success`
 - `BannerAlertSeverity.Warning`

--- a/packages/design-system-shared/src/types/BannerAlert/BannerAlert.types.ts
+++ b/packages/design-system-shared/src/types/BannerAlert/BannerAlert.types.ts
@@ -5,6 +5,8 @@ import type { BannerBasePropsShared } from '../BannerBase';
  * Uses const object with derived union type (ADR-0003).
  */
 export const BannerAlertSeverity = {
+  /** Neutral style. */
+  Neutral: 'neutral',
   /** Informational style. */
   Info: 'info',
   /** Success style. */


### PR DESCRIPTION
## Summary
- Adds `BannerAlertSeverity.Neutral` to shared types for web and mobile
- Maps neutral styling to section background, default icon color, and info icon in React and React Native constants
- Updates BannerAlert stories, docs, and tests to document and cover the new variant

## Test plan
- [x] `yarn workspace @metamask/design-system-react run test --testPathPattern=BannerAlert`
- [x] `yarn workspace @metamask/design-system-react-native run test --testPathPattern=BannerAlert`
- [x] Verify Neutral banner in React Storybook (`Severity` story)
- [x] Verify Neutral banner in React Native Storybook (`Severity` story)


Made with [Cursor](https://cursor.com)

| Before | After |
|--------|--------|
| <img width="1078" height="695" alt="image" src="https://github.com/user-attachments/assets/4ac27e22-81a4-44b1-ab57-89599ecdc8d8" /> | <img width="1082" height="857" alt="image" src="https://github.com/user-attachments/assets/2f1f23f6-9244-4663-968b-f2b18a91e16a" /> | 
| <img width="433" height="340" alt="image" src="https://github.com/user-attachments/assets/4a95b1ee-e4be-41ec-8d14-2417f3d4a96d" /> | <img width="431" height="415" alt="image" src="https://github.com/user-attachments/assets/5b5ab618-237e-4e3f-9a3a-13fa5500b989" /> | 