### PR TITLE
chore: polish tag neutral variant

### DIFF
--- a/packages/design-system-react-native/src/components/Tag/Tag.constants.ts
+++ b/packages/design-system-react-native/src/components/Tag/Tag.constants.ts
@@ -17,7 +17,7 @@ export const MAP_TAG_SEVERITY_BACKGROUND: Record<
 };
 
 export const MAP_TAG_SEVERITY_TEXT_COLOR: Record<TagSeverity, TextColor> = {
-  [TagSeverity.Neutral]: TextColor.TextDefault,
+  [TagSeverity.Neutral]: TextColor.TextAlternative,
   [TagSeverity.Success]: TextColor.SuccessDefault,
   [TagSeverity.Danger]: TextColor.ErrorDefault,
   [TagSeverity.Warning]: TextColor.WarningDefault,
@@ -25,7 +25,7 @@ export const MAP_TAG_SEVERITY_TEXT_COLOR: Record<TagSeverity, TextColor> = {
 };
 
 export const MAP_TAG_SEVERITY_ICON_COLOR: Record<TagSeverity, IconColor> = {
-  [TagSeverity.Neutral]: IconColor.IconDefault,
+  [TagSeverity.Neutral]: IconColor.IconAlternative,
   [TagSeverity.Success]: IconColor.SuccessDefault,
   [TagSeverity.Danger]: IconColor.ErrorDefault,
   [TagSeverity.Warning]: IconColor.WarningDefault,

--- a/packages/design-system-react-native/src/components/Tag/Tag.stories.tsx
+++ b/packages/design-system-react-native/src/components/Tag/Tag.stories.tsx
@@ -74,7 +74,7 @@ export const StartAccessory: Story = {
         <Icon
           name={IconName.Warning}
           size={IconSize.Xs}
-          color={IconColor.IconDefault}
+          color={IconColor.IconAlternative}
           testID="tag-story-start-accessory"
         />
       }
@@ -91,7 +91,7 @@ export const EndAccessory: Story = {
         <Icon
           name={IconName.ArrowDown}
           size={IconSize.Xs}
-          color={IconColor.IconDefault}
+          color={IconColor.IconAlternative}
           testID="tag-story-end-accessory"
         />
       }

--- a/packages/design-system-react/src/components/Tag/Tag.constants.ts
+++ b/packages/design-system-react/src/components/Tag/Tag.constants.ts
@@ -17,7 +17,7 @@ export const MAP_TAG_SEVERITY_BACKGROUND: Record<
 };
 
 export const MAP_TAG_SEVERITY_TEXT_COLOR: Record<TagSeverity, TextColor> = {
-  [TagSeverity.Neutral]: TextColor.TextDefault,
+  [TagSeverity.Neutral]: TextColor.TextAlternative,
   [TagSeverity.Success]: TextColor.SuccessDefault,
   [TagSeverity.Danger]: TextColor.ErrorDefault,
   [TagSeverity.Warning]: TextColor.WarningDefault,
@@ -25,7 +25,7 @@ export const MAP_TAG_SEVERITY_TEXT_COLOR: Record<TagSeverity, TextColor> = {
 };
 
 export const MAP_TAG_SEVERITY_ICON_COLOR: Record<TagSeverity, IconColor> = {
-  [TagSeverity.Neutral]: IconColor.IconDefault,
+  [TagSeverity.Neutral]: IconColor.IconAlternative,
   [TagSeverity.Success]: IconColor.SuccessDefault,
   [TagSeverity.Danger]: IconColor.ErrorDefault,
   [TagSeverity.Warning]: IconColor.WarningDefault,

--- a/packages/design-system-react/src/components/Tag/Tag.stories.tsx
+++ b/packages/design-system-react/src/components/Tag/Tag.stories.tsx
@@ -1,5 +1,6 @@
 import {
   IconName,
+  IconColor,
   IconSize,
   TagSeverity,
 } from '@metamask/design-system-shared';
@@ -80,6 +81,7 @@ export const StartAccessory: Story = {
       startAccessory={
         <Icon
           name={IconName.Warning}
+          color={IconColor.IconAlternative}
           size={IconSize.Xs}
           data-testid="tag-story-start-accessory"
           aria-hidden
@@ -97,6 +99,7 @@ export const EndAccessory: Story = {
       endAccessory={
         <Icon
           name={IconName.ArrowDown}
+          color={IconColor.IconAlternative}
           size={IconSize.Xs}
           data-testid="tag-story-end-accessory"
           aria-hidden

--- a/packages/design-system-react/src/components/Tag/Tag.test.tsx
+++ b/packages/design-system-react/src/components/Tag/Tag.test.tsx
@@ -2,8 +2,6 @@ import { IconName, TagSeverity } from '@metamask/design-system-shared';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { TextColor } from '../Text';
-
 import { Tag } from './Tag';
 import {
   MAP_TAG_SEVERITY_BACKGROUND,
@@ -29,7 +27,7 @@ describe('Tag', () => {
     expect(screen.getByText('From string')).toBeInTheDocument();
     expect(tag.querySelector('p')).toHaveClass(
       'text-s-body-xs',
-      TextColor.TextDefault,
+      MAP_TAG_SEVERITY_TEXT_COLOR[TagSeverity.Neutral],
     );
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates default icon and text color for `neutral` to `alternative`

## **Related issues**

Fixes:

## **Manual testing steps**

Test that colors match

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/a71a860b-755d-4121-b3f1-75e3d439d4ac



https://github.com/user-attachments/assets/27aed98b-ba3e-4000-be09-baabb337a12a



### **After**

https://github.com/user-attachments/assets/e43daf63-72c0-4007-b2ac-97eccd32a0aa


https://github.com/user-attachments/assets/4c5c1320-daef-437c-9ae9-ac4eed374801




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual token swap on a design-system component only; no logic, API, or security impact beyond slightly different neutral tag appearance in consuming apps.
> 
> **Overview**
> **Neutral** `Tag` severity now uses **alternative** design tokens for label text and icons instead of **default**, in both `@metamask/design-system-react` and `@metamask/design-system-react-native` (`MAP_TAG_SEVERITY_TEXT_COLOR` / `MAP_TAG_SEVERITY_ICON_COLOR`).
> 
> Storybook accessory examples set explicit `IconColor.IconAlternative` where needed. The React unit test for string children asserts against the neutral severity map entry instead of hard-coding `TextColor.TextDefault`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4628e4902df5a7780ab83ec17a13d8459798517c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->