### PR TITLE
perf: lazy-load icons for per-icon code splitting

### DIFF
--- a/packages/design-system-react/jest.setup.ts
+++ b/packages/design-system-react/jest.setup.ts
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom';
+
+import { iconLoaders } from './src/components/Icon/icons';
+
+// Preload all icon modules so React.lazy resolves synchronously in tests.
+// Production code still lazy-loads icons for per-icon code splitting.
+beforeAll(async () => {
+  await Promise.all(Object.values(iconLoaders).map((loader) => loader()));
+});

--- a/packages/design-system-react/jest.setup.ts
+++ b/packages/design-system-react/jest.setup.ts
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
 
-import { iconLoaders } from './src/components/Icon/icons';
+import { preloadIconsForTests } from './src/components/Icon/Icon.registry';
 
-// Preload all icon modules so React.lazy resolves synchronously in tests.
-// Production code still lazy-loads icons for per-icon code splitting.
+// Preload all icon modules once per Jest worker so Icon renders synchronously
+// in tests. Production code still lazy-loads icons for per-icon code splitting.
 beforeAll(async () => {
-  await Promise.all(Object.values(iconLoaders).map((loader) => loader()));
+  await preloadIconsForTests();
 });

--- a/packages/design-system-react/src/components/Icon/Icon.registry.test.ts
+++ b/packages/design-system-react/src/components/Icon/Icon.registry.test.ts
@@ -1,0 +1,16 @@
+import { IconName } from '@metamask/design-system-shared';
+
+import { getLazyIcon, preloadIcon } from './Icon.registry';
+
+describe('Icon.registry', () => {
+  it('returns the same lazy component instance for repeated lookups', () => {
+    const first = getLazyIcon(IconName.Add);
+    const second = getLazyIcon(IconName.Add);
+
+    expect(first).toBe(second);
+  });
+
+  it('preloads an icon module', async () => {
+    expect(await preloadIcon(IconName.Close)).toBeUndefined();
+  });
+});

--- a/packages/design-system-react/src/components/Icon/Icon.registry.test.ts
+++ b/packages/design-system-react/src/components/Icon/Icon.registry.test.ts
@@ -1,6 +1,11 @@
 import { IconName } from '@metamask/design-system-shared';
 
-import { getLazyIcon, preloadIcon } from './Icon.registry';
+import {
+  getIconComponent,
+  getLazyIcon,
+  preloadIcon,
+  preloadIconsForTests,
+} from './Icon.registry';
 
 describe('Icon.registry', () => {
   it('returns the same lazy component instance for repeated lookups', () => {
@@ -12,5 +17,20 @@ describe('Icon.registry', () => {
 
   it('preloads an icon module', async () => {
     expect(await preloadIcon(IconName.Close)).toBeUndefined();
+  });
+
+  it('returns cached synchronous components in test environment', async () => {
+    await preloadIconsForTests();
+
+    const component = getIconComponent(IconName.Add);
+
+    expect(component).toBeDefined();
+    expect(getLazyIcon(IconName.Add)).not.toBe(component);
+  });
+
+  it('falls back to lazy components when test cache is disabled', () => {
+    expect(getIconComponent(IconName.Add, { useTestCache: false })).toBe(
+      getLazyIcon(IconName.Add),
+    );
   });
 });

--- a/packages/design-system-react/src/components/Icon/Icon.registry.ts
+++ b/packages/design-system-react/src/components/Icon/Icon.registry.ts
@@ -10,6 +10,28 @@ const lazyIconCache = new Map<
   LazyExoticComponent<IconComponentType>
 >();
 
+const testIconCache = new Map<IconName, IconComponentType>();
+
+let testPreloadPromise: Promise<void> | undefined;
+
+/**
+ * Preloads all icon modules for the Jest test environment.
+ * Icons are cached as synchronous components so tests can query the DOM
+ * immediately without waiting for React.lazy resolution.
+ *
+ * @returns A promise that resolves when all icons are cached.
+ */
+export function preloadIconsForTests(): Promise<void> {
+  testPreloadPromise ??= Promise.all(
+    Object.entries(iconLoaders).map(async ([name, loader]) => {
+      const mod = await loader();
+      testIconCache.set(name as IconName, mod.default);
+    }),
+  ).then(() => undefined);
+
+  return testPreloadPromise;
+}
+
 /**
  * Returns a cached React.lazy wrapper for the given icon name.
  * Each icon is loaded on demand via dynamic import, enabling per-icon
@@ -29,6 +51,34 @@ export function getLazyIcon(
   }
 
   return lazyIcon;
+}
+
+type GetIconComponentOptions = {
+  useTestCache?: boolean;
+};
+
+/**
+ * Resolves an icon component for rendering.
+ * In tests, returns a synchronously cached component after preloadIconsForTests().
+ * In production, returns a React.lazy wrapper for code splitting.
+ *
+ * @param name - The icon name to resolve.
+ * @param options - Optional resolver configuration.
+ * @param options.useTestCache - Whether to read from the Jest preload cache.
+ * @returns The icon component to render.
+ */
+export function getIconComponent(
+  name: IconName,
+  options?: GetIconComponentOptions,
+): IconComponentType | LazyExoticComponent<IconComponentType> {
+  const useTestCache = options?.useTestCache ?? process.env.NODE_ENV === 'test';
+  const cachedTestIcon = useTestCache ? testIconCache.get(name) : undefined;
+
+  if (cachedTestIcon) {
+    return cachedTestIcon;
+  }
+
+  return getLazyIcon(name);
 }
 
 /**

--- a/packages/design-system-react/src/components/Icon/Icon.registry.ts
+++ b/packages/design-system-react/src/components/Icon/Icon.registry.ts
@@ -1,0 +1,45 @@
+import type { IconName } from '@metamask/design-system-shared';
+import type { LazyExoticComponent } from 'react';
+import { lazy } from 'react';
+
+import type { IconComponentType } from './icons';
+import { iconLoaders, isIconName } from './icons';
+
+const lazyIconCache = new Map<
+  IconName,
+  LazyExoticComponent<IconComponentType>
+>();
+
+/**
+ * Returns a cached React.lazy wrapper for the given icon name.
+ * Each icon is loaded on demand via dynamic import, enabling per-icon
+ * code splitting instead of bundling all ~291 icons upfront.
+ *
+ * @param name - The icon name to resolve.
+ * @returns A lazy-loaded icon component.
+ */
+export function getLazyIcon(
+  name: IconName,
+): LazyExoticComponent<IconComponentType> {
+  let lazyIcon = lazyIconCache.get(name);
+
+  if (!lazyIcon) {
+    lazyIcon = lazy(iconLoaders[name]);
+    lazyIconCache.set(name, lazyIcon);
+  }
+
+  return lazyIcon;
+}
+
+/**
+ * Preloads an icon module so it is available synchronously on the next render.
+ * Useful for warming commonly used icons before they appear on screen.
+ *
+ * @param name - The icon name to preload.
+ * @returns A promise that resolves when the icon module has loaded.
+ */
+export function preloadIcon(name: IconName): Promise<void> {
+  return iconLoaders[name]().then(() => undefined);
+}
+
+export { isIconName };

--- a/packages/design-system-react/src/components/Icon/Icon.registry.ts
+++ b/packages/design-system-react/src/components/Icon/Icon.registry.ts
@@ -59,23 +59,25 @@ type GetIconComponentOptions = {
 
 /**
  * Resolves an icon component for rendering.
- * In tests, returns a synchronously cached component after preloadIconsForTests().
- * In production, returns a React.lazy wrapper for code splitting.
+ * Returns a synchronously cached component when present in the test preload
+ * cache (populated by preloadIconsForTests()). Otherwise returns a React.lazy
+ * wrapper for per-icon code splitting.
  *
  * @param name - The icon name to resolve.
  * @param options - Optional resolver configuration.
- * @param options.useTestCache - Whether to read from the Jest preload cache.
+ * @param options.useTestCache - When false, skips the test preload cache.
  * @returns The icon component to render.
  */
 export function getIconComponent(
   name: IconName,
   options?: GetIconComponentOptions,
 ): IconComponentType | LazyExoticComponent<IconComponentType> {
-  const useTestCache = options?.useTestCache ?? process.env.NODE_ENV === 'test';
-  const cachedTestIcon = useTestCache ? testIconCache.get(name) : undefined;
+  if (options?.useTestCache !== false) {
+    const cachedTestIcon = testIconCache.get(name);
 
-  if (cachedTestIcon) {
-    return cachedTestIcon;
+    if (cachedTestIcon) {
+      return cachedTestIcon;
+    }
   }
 
   return getLazyIcon(name);

--- a/packages/design-system-react/src/components/Icon/Icon.test.tsx
+++ b/packages/design-system-react/src/components/Icon/Icon.test.tsx
@@ -1,108 +1,112 @@
 import { IconName, IconSize, IconColor } from '@metamask/design-system-shared';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { Icon } from './Icon';
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from './Icon.constants';
 import type { IconProps } from './Icon.types';
 
-describe('Icon', () => {
-  it('should render correctly', () => {
-    render(<Icon name={IconName.AddSquare} data-testid="icon" />);
-    const icon = screen.getByTestId('icon');
-    expect(icon).toBeDefined();
-    expect(icon.tagName.toLowerCase()).toBe('svg');
+async function renderIcon(props: IconProps) {
+  const result = render(<Icon {...props} />);
+
+  if (props['data-testid']) {
+    const icon = await screen.findByTestId(props['data-testid']);
+    return { ...result, icon };
+  }
+
+  await waitFor(() => {
+    expect(result.container.querySelector('svg')).toBeInTheDocument();
   });
 
-  it('should render with different sizes', () => {
-    Object.values(IconSize).forEach((size) => {
-      const { container } = render(
-        <Icon
-          name={IconName.AddSquare}
-          size={size}
-          data-testid={`icon-${size}`}
-        />,
-      );
-      const icon = container.firstChild;
+  return { ...result, icon: result.container.querySelector('svg') };
+}
+
+describe('Icon', () => {
+  it('renders correctly', async () => {
+    const { icon } = await renderIcon({
+      name: IconName.AddSquare,
+      'data-testid': 'icon',
+    });
+
+    expect(icon).toBeDefined();
+    expect(icon?.tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('renders with different sizes', async () => {
+    for (const size of Object.values(IconSize) as IconSize[]) {
+      const { icon } = await renderIcon({
+        name: IconName.AddSquare,
+        size,
+        'data-testid': `icon-${size}`,
+      });
+
       expect(icon).toHaveClass('inline-block');
       expect(icon).toHaveClass(TWCLASSMAP_ICON_SIZE_DIMENSION[size]);
-    });
+    }
   });
 
-  it('should render with different colors', () => {
-    Object.values(IconColor).forEach((color) => {
-      const { container } = render(
-        <Icon
-          name={IconName.AddSquare}
-          color={color}
-          data-testid={`icon-${color}`}
-        />,
-      );
-      const icon = container.firstChild;
+  it('renders with different colors', async () => {
+    for (const color of Object.values(IconColor) as IconColor[]) {
+      const { icon } = await renderIcon({
+        name: IconName.AddSquare,
+        color,
+        'data-testid': `icon-${color}`,
+      });
+
       expect(icon).toHaveClass('inline-block');
       expect(icon).toHaveClass(color);
-    });
+    }
   });
 
-  it('should apply custom className', () => {
-    const { container } = render(
-      <Icon name={IconName.AddSquare} className="bg-default" />,
-    );
-    const icon = container.firstChild;
+  it('applies custom className', async () => {
+    const { icon } = await renderIcon({
+      name: IconName.AddSquare,
+      className: 'bg-default',
+    });
+
     expect(icon).toHaveClass('inline-block');
     expect(icon).toHaveClass('bg-default');
   });
 
-  it('should have correct SVG attributes', () => {
-    const { container } = render(<Icon name={IconName.AddSquare} />);
-    const svg = container.firstChild;
+  it('has correct SVG attributes', async () => {
+    const { icon } = await renderIcon({ name: IconName.AddSquare });
 
-    expect(svg).toHaveAttribute('xmlns', 'http://www.w3.org/2000/svg');
-    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
-    expect(svg).toHaveAttribute('fill', 'currentColor');
+    expect(icon).toHaveAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    expect(icon).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(icon).toHaveAttribute('fill', 'currentColor');
   });
 
-  it('should apply custom styles', () => {
+  it('applies custom styles', async () => {
     const customStyle = { marginTop: '10px' };
-    const { container } = render(
-      <Icon name={IconName.AddSquare} style={customStyle} />,
-    );
-    const icon = container.firstChild;
+    const { icon } = await renderIcon({
+      name: IconName.AddSquare,
+      style: customStyle,
+    });
+
     expect(icon).toHaveStyle(customStyle);
   });
 
   describe('className overrides', () => {
-    it('should allow className to override color prop', () => {
-      const { container } = render(
-        <Icon
-          name={IconName.AddSquare}
-          color={IconColor.IconDefault}
-          className="text-inherit"
-        />,
-      );
-      const icon = container.firstChild;
+    it('allows className to override color prop', async () => {
+      const { icon } = await renderIcon({
+        name: IconName.AddSquare,
+        color: IconColor.IconDefault,
+        className: 'text-inherit',
+      });
 
-      // Verify the custom class is present
       expect(icon).toHaveClass('text-inherit');
-
-      // Verify the default color class is not present
       expect(icon).not.toHaveClass(IconColor.IconDefault);
     });
 
-    it('should allow className to override size prop', () => {
-      const { container } = render(
-        <Icon
-          name={IconName.AddSquare}
-          size={IconSize.Md}
-          className="size-10"
-        />,
-      );
-      const icon = container.firstChild;
+    it('allows className to override size prop', async () => {
+      const { icon } = await renderIcon({
+        name: IconName.AddSquare,
+        size: IconSize.Md,
+        className: 'size-10',
+      });
 
-      // Verify the custom size classes are present
       expect(icon).toHaveClass('size-10');
 
-      // Verify the default size classes are not present
       const defaultSizeClasses =
         TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Md].split(' ');
       defaultSizeClasses.forEach((className) => {
@@ -110,22 +114,16 @@ describe('Icon', () => {
       });
     });
 
-    it('should allow className to override both color and size props', () => {
-      const { container } = render(
-        <Icon
-          name={IconName.AddSquare}
-          color={IconColor.IconDefault}
-          size={IconSize.Md}
-          className="size-10 text-inherit"
-        />,
-      );
-      const icon = container.firstChild;
+    it('allows className to override both color and size props', async () => {
+      const { icon } = await renderIcon({
+        name: IconName.AddSquare,
+        color: IconColor.IconDefault,
+        size: IconSize.Md,
+        className: 'size-10 text-inherit',
+      });
 
-      // Verify custom classes are present
       expect(icon).toHaveClass('text-inherit');
       expect(icon).toHaveClass('size-10');
-
-      // Verify default classes are not present
       expect(icon).not.toHaveClass(IconColor.IconDefault);
 
       const defaultSizeClasses =
@@ -152,7 +150,7 @@ describe('Icon error cases', () => {
     consoleSpy.mockRestore();
   });
 
-  it('should warn and return null when name prop is missing', () => {
+  it('warns and returns null when name prop is missing', () => {
     // @ts-expect-error Testing undefined name prop
     const { container } = render(<Icon {...({} as Partial<IconProps>)} />);
 
@@ -160,7 +158,7 @@ describe('Icon error cases', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('should warn and return null when icon is not found', () => {
+  it('warns and returns null when icon is not found', () => {
     const { container } = render(<Icon name={'NonExistentIcon' as IconName} />);
 
     expect(consoleSpy).toHaveBeenCalledWith('Icon "NonExistentIcon" not found');

--- a/packages/design-system-react/src/components/Icon/Icon.tsx
+++ b/packages/design-system-react/src/components/Icon/Icon.tsx
@@ -4,7 +4,7 @@ import React, { Suspense } from 'react';
 import { twMerge } from '../../utils/tw-merge';
 
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from './Icon.constants';
-import { getLazyIcon, isIconName } from './Icon.registry';
+import { getIconComponent, isIconName } from './Icon.registry';
 import type { IconProps } from './Icon.types';
 
 const IconRenderer: React.FC<IconProps> = ({
@@ -25,7 +25,7 @@ const IconRenderer: React.FC<IconProps> = ({
     return null;
   }
 
-  const LazyIconComponent = getLazyIcon(name);
+  const IconComponent = getIconComponent(name);
 
   const mergedClassName = twMerge(
     'inline-block',
@@ -35,7 +35,7 @@ const IconRenderer: React.FC<IconProps> = ({
   );
 
   return (
-    <LazyIconComponent
+    <IconComponent
       className={mergedClassName}
       {...(props as React.SVGProps<SVGSVGElement>)}
       style={style}

--- a/packages/design-system-react/src/components/Icon/Icon.tsx
+++ b/packages/design-system-react/src/components/Icon/Icon.tsx
@@ -1,13 +1,13 @@
 import { IconSize, IconColor } from '@metamask/design-system-shared';
-import React from 'react';
+import React, { Suspense } from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
 
 import { TWCLASSMAP_ICON_SIZE_DIMENSION } from './Icon.constants';
+import { getLazyIcon, isIconName } from './Icon.registry';
 import type { IconProps } from './Icon.types';
-import { Icons } from './icons';
 
-export const Icon: React.FC<IconProps> = ({
+const IconRenderer: React.FC<IconProps> = ({
   name,
   size = IconSize.Md,
   color = IconColor.IconDefault,
@@ -20,12 +20,12 @@ export const Icon: React.FC<IconProps> = ({
     return null;
   }
 
-  const IconComponent = Icons[name];
-
-  if (!IconComponent) {
-    console.warn(`Icon "${name}" not found`);
+  if (!isIconName(name)) {
+    console.warn(`Icon "${String(name)}" not found`);
     return null;
   }
+
+  const LazyIconComponent = getLazyIcon(name);
 
   const mergedClassName = twMerge(
     'inline-block',
@@ -35,10 +35,16 @@ export const Icon: React.FC<IconProps> = ({
   );
 
   return (
-    <IconComponent
+    <LazyIconComponent
       className={mergedClassName}
       {...(props as React.SVGProps<SVGSVGElement>)}
       style={style}
     />
   );
 };
+
+export const Icon: React.FC<IconProps> = (props) => (
+  <Suspense fallback={null}>
+    <IconRenderer {...props} />
+  </Suspense>
+);

--- a/packages/design-system-react/src/components/Icon/icons/index.ts
+++ b/packages/design-system-react/src/components/Icon/icons/index.ts
@@ -1,595 +1,312 @@
 // This file is auto-generated — do not edit manually
 // Run `yarn generate:icons` from the repo root to regenerate
-import type { ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react';
+import type { ComponentType, SVGProps } from 'react';
+import type { IconName } from '@metamask/design-system-shared';
 
-import Accessibility from './Accessibility';
-import Activity from './Activity';
-import AddCard from './AddCard';
-import AddCircle from './AddCircle';
-import AddSquare from './AddSquare';
-import Add from './Add';
-import AfterHours from './AfterHours';
-import Ai from './Ai';
-import AlternateEmail from './AlternateEmail';
-import AppleLogo from './AppleLogo';
-import Apps from './Apps';
-import Arrow2Down from './Arrow2Down';
-import Arrow2Left from './Arrow2Left';
-import Arrow2Right from './Arrow2Right';
-import Arrow2UpRight from './Arrow2UpRight';
-import Arrow2Up from './Arrow2Up';
-import ArrowCircleDown from './ArrowCircleDown';
-import ArrowCircleUp from './ArrowCircleUp';
-import ArrowDoubleLeft from './ArrowDoubleLeft';
-import ArrowDoubleRight from './ArrowDoubleRight';
-import ArrowDown from './ArrowDown';
-import ArrowDropDownCircle from './ArrowDropDownCircle';
-import ArrowLeft from './ArrowLeft';
-import ArrowRight from './ArrowRight';
-import ArrowUp from './ArrowUp';
-import AttachMoney from './AttachMoney';
-import Attachment from './Attachment';
-import Backspace from './Backspace';
-import Ban from './Ban';
-import BankAssured from './BankAssured';
-import Bank from './Bank';
-import Bold from './Bold';
-import Book from './Book';
-import Bookmark from './Bookmark';
-import Bridge from './Bridge';
-import Briefcase from './Briefcase';
-import Bulb from './Bulb';
-import BuySell from './BuySell';
-import Cake from './Cake';
-import Calculator from './Calculator';
-import Calendar from './Calendar';
-import Call from './Call';
-import Camera from './Camera';
-import Campaign from './Campaign';
-import Candlestick from './Candlestick';
-import CardPos from './CardPos';
-import Card from './Card';
-import Cash from './Cash';
-import Category from './Category';
-import Chart from './Chart';
-import CheckBold from './CheckBold';
-import Check from './Check';
-import CircleX from './CircleX';
-import Clear from './Clear';
-import ClockFilled from './ClockFilled';
-import Clock from './Clock';
-import Close from './Close';
-import CloudDownload from './CloudDownload';
-import CloudUpload from './CloudUpload';
-import Cloud from './Cloud';
-import CodeCircle from './CodeCircle';
-import Code from './Code';
-import Coin from './Coin';
-import Collapse from './Collapse';
-import Confirmation from './Confirmation';
-import Connect from './Connect';
-import CopySuccess from './CopySuccess';
-import Copy from './Copy';
-import CorporateFare from './CorporateFare';
-import CreditCheck from './CreditCheck';
-import CurrencyFranc from './CurrencyFranc';
-import CurrencyLira from './CurrencyLira';
-import CurrencyPound from './CurrencyPound';
-import CurrencyYuan from './CurrencyYuan';
-import Customize from './Customize';
-import Danger from './Danger';
-import DarkFilled from './DarkFilled';
-import Dark from './Dark';
-import Data from './Data';
-import Description from './Description';
-import Details from './Details';
-import Diagram from './Diagram';
-import DocumentCode from './DocumentCode';
-import Download from './Download';
-import Draft from './Draft';
-import EcoLeaf from './EcoLeaf';
-import EditSquare from './EditSquare';
-import Edit from './Edit';
-import EncryptedAdd from './EncryptedAdd';
-import Eraser from './Eraser';
-import Error from './Error';
-import Ethereum from './Ethereum';
-import Exchange from './Exchange';
-import ExpandVertical from './ExpandVertical';
-import Expand from './Expand';
-import ExploreFilled from './ExploreFilled';
-import Explore from './Explore';
-import Export from './Export';
-import Extension from './Extension';
-import EyeSlash from './EyeSlash';
-import Eye from './Eye';
-import FaceId from './FaceId';
-import Feedback from './Feedback';
-import File from './File';
-import Filter from './Filter';
-import Fingerprint from './Fingerprint';
-import Fire from './Fire';
-import FirstPage from './FirstPage';
-import Flag from './Flag';
-import FlashFilled from './FlashFilled';
-import FlashSlash from './FlashSlash';
-import Flash from './Flash';
-import Flask from './Flask';
-import Flower from './Flower';
-import Folder from './Folder';
-import Forest from './Forest';
-import FullCircle from './FullCircle';
-import Gas from './Gas';
-import Gift from './Gift';
-import GlobalSearch from './GlobalSearch';
-import Global from './Global';
-import Graph from './Graph';
-import Group from './Group';
-import Hardware from './Hardware';
-import HashTag from './HashTag';
-import HeartFilled from './HeartFilled';
-import Heart from './Heart';
-import Hierarchy from './Hierarchy';
-import HomeFilled from './HomeFilled';
-import Home from './Home';
-import Image from './Image';
-import Info from './Info';
-import Inventory from './Inventory';
-import Joystick from './Joystick';
-import KeepFilled from './KeepFilled';
-import Keep from './Keep';
-import Key from './Key';
-import LastPage from './LastPage';
-import LightFilled from './LightFilled';
-import Light from './Light';
-import Link from './Link';
-import ListArrow from './ListArrow';
-import Loading from './Loading';
-import Location from './Location';
-import LockSlash from './LockSlash';
-import Lock from './Lock';
-import LockedFilled from './LockedFilled';
-import Login from './Login';
-import Logout from './Logout';
-import Mail from './Mail';
-import Map from './Map';
-import Menu from './Menu';
-import Merge from './Merge';
-import MessageQuestion from './MessageQuestion';
-import Messages from './Messages';
-import MetamaskFoxOutline from './MetamaskFoxOutline';
-import Mic from './Mic';
-import MinusBold from './MinusBold';
-import MinusSquare from './MinusSquare';
-import Minus from './Minus';
-import Mobile from './Mobile';
-import MoneyBag from './MoneyBag';
-import Money from './Money';
-import Monitor from './Monitor';
-import MoreHorizontal from './MoreHorizontal';
-import MoreVertical from './MoreVertical';
-import MountainFlag from './MountainFlag';
-import MusdFilled from './MusdFilled';
-import Musd from './Musd';
-import MusicNote from './MusicNote';
-import NoPhotography from './NoPhotography';
-import Notification from './Notification';
-import PageInfo from './PageInfo';
-import Palette from './Palette';
-import PasswordCheck from './PasswordCheck';
-import Pending from './Pending';
-import People from './People';
-import PersonCancel from './PersonCancel';
-import PieChart from './PieChart';
-import Pin from './Pin';
-import Plant from './Plant';
-import Plug from './Plug';
-import PlusAndMinus from './PlusAndMinus';
-import PolicyAlert from './PolicyAlert';
-import PopUp from './PopUp';
-import Predictions from './Predictions';
-import Print from './Print';
-import PriorityHigh from './PriorityHigh';
-import PrivacyTip from './PrivacyTip';
-import ProgrammingArrows from './ProgrammingArrows';
-import Publish from './Publish';
-import QrCode from './QrCode';
-import Question from './Question';
-import Receive from './Receive';
-import Received from './Received';
-import Refresh from './Refresh';
-import RemoveMinus from './RemoveMinus';
-import Report from './Report';
-import Rocket from './Rocket';
-import SaveFilled from './SaveFilled';
-import Save from './Save';
-import Saving from './Saving';
-import ScanBarcode from './ScanBarcode';
-import ScanFocus from './ScanFocus';
-import Scan from './Scan';
-import Search from './Search';
-import SecurityAlert from './SecurityAlert';
-import SecurityCross from './SecurityCross';
-import SecurityKey from './SecurityKey';
-import SecuritySearch from './SecuritySearch';
-import SecuritySlash from './SecuritySlash';
-import SecurityTick from './SecurityTick';
-import SecurityTime from './SecurityTime';
-import SecurityUser from './SecurityUser';
-import Security from './Security';
-import Send from './Send';
-import SentimentDissatisfied from './SentimentDissatisfied';
-import SentimentNeutral from './SentimentNeutral';
-import SentimentSatisfied from './SentimentSatisfied';
-import SentimentVerySatisfied from './SentimentVerySatisfied';
-import SettingFilled from './SettingFilled';
-import Setting from './Setting';
-import Share from './Share';
-import ShieldLock from './ShieldLock';
-import ShoppingBag from './ShoppingBag';
-import ShoppingCart from './ShoppingCart';
-import SidePanel from './SidePanel';
-import SignalCellular from './SignalCellular';
-import Slash from './Slash';
-import Sms from './Sms';
-import SnapsMobile from './SnapsMobile';
-import SnapsPlus from './SnapsPlus';
-import SnapsRound from './SnapsRound';
-import Snaps from './Snaps';
-import SortByAlpha from './SortByAlpha';
-import Sort from './Sort';
-import Sparkle from './Sparkle';
-import Speed from './Speed';
-import Speedometer from './Speedometer';
-import Square from './Square';
-import Stake from './Stake';
-import StarFilled from './StarFilled';
-import Star from './Star';
-import Start from './Start';
-import Storefront from './Storefront';
-import Student from './Student';
-import SwapHorizontal from './SwapHorizontal';
-import SwapVertical from './SwapVertical';
-import TabClose from './TabClose';
-import TableRow from './TableRow';
-import Tablet from './Tablet';
-import Tag from './Tag';
-import Telegram from './Telegram';
-import ThumbDownFilled from './ThumbDownFilled';
-import ThumbDown from './ThumbDown';
-import ThumbUpFilled from './ThumbUpFilled';
-import ThumbUp from './ThumbUp';
-import Tint from './Tint';
-import Tooltip from './Tooltip';
-import Translate from './Translate';
-import Trash from './Trash';
-import TrendDown from './TrendDown';
-import TrendUp from './TrendUp';
-import Trophy from './Trophy';
-import Undo from './Undo';
-import Unfold from './Unfold';
-import UnlockedFilled from './UnlockedFilled';
-import Unpin from './Unpin';
-import UploadFile from './UploadFile';
-import Upload from './Upload';
-import Usb from './Usb';
-import UserCheck from './UserCheck';
-import UserCircleAdd from './UserCircleAdd';
-import UserCircleRemove from './UserCircleRemove';
-import UserCircle from './UserCircle';
-import User from './User';
-import VerifiedFilled from './VerifiedFilled';
-import Verified from './Verified';
-import Videocam from './Videocam';
-import ViewColumn from './ViewColumn';
-import ViewInAr from './ViewInAr';
-import VolumeOff from './VolumeOff';
-import VolumeUp from './VolumeUp';
-import WalletFilled from './WalletFilled';
-import Wallet from './Wallet';
-import Warning from './Warning';
-import WebTraffic from './WebTraffic';
-import Widgets from './Widgets';
-import WifiOff from './WifiOff';
-import Wifi from './Wifi';
-import X from './X';
+export type IconComponentType = ComponentType<SVGProps<SVGSVGElement>>;
 
-export const Icons = {
-  Accessibility,
-  Activity,
-  AddCard,
-  AddCircle,
-  AddSquare,
-  Add,
-  AfterHours,
-  Ai,
-  AlternateEmail,
-  AppleLogo,
-  Apps,
-  Arrow2Down,
-  Arrow2Left,
-  Arrow2Right,
-  Arrow2UpRight,
-  Arrow2Up,
-  ArrowCircleDown,
-  ArrowCircleUp,
-  ArrowDoubleLeft,
-  ArrowDoubleRight,
-  ArrowDown,
-  ArrowDropDownCircle,
-  ArrowLeft,
-  ArrowRight,
-  ArrowUp,
-  AttachMoney,
-  Attachment,
-  Backspace,
-  Ban,
-  BankAssured,
-  Bank,
-  Bold,
-  Book,
-  Bookmark,
-  Bridge,
-  Briefcase,
-  Bulb,
-  BuySell,
-  Cake,
-  Calculator,
-  Calendar,
-  Call,
-  Camera,
-  Campaign,
-  Candlestick,
-  CardPos,
-  Card,
-  Cash,
-  Category,
-  Chart,
-  CheckBold,
-  Check,
-  CircleX,
-  Clear,
-  ClockFilled,
-  Clock,
-  Close,
-  CloudDownload,
-  CloudUpload,
-  Cloud,
-  CodeCircle,
-  Code,
-  Coin,
-  Collapse,
-  Confirmation,
-  Connect,
-  CopySuccess,
-  Copy,
-  CorporateFare,
-  CreditCheck,
-  CurrencyFranc,
-  CurrencyLira,
-  CurrencyPound,
-  CurrencyYuan,
-  Customize,
-  Danger,
-  DarkFilled,
-  Dark,
-  Data,
-  Description,
-  Details,
-  Diagram,
-  DocumentCode,
-  Download,
-  Draft,
-  EcoLeaf,
-  EditSquare,
-  Edit,
-  EncryptedAdd,
-  Eraser,
-  Error,
-  Ethereum,
-  Exchange,
-  ExpandVertical,
-  Expand,
-  ExploreFilled,
-  Explore,
-  Export,
-  Extension,
-  EyeSlash,
-  Eye,
-  FaceId,
-  Feedback,
-  File,
-  Filter,
-  Fingerprint,
-  Fire,
-  FirstPage,
-  Flag,
-  FlashFilled,
-  FlashSlash,
-  Flash,
-  Flask,
-  Flower,
-  Folder,
-  Forest,
-  FullCircle,
-  Gas,
-  Gift,
-  GlobalSearch,
-  Global,
-  Graph,
-  Group,
-  Hardware,
-  HashTag,
-  HeartFilled,
-  Heart,
-  Hierarchy,
-  HomeFilled,
-  Home,
-  Image,
-  Info,
-  Inventory,
-  Joystick,
-  KeepFilled,
-  Keep,
-  Key,
-  LastPage,
-  LightFilled,
-  Light,
-  Link,
-  ListArrow,
-  Loading,
-  Location,
-  LockSlash,
-  Lock,
-  LockedFilled,
-  Login,
-  Logout,
-  Mail,
-  Map,
-  Menu,
-  Merge,
-  MessageQuestion,
-  Messages,
-  MetamaskFoxOutline,
-  Mic,
-  MinusBold,
-  MinusSquare,
-  Minus,
-  Mobile,
-  MoneyBag,
-  Money,
-  Monitor,
-  MoreHorizontal,
-  MoreVertical,
-  MountainFlag,
-  MusdFilled,
-  Musd,
-  MusicNote,
-  NoPhotography,
-  Notification,
-  PageInfo,
-  Palette,
-  PasswordCheck,
-  Pending,
-  People,
-  PersonCancel,
-  PieChart,
-  Pin,
-  Plant,
-  Plug,
-  PlusAndMinus,
-  PolicyAlert,
-  PopUp,
-  Predictions,
-  Print,
-  PriorityHigh,
-  PrivacyTip,
-  ProgrammingArrows,
-  Publish,
-  QrCode,
-  Question,
-  Receive,
-  Received,
-  Refresh,
-  RemoveMinus,
-  Report,
-  Rocket,
-  SaveFilled,
-  Save,
-  Saving,
-  ScanBarcode,
-  ScanFocus,
-  Scan,
-  Search,
-  SecurityAlert,
-  SecurityCross,
-  SecurityKey,
-  SecuritySearch,
-  SecuritySlash,
-  SecurityTick,
-  SecurityTime,
-  SecurityUser,
-  Security,
-  Send,
-  SentimentDissatisfied,
-  SentimentNeutral,
-  SentimentSatisfied,
-  SentimentVerySatisfied,
-  SettingFilled,
-  Setting,
-  Share,
-  ShieldLock,
-  ShoppingBag,
-  ShoppingCart,
-  SidePanel,
-  SignalCellular,
-  Slash,
-  Sms,
-  SnapsMobile,
-  SnapsPlus,
-  SnapsRound,
-  Snaps,
-  SortByAlpha,
-  Sort,
-  Sparkle,
-  Speed,
-  Speedometer,
-  Square,
-  Stake,
-  StarFilled,
-  Star,
-  Start,
-  Storefront,
-  Student,
-  SwapHorizontal,
-  SwapVertical,
-  TabClose,
-  TableRow,
-  Tablet,
-  Tag,
-  Telegram,
-  ThumbDownFilled,
-  ThumbDown,
-  ThumbUpFilled,
-  ThumbUp,
-  Tint,
-  Tooltip,
-  Translate,
-  Trash,
-  TrendDown,
-  TrendUp,
-  Trophy,
-  Undo,
-  Unfold,
-  UnlockedFilled,
-  Unpin,
-  UploadFile,
-  Upload,
-  Usb,
-  UserCheck,
-  UserCircleAdd,
-  UserCircleRemove,
-  UserCircle,
-  User,
-  VerifiedFilled,
-  Verified,
-  Videocam,
-  ViewColumn,
-  ViewInAr,
-  VolumeOff,
-  VolumeUp,
-  WalletFilled,
-  Wallet,
-  Warning,
-  WebTraffic,
-  Widgets,
-  WifiOff,
-  Wifi,
-  X,
-} as const;
+export type IconLoader = () => Promise<{ default: IconComponentType }>;
 
-export type IconComponentType = ForwardRefExoticComponent<
-  SVGProps<SVGSVGElement> & RefAttributes<SVGSVGElement>
->;
+export const iconLoaders = {
+  Accessibility: () => import('./Accessibility'),
+  Activity: () => import('./Activity'),
+  AddCard: () => import('./AddCard'),
+  AddCircle: () => import('./AddCircle'),
+  AddSquare: () => import('./AddSquare'),
+  Add: () => import('./Add'),
+  AfterHours: () => import('./AfterHours'),
+  Ai: () => import('./Ai'),
+  AlternateEmail: () => import('./AlternateEmail'),
+  AppleLogo: () => import('./AppleLogo'),
+  Apps: () => import('./Apps'),
+  Arrow2Down: () => import('./Arrow2Down'),
+  Arrow2Left: () => import('./Arrow2Left'),
+  Arrow2Right: () => import('./Arrow2Right'),
+  Arrow2UpRight: () => import('./Arrow2UpRight'),
+  Arrow2Up: () => import('./Arrow2Up'),
+  ArrowCircleDown: () => import('./ArrowCircleDown'),
+  ArrowCircleUp: () => import('./ArrowCircleUp'),
+  ArrowDoubleLeft: () => import('./ArrowDoubleLeft'),
+  ArrowDoubleRight: () => import('./ArrowDoubleRight'),
+  ArrowDown: () => import('./ArrowDown'),
+  ArrowDropDownCircle: () => import('./ArrowDropDownCircle'),
+  ArrowLeft: () => import('./ArrowLeft'),
+  ArrowRight: () => import('./ArrowRight'),
+  ArrowUp: () => import('./ArrowUp'),
+  AttachMoney: () => import('./AttachMoney'),
+  Attachment: () => import('./Attachment'),
+  Backspace: () => import('./Backspace'),
+  Ban: () => import('./Ban'),
+  BankAssured: () => import('./BankAssured'),
+  Bank: () => import('./Bank'),
+  Bold: () => import('./Bold'),
+  Book: () => import('./Book'),
+  Bookmark: () => import('./Bookmark'),
+  Bridge: () => import('./Bridge'),
+  Briefcase: () => import('./Briefcase'),
+  Bulb: () => import('./Bulb'),
+  BuySell: () => import('./BuySell'),
+  Cake: () => import('./Cake'),
+  Calculator: () => import('./Calculator'),
+  Calendar: () => import('./Calendar'),
+  Call: () => import('./Call'),
+  Camera: () => import('./Camera'),
+  Campaign: () => import('./Campaign'),
+  Candlestick: () => import('./Candlestick'),
+  CardPos: () => import('./CardPos'),
+  Card: () => import('./Card'),
+  Cash: () => import('./Cash'),
+  Category: () => import('./Category'),
+  Chart: () => import('./Chart'),
+  CheckBold: () => import('./CheckBold'),
+  Check: () => import('./Check'),
+  CircleX: () => import('./CircleX'),
+  Clear: () => import('./Clear'),
+  ClockFilled: () => import('./ClockFilled'),
+  Clock: () => import('./Clock'),
+  Close: () => import('./Close'),
+  CloudDownload: () => import('./CloudDownload'),
+  CloudUpload: () => import('./CloudUpload'),
+  Cloud: () => import('./Cloud'),
+  CodeCircle: () => import('./CodeCircle'),
+  Code: () => import('./Code'),
+  Coin: () => import('./Coin'),
+  Collapse: () => import('./Collapse'),
+  Confirmation: () => import('./Confirmation'),
+  Connect: () => import('./Connect'),
+  CopySuccess: () => import('./CopySuccess'),
+  Copy: () => import('./Copy'),
+  CorporateFare: () => import('./CorporateFare'),
+  CreditCheck: () => import('./CreditCheck'),
+  CurrencyFranc: () => import('./CurrencyFranc'),
+  CurrencyLira: () => import('./CurrencyLira'),
+  CurrencyPound: () => import('./CurrencyPound'),
+  CurrencyYuan: () => import('./CurrencyYuan'),
+  Customize: () => import('./Customize'),
+  Danger: () => import('./Danger'),
+  DarkFilled: () => import('./DarkFilled'),
+  Dark: () => import('./Dark'),
+  Data: () => import('./Data'),
+  Description: () => import('./Description'),
+  Details: () => import('./Details'),
+  Diagram: () => import('./Diagram'),
+  DocumentCode: () => import('./DocumentCode'),
+  Download: () => import('./Download'),
+  Draft: () => import('./Draft'),
+  EcoLeaf: () => import('./EcoLeaf'),
+  EditSquare: () => import('./EditSquare'),
+  Edit: () => import('./Edit'),
+  EncryptedAdd: () => import('./EncryptedAdd'),
+  Eraser: () => import('./Eraser'),
+  Error: () => import('./Error'),
+  Ethereum: () => import('./Ethereum'),
+  Exchange: () => import('./Exchange'),
+  ExpandVertical: () => import('./ExpandVertical'),
+  Expand: () => import('./Expand'),
+  ExploreFilled: () => import('./ExploreFilled'),
+  Explore: () => import('./Explore'),
+  Export: () => import('./Export'),
+  Extension: () => import('./Extension'),
+  EyeSlash: () => import('./EyeSlash'),
+  Eye: () => import('./Eye'),
+  FaceId: () => import('./FaceId'),
+  Feedback: () => import('./Feedback'),
+  File: () => import('./File'),
+  Filter: () => import('./Filter'),
+  Fingerprint: () => import('./Fingerprint'),
+  Fire: () => import('./Fire'),
+  FirstPage: () => import('./FirstPage'),
+  Flag: () => import('./Flag'),
+  FlashFilled: () => import('./FlashFilled'),
+  FlashSlash: () => import('./FlashSlash'),
+  Flash: () => import('./Flash'),
+  Flask: () => import('./Flask'),
+  Flower: () => import('./Flower'),
+  Folder: () => import('./Folder'),
+  Forest: () => import('./Forest'),
+  FullCircle: () => import('./FullCircle'),
+  Gas: () => import('./Gas'),
+  Gift: () => import('./Gift'),
+  GlobalSearch: () => import('./GlobalSearch'),
+  Global: () => import('./Global'),
+  Graph: () => import('./Graph'),
+  Group: () => import('./Group'),
+  Hardware: () => import('./Hardware'),
+  HashTag: () => import('./HashTag'),
+  HeartFilled: () => import('./HeartFilled'),
+  Heart: () => import('./Heart'),
+  Hierarchy: () => import('./Hierarchy'),
+  HomeFilled: () => import('./HomeFilled'),
+  Home: () => import('./Home'),
+  Image: () => import('./Image'),
+  Info: () => import('./Info'),
+  Inventory: () => import('./Inventory'),
+  Joystick: () => import('./Joystick'),
+  KeepFilled: () => import('./KeepFilled'),
+  Keep: () => import('./Keep'),
+  Key: () => import('./Key'),
+  LastPage: () => import('./LastPage'),
+  LightFilled: () => import('./LightFilled'),
+  Light: () => import('./Light'),
+  Link: () => import('./Link'),
+  ListArrow: () => import('./ListArrow'),
+  Loading: () => import('./Loading'),
+  Location: () => import('./Location'),
+  LockSlash: () => import('./LockSlash'),
+  Lock: () => import('./Lock'),
+  LockedFilled: () => import('./LockedFilled'),
+  Login: () => import('./Login'),
+  Logout: () => import('./Logout'),
+  Mail: () => import('./Mail'),
+  Map: () => import('./Map'),
+  Menu: () => import('./Menu'),
+  Merge: () => import('./Merge'),
+  MessageQuestion: () => import('./MessageQuestion'),
+  Messages: () => import('./Messages'),
+  MetamaskFoxOutline: () => import('./MetamaskFoxOutline'),
+  Mic: () => import('./Mic'),
+  MinusBold: () => import('./MinusBold'),
+  MinusSquare: () => import('./MinusSquare'),
+  Minus: () => import('./Minus'),
+  Mobile: () => import('./Mobile'),
+  MoneyBag: () => import('./MoneyBag'),
+  Money: () => import('./Money'),
+  Monitor: () => import('./Monitor'),
+  MoreHorizontal: () => import('./MoreHorizontal'),
+  MoreVertical: () => import('./MoreVertical'),
+  MountainFlag: () => import('./MountainFlag'),
+  MusdFilled: () => import('./MusdFilled'),
+  Musd: () => import('./Musd'),
+  MusicNote: () => import('./MusicNote'),
+  NoPhotography: () => import('./NoPhotography'),
+  Notification: () => import('./Notification'),
+  PageInfo: () => import('./PageInfo'),
+  Palette: () => import('./Palette'),
+  PasswordCheck: () => import('./PasswordCheck'),
+  Pending: () => import('./Pending'),
+  People: () => import('./People'),
+  PersonCancel: () => import('./PersonCancel'),
+  PieChart: () => import('./PieChart'),
+  Pin: () => import('./Pin'),
+  Plant: () => import('./Plant'),
+  Plug: () => import('./Plug'),
+  PlusAndMinus: () => import('./PlusAndMinus'),
+  PolicyAlert: () => import('./PolicyAlert'),
+  PopUp: () => import('./PopUp'),
+  Predictions: () => import('./Predictions'),
+  Print: () => import('./Print'),
+  PriorityHigh: () => import('./PriorityHigh'),
+  PrivacyTip: () => import('./PrivacyTip'),
+  ProgrammingArrows: () => import('./ProgrammingArrows'),
+  Publish: () => import('./Publish'),
+  QrCode: () => import('./QrCode'),
+  Question: () => import('./Question'),
+  Receive: () => import('./Receive'),
+  Received: () => import('./Received'),
+  Refresh: () => import('./Refresh'),
+  RemoveMinus: () => import('./RemoveMinus'),
+  Report: () => import('./Report'),
+  Rocket: () => import('./Rocket'),
+  SaveFilled: () => import('./SaveFilled'),
+  Save: () => import('./Save'),
+  Saving: () => import('./Saving'),
+  ScanBarcode: () => import('./ScanBarcode'),
+  ScanFocus: () => import('./ScanFocus'),
+  Scan: () => import('./Scan'),
+  Search: () => import('./Search'),
+  SecurityAlert: () => import('./SecurityAlert'),
+  SecurityCross: () => import('./SecurityCross'),
+  SecurityKey: () => import('./SecurityKey'),
+  SecuritySearch: () => import('./SecuritySearch'),
+  SecuritySlash: () => import('./SecuritySlash'),
+  SecurityTick: () => import('./SecurityTick'),
+  SecurityTime: () => import('./SecurityTime'),
+  SecurityUser: () => import('./SecurityUser'),
+  Security: () => import('./Security'),
+  Send: () => import('./Send'),
+  SentimentDissatisfied: () => import('./SentimentDissatisfied'),
+  SentimentNeutral: () => import('./SentimentNeutral'),
+  SentimentSatisfied: () => import('./SentimentSatisfied'),
+  SentimentVerySatisfied: () => import('./SentimentVerySatisfied'),
+  SettingFilled: () => import('./SettingFilled'),
+  Setting: () => import('./Setting'),
+  Share: () => import('./Share'),
+  ShieldLock: () => import('./ShieldLock'),
+  ShoppingBag: () => import('./ShoppingBag'),
+  ShoppingCart: () => import('./ShoppingCart'),
+  SidePanel: () => import('./SidePanel'),
+  SignalCellular: () => import('./SignalCellular'),
+  Slash: () => import('./Slash'),
+  Sms: () => import('./Sms'),
+  SnapsMobile: () => import('./SnapsMobile'),
+  SnapsPlus: () => import('./SnapsPlus'),
+  SnapsRound: () => import('./SnapsRound'),
+  Snaps: () => import('./Snaps'),
+  SortByAlpha: () => import('./SortByAlpha'),
+  Sort: () => import('./Sort'),
+  Sparkle: () => import('./Sparkle'),
+  Speed: () => import('./Speed'),
+  Speedometer: () => import('./Speedometer'),
+  Square: () => import('./Square'),
+  Stake: () => import('./Stake'),
+  StarFilled: () => import('./StarFilled'),
+  Star: () => import('./Star'),
+  Start: () => import('./Start'),
+  Storefront: () => import('./Storefront'),
+  Student: () => import('./Student'),
+  SwapHorizontal: () => import('./SwapHorizontal'),
+  SwapVertical: () => import('./SwapVertical'),
+  TabClose: () => import('./TabClose'),
+  TableRow: () => import('./TableRow'),
+  Tablet: () => import('./Tablet'),
+  Tag: () => import('./Tag'),
+  Telegram: () => import('./Telegram'),
+  ThumbDownFilled: () => import('./ThumbDownFilled'),
+  ThumbDown: () => import('./ThumbDown'),
+  ThumbUpFilled: () => import('./ThumbUpFilled'),
+  ThumbUp: () => import('./ThumbUp'),
+  Tint: () => import('./Tint'),
+  Tooltip: () => import('./Tooltip'),
+  Translate: () => import('./Translate'),
+  Trash: () => import('./Trash'),
+  TrendDown: () => import('./TrendDown'),
+  TrendUp: () => import('./TrendUp'),
+  Trophy: () => import('./Trophy'),
+  Undo: () => import('./Undo'),
+  Unfold: () => import('./Unfold'),
+  UnlockedFilled: () => import('./UnlockedFilled'),
+  Unpin: () => import('./Unpin'),
+  UploadFile: () => import('./UploadFile'),
+  Upload: () => import('./Upload'),
+  Usb: () => import('./Usb'),
+  UserCheck: () => import('./UserCheck'),
+  UserCircleAdd: () => import('./UserCircleAdd'),
+  UserCircleRemove: () => import('./UserCircleRemove'),
+  UserCircle: () => import('./UserCircle'),
+  User: () => import('./User'),
+  VerifiedFilled: () => import('./VerifiedFilled'),
+  Verified: () => import('./Verified'),
+  Videocam: () => import('./Videocam'),
+  ViewColumn: () => import('./ViewColumn'),
+  ViewInAr: () => import('./ViewInAr'),
+  VolumeOff: () => import('./VolumeOff'),
+  VolumeUp: () => import('./VolumeUp'),
+  WalletFilled: () => import('./WalletFilled'),
+  Wallet: () => import('./Wallet'),
+  Warning: () => import('./Warning'),
+  WebTraffic: () => import('./WebTraffic'),
+  Widgets: () => import('./Widgets'),
+  WifiOff: () => import('./WifiOff'),
+  Wifi: () => import('./Wifi'),
+  X: () => import('./X'),
+} as unknown as Record<IconName, IconLoader>;
 
-export type IconsType = typeof Icons;
+/**
+ * Type guard to check if a string is a valid IconName at runtime.
+ *
+ * @param name - The icon name to check.
+ * @returns True if the name corresponds to a registered icon loader.
+ */
+export function isIconName(name: string): name is IconName {
+  return Object.prototype.hasOwnProperty.call(iconLoaders, name);
+}

--- a/packages/design-system-react/src/components/Icon/index.ts
+++ b/packages/design-system-react/src/components/Icon/index.ts
@@ -1,3 +1,4 @@
 export { IconName, IconSize, IconColor } from '@metamask/design-system-shared';
 export { Icon } from './Icon';
+export { preloadIcon } from './Icon.registry';
 export type { IconProps } from './Icon.types';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -86,7 +86,7 @@ export { HelpText, HelpTextSeverity } from './HelpText';
 export type { HelpTextProps } from './HelpText';
 
 export { Icon } from './Icon';
-export { IconName, IconSize, IconColor } from './Icon';
+export { IconName, IconSize, IconColor, preloadIcon } from './Icon';
 export type { IconProps } from './Icon';
 
 export { Input } from './Input';

--- a/packages/design-system-shared/scripts/generate-icons.ts
+++ b/packages/design-system-shared/scripts/generate-icons.ts
@@ -8,6 +8,8 @@ import * as path from 'path';
 
 const REPO_ROOT = path.join(__dirname, '../../..');
 
+const SHARED_PACKAGE_JSON = path.join(__dirname, '../package.json');
+
 /** Single source of truth for all icon SVG assets */
 const SHARED_ASSETS_DIR = path.join(__dirname, '../src/assets/icons');
 
@@ -192,6 +194,7 @@ async function generateReactNativeAssets(svgFiles: string[]): Promise<void> {
   // already rewritten the scope in committed source files — causing TS2307 in
   // the preview publish workflow. The AssetByIconName type annotation provides
   // the same compile-time exhaustiveness check without the cross-package import.
+  // React icons/index.ts uses the same package name from package.json instead.
   const lines: string[] = [
     `// /////////////////////////////////////////////////////`,
     `// This is a generated file`,
@@ -223,9 +226,23 @@ async function generateReactNativeAssets(svgFiles: string[]): Promise<void> {
   await fs.writeFile(RN_ASSETS_FILE, lines.join('\n'));
 }
 
+/**
+ * Reads the shared package name from package.json.
+ * Preview publish renames the package (e.g. to @metamask-previews/design-system-shared)
+ * before build, so generated cross-package imports must use the current name rather
+ * than a hardcoded @metamask/ scope.
+ *
+ * @returns The current npm package name from package.json.
+ */
+async function getSharedPackageName(): Promise<string> {
+  const raw = await fs.readFile(SHARED_PACKAGE_JSON, 'utf-8');
+  return (JSON.parse(raw) as { name: string }).name;
+}
+
 // ─── Step 4: React — generate TSX components + icons/index.ts ────────────────
 
 async function generateReactIcons(svgFiles: string[]): Promise<void> {
+  const sharedPackageName = await getSharedPackageName();
   // Ensure icons directory exists and clear previous output
   await fs.mkdir(REACT_ICONS_DIR, { recursive: true });
   const existing = await fs.readdir(REACT_ICONS_DIR);
@@ -289,7 +306,7 @@ async function generateReactIcons(svgFiles: string[]): Promise<void> {
     `// This file is auto-generated — do not edit manually`,
     `// Run \`yarn generate:icons\` from the repo root to regenerate`,
     `import type { ComponentType, SVGProps } from 'react';`,
-    `import type { IconName } from '@metamask/design-system-shared';`,
+    `import type { IconName } from '${sharedPackageName}';`,
     ``,
     `export type IconComponentType = ComponentType<SVGProps<SVGSVGElement>>;`,
     ``,

--- a/packages/design-system-shared/scripts/generate-icons.ts
+++ b/packages/design-system-shared/scripts/generate-icons.ts
@@ -282,23 +282,32 @@ async function generateReactIcons(svgFiles: string[]): Promise<void> {
     );
   }
 
-  // Generate icons/index.ts barrel export
+  // Generate icons/index.ts with lazy loaders for per-icon code splitting.
+  // Static imports of all ~291 icons were removed to allow bundlers to tree-shake
+  // unused icons — only icons actually rendered get included in the bundle.
   const indexLines: string[] = [
     `// This file is auto-generated — do not edit manually`,
     `// Run \`yarn generate:icons\` from the repo root to regenerate`,
-    `import type { ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react';`,
+    `import type { ComponentType, SVGProps } from 'react';`,
+    `import type { IconName } from '@metamask/design-system-shared';`,
     ``,
-    ...iconNames.map((name) => `import ${name} from './${name}';`),
+    `export type IconComponentType = ComponentType<SVGProps<SVGSVGElement>>;`,
     ``,
-    `export const Icons = {`,
-    ...iconNames.map((name) => `  ${name},`),
-    `} as const;`,
+    `export type IconLoader = () => Promise<{ default: IconComponentType }>;`,
     ``,
-    `export type IconComponentType = ForwardRefExoticComponent<`,
-    `  SVGProps<SVGSVGElement> & RefAttributes<SVGSVGElement>`,
-    `>;`,
+    `export const iconLoaders = {`,
+    ...iconNames.map((name) => `  ${name}: () => import('./${name}'),`),
+    `} as unknown as Record<IconName, IconLoader>;`,
     ``,
-    `export type IconsType = typeof Icons;`,
+    `/**`,
+    ` * Type guard to check if a string is a valid IconName at runtime.`,
+    ` *`,
+    ` * @param name - The icon name to check.`,
+    ` * @returns True if the name corresponds to a registered icon loader.`,
+    ` */`,
+    `export function isIconName(name: string): name is IconName {`,
+    `  return Object.prototype.hasOwnProperty.call(iconLoaders, name);`,
+    `}`,
     ``,
   ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Addresses the critical Icon bundle bloat identified in the design-system-react performance review. Previously, the `Icon` component statically imported all ~291 SVG icon components through a single `Icons` registry, pulling ~9.3 MB of icons into any bundle that imported `Icon` (including via `ButtonBase`, `Checkbox`, `Tag`, etc.).

This change replaces the static registry with a dynamic `iconLoaders` map that uses `import()` per icon. The `Icon` component now resolves icons via `React.lazy` + `Suspense`, enabling bundlers to code-split icons so only icons actually rendered are included in consumer bundles.

**Key changes:**
- `generate-icons.ts` now emits `iconLoaders` with dynamic `import()` instead of static imports
- New `Icon.registry.ts` provides cached `getLazyIcon()` and exported `preloadIcon()` for warming commonly used icons
- `Icon.tsx` wraps rendering in `Suspense` with a `null` fallback (no layout shift for inline icons)
- Tests preload icon modules in `jest.setup.ts` via `preloadIconsForTests()`, caching synchronous components for reliable DOM queries under CI parallel workers

**Consumer impact:** Apps like metamask-extension that use ~130 of ~291 icons should see significant bundle savings once they pick up this release, since unused icons are no longer pulled in through the `Button → ButtonBase → Icon` import chain.

## **Related issues**

Fixes: Performance review — Icon bundle bloat (~9.3 MB of ~15 MB total)

## **Manual testing steps**

1. Build the package: `yarn workspace @metamask/design-system-react build`
2. Verify `dist/components/Icon/icons/index.mjs` uses dynamic `import()` instead of static imports
3. Run tests: `yarn workspace @metamask/design-system-react test`
4. In Storybook, verify icons render correctly across Button, Checkbox, Tag, and Icon stories
5. Optionally use `preloadIcon(IconName.Close)` before navigation to warm commonly used icons

## **Screenshots/Recordings**

### **Before**

- `Icon.tsx` imported `./icons` which statically imported all ~291 icon components
- Any import chain reaching `Icon` bundled the full icon set

<img width="759" height="844" alt="Screenshot 2026-06-26 at 10 08 46 AM" src="https://github.com/user-attachments/assets/3267f4d2-210f-4a14-9b34-87f9d40f0db8" />

Loading icons is instant

https://github.com/user-attachments/assets/335f499b-0b61-4509-b97e-6ea95920c273

### **After**

- `Icon.tsx` uses `React.lazy` with per-icon dynamic imports
- Bundlers can tree-shake / code-split unused icons

<img width="1115" height="678" alt="Screenshot 2026-06-26 at 10 20 10 AM" src="https://github.com/user-attachments/assets/d73bc2db-9172-4772-9bb9-33ce8e6c5c0a" />

Loading icons is lazy this is likely a blocker for this approach

https://github.com/user-attachments/assets/05779cb3-50bc-4589-8f7d-9f3175f11c5a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92cb01f1-81cf-4d1b-86a6-330ddaab7f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92cb01f1-81cf-4d1b-86a6-330ddaab7f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

