### PR TITLE
prototype: Refine bottom sheet animation

### DIFF
--- a/packages/design-system-react-native/src/components/BottomSheet/BottomSheet.test.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheet/BottomSheet.test.tsx
@@ -16,6 +16,31 @@ let capturedDialogOnClose: ((hasPendingAction?: boolean) => void) | undefined;
 let capturedDialogOnOpen: ((hasPendingAction?: boolean) => void) | undefined;
 const mockCloseDialog = jest.fn();
 const mockOpenDialog = jest.fn();
+const mockOverlayFadeOut = jest.fn();
+const mockOverlayFadeIn = jest.fn();
+
+jest.mock('../BottomSheetOverlay/BottomSheetOverlay', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { forwardRef, useImperativeHandle } = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { TouchableOpacity } = require('react-native');
+  return {
+    BottomSheetOverlay: forwardRef(
+      (
+        { onPress }: { onPress?: () => void },
+        ref: unknown,
+      ) => {
+        useImperativeHandle(ref, () => ({
+          fadeIn: mockOverlayFadeIn,
+          fadeOut: mockOverlayFadeOut,
+        }));
+        return onPress ? (
+          <TouchableOpacity onPress={onPress} testID="overlay-touchable" />
+        ) : null;
+      },
+    ),
+  };
+});
 
 jest.mock('../BottomSheetDialog', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -27,10 +52,12 @@ jest.mock('../BottomSheetDialog', () => {
           children,
           onClose,
           onOpen,
+          onDismissStart,
         }: {
           children?: unknown;
           onClose?: (hasPendingAction?: boolean) => void;
           onOpen?: (hasPendingAction?: boolean) => void;
+          onDismissStart?: () => void;
         },
         ref: unknown,
       ) => {
@@ -38,6 +65,7 @@ jest.mock('../BottomSheetDialog', () => {
         capturedDialogOnOpen = onOpen;
         useImperativeHandle(ref, () => ({
           onCloseDialog: (callback?: () => void) => {
+            onDismissStart?.();
             mockCloseDialog();
             onClose?.();
             callback?.();
@@ -60,9 +88,10 @@ describe('BottomSheet', () => {
   beforeEach(() => {
     mockCloseDialog.mockClear();
     mockOpenDialog.mockClear();
+    mockOverlayFadeOut.mockClear();
+    mockOverlayFadeIn.mockClear();
     capturedDialogOnClose = undefined;
     capturedDialogOnOpen = undefined;
-    capturedPanGestureHandlerProps = undefined;
   });
 
   it('renders with testID on root element', () => {
@@ -202,6 +231,18 @@ describe('BottomSheet', () => {
       fireEvent.press(UNSAFE_getAllByType(TouchableOpacity)[0]);
 
       expect(mockCloseDialog).toHaveBeenCalledTimes(1);
+    });
+
+    it('fades out overlay when dismiss starts', () => {
+      const { getByTestId } = render(
+        <BottomSheet goBack={noop} isInteractable>
+          <View />
+        </BottomSheet>,
+      );
+
+      fireEvent.press(getByTestId('overlay-touchable'));
+
+      expect(mockOverlayFadeOut).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/design-system-react-native/src/components/BottomSheet/BottomSheet.test.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheet/BottomSheet.test.tsx
@@ -23,19 +23,16 @@ jest.mock('../BottomSheetOverlay/BottomSheetOverlay', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { forwardRef, useImperativeHandle } = require('react');
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { TouchableOpacity } = require('react-native');
+  const { TouchableOpacity: MockTouchableOpacity } = require('react-native');
   return {
     BottomSheetOverlay: forwardRef(
-      (
-        { onPress }: { onPress?: () => void },
-        ref: unknown,
-      ) => {
+      ({ onPress }: { onPress?: () => void }, ref: unknown) => {
         useImperativeHandle(ref, () => ({
           fadeIn: mockOverlayFadeIn,
           fadeOut: mockOverlayFadeOut,
         }));
         return onPress ? (
-          <TouchableOpacity onPress={onPress} testID="overlay-touchable" />
+          <MockTouchableOpacity onPress={onPress} testID="overlay-touchable" />
         ) : null;
       },
     ),

--- a/packages/design-system-react-native/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheet/BottomSheet.tsx
@@ -15,6 +15,7 @@ import {
 import { BottomSheetDialog } from '../BottomSheetDialog';
 import type { BottomSheetDialogRef } from '../BottomSheetDialog';
 import { BottomSheetOverlay } from '../BottomSheetOverlay/BottomSheetOverlay';
+import type { BottomSheetOverlayRef } from '../BottomSheetOverlay/BottomSheetOverlay.types';
 
 import type {
   BottomSheetPostCallback,
@@ -43,6 +44,7 @@ export const BottomSheet = forwardRef<BottomSheetRef, BottomSheetProps>(
     const { y: frameY } = useSafeAreaFrame();
     const postCallback = useRef<BottomSheetPostCallback | undefined>(undefined);
     const bottomSheetDialogRef = useRef<BottomSheetDialogRef>(null);
+    const bottomSheetOverlayRef = useRef<BottomSheetOverlayRef>(null);
     const didNavigateBackRef = useRef(false);
     const closeRequestedRef = useRef(false);
     const didRunPostCallbackRef = useRef(false);
@@ -77,6 +79,14 @@ export const BottomSheet = forwardRef<BottomSheetRef, BottomSheetProps>(
       }
     }, [goBack, onClose]);
 
+    const onDismissStart = useCallback(() => {
+      bottomSheetOverlayRef.current?.fadeOut();
+    }, []);
+
+    const dismissSheet = useCallback((callback?: () => void) => {
+      bottomSheetDialogRef.current?.onCloseDialog(callback);
+    }, []);
+
     // Dismiss the sheet when Android back button is pressed.
     useEffect(() => {
       if (Platform.OS !== 'android') {
@@ -85,7 +95,7 @@ export const BottomSheet = forwardRef<BottomSheetRef, BottomSheetProps>(
 
       const hardwareBackPress = () => {
         if (isInteractable) {
-          bottomSheetDialogRef.current?.onCloseDialog();
+          dismissSheet();
         }
         return true;
       };
@@ -96,7 +106,7 @@ export const BottomSheet = forwardRef<BottomSheetRef, BottomSheetProps>(
       return () => {
         subscription.remove();
       };
-    }, [isInteractable]);
+    }, [dismissSheet, isInteractable]);
 
     useImperativeHandle(ref, () => ({
       onCloseBottomSheet: (callback) => {
@@ -105,7 +115,7 @@ export const BottomSheet = forwardRef<BottomSheetRef, BottomSheetProps>(
         }
         closeRequestedRef.current = true;
         postCallback.current = callback;
-        bottomSheetDialogRef.current?.onCloseDialog();
+        dismissSheet();
       },
       onOpenBottomSheet: (callback) => {
         didNavigateBackRef.current = false;
@@ -127,14 +137,12 @@ export const BottomSheet = forwardRef<BottomSheetRef, BottomSheetProps>(
         {...props}
       >
         <BottomSheetOverlay
-          onPress={
-            isInteractable
-              ? () => bottomSheetDialogRef.current?.onCloseDialog()
-              : undefined
-          }
+          ref={bottomSheetOverlayRef}
+          onPress={isInteractable ? () => dismissSheet() : undefined}
         />
         <BottomSheetDialog
           isInteractable={isInteractable}
+          onDismissStart={onDismissStart}
           onClose={onCloseCB}
           onOpen={onOpenCB}
           ref={bottomSheetDialogRef}

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.constants.ts
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.constants.ts
@@ -1,17 +1,21 @@
 import { AnimationDuration } from '@metamask/design-tokens';
+import type { WithSpringConfig } from 'react-native-reanimated';
 
-// Defaults
+/** iOS-like sheet spring: natural deceleration with minimal overshoot on open. */
+export const DEFAULT_BOTTOMSHEETDIALOG_SPRING_CONFIG = {
+  damping: 28,
+  stiffness: 320,
+  mass: 0.9,
+  overshootClamping: true,
+} satisfies WithSpringConfig;
+
 /**
- * The animation duration used for initial render.
+ * Minimum swipe velocity (px/s) to treat the gesture as a fling for snap/dismiss.
  */
-export const DEFAULT_BOTTOMSHEETDIALOG_DISPLAY_DURATION =
-  AnimationDuration.Fast;
-/**
- * This number represents the swipe speed to meet the velocity threshold.
- */
-export const DEFAULT_BOTTOMSHEETDIALOG_SWIPETHRESHOLD_DURATION =
+export const DEFAULT_BOTTOMSHEETDIALOG_SWIPETHRESHOLD_VELOCITY =
   AnimationDuration.Regularly;
+
 /**
- * This indicates that 60% of the sheet needs to be offscreen to meet the distance threshold.
+ * Fraction of sheet height dragged down before dismiss without a fling.
  */
 export const DEFAULT_BOTTOMSHEETDIALOG_DISMISSTHRESHOLD = 0.6;

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.constants.ts
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.constants.ts
@@ -7,7 +7,18 @@ export const DEFAULT_BOTTOMSHEETDIALOG_SPRING_CONFIG = {
   stiffness: 320,
   mass: 0.9,
   overshootClamping: true,
-} satisfies WithSpringConfig;
+} as const satisfies WithSpringConfig;
+
+type BottomSheetDialogSpringOverrides = Partial<
+  Pick<WithSpringConfig, 'velocity' | 'reduceMotion' | 'energyThreshold'>
+>;
+
+export const getBottomSheetDialogSpringConfig = (
+  overrides?: BottomSheetDialogSpringOverrides,
+): WithSpringConfig => ({
+  ...DEFAULT_BOTTOMSHEETDIALOG_SPRING_CONFIG,
+  ...overrides,
+});
 
 /**
  * Minimum swipe velocity (px/s) to treat the gesture as a fling for snap/dismiss.

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.test.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.test.tsx
@@ -12,6 +12,19 @@ import type { BottomSheetDialogRef } from './BottomSheetDialog.types';
 
 const mockThemeRef = { current: 'light' };
 
+type PanGestureEvent = {
+  translationY: number;
+  velocityY: number;
+};
+
+type CapturedPanGestureCallbacks = {
+  onStart?: () => void;
+  onUpdate?: (event: PanGestureEvent) => void;
+  onEnd?: (event: PanGestureEvent) => void;
+};
+
+const capturedPanGestureCallbacks: CapturedPanGestureCallbacks = {};
+
 jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: ({ children }: { children: React.ReactNode }) => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -21,11 +34,15 @@ jest.mock('react-native-gesture-handler', () => ({
   Gesture: {
     Pan: () => {
       const gesture: Record<string, unknown> = {};
-      const noop = () => gesture;
-      gesture.enabled = noop;
-      gesture.onStart = noop;
-      gesture.onUpdate = noop;
-      gesture.onEnd = noop;
+      const capture =
+        (key: keyof CapturedPanGestureCallbacks) => (callback: unknown) => {
+          capturedPanGestureCallbacks[key] = callback as never;
+          return gesture;
+        };
+      gesture.enabled = () => gesture;
+      gesture.onStart = capture('onStart');
+      gesture.onUpdate = capture('onUpdate');
+      gesture.onEnd = capture('onEnd');
       return gesture;
     },
   },
@@ -51,7 +68,42 @@ jest.mock('react-native-reanimated', () => {
   return Reanimated;
 });
 
+const SHEET_HEIGHT = 400;
+
+const findLayoutNode = (
+  current: { props: { onLayout?: unknown }; parent: unknown } | null,
+): typeof current => {
+  if (!current) {
+    return null;
+  }
+  if (current.props.onLayout) {
+    return current;
+  }
+  return findLayoutNode(current.parent as typeof current);
+};
+
+const triggerSheetLayout = (
+  getByText: (text: string) => { parent: unknown },
+  height = SHEET_HEIGHT,
+) => {
+  const content = getByText('Layout Content');
+  const layoutNode = findLayoutNode(content.parent as never);
+  expect(layoutNode).toBeDefined();
+  if (layoutNode) {
+    act(() => {
+      fireEvent(layoutNode, 'layout', {
+        nativeEvent: { layout: { height, width: 300, x: 0, y: 0 } },
+      });
+    });
+  }
+};
+
 describe('BottomSheetDialog', () => {
+  beforeEach(() => {
+    capturedPanGestureCallbacks.onStart = undefined;
+    capturedPanGestureCallbacks.onUpdate = undefined;
+    capturedPanGestureCallbacks.onEnd = undefined;
+  });
   it('renders correctly with children', () => {
     const { getByText } = render(
       <BottomSheetDialog>
@@ -371,5 +423,125 @@ describe('BottomSheetDialog', () => {
     );
     expect(getByText('Android Content')).toBeDefined();
     Platform.OS = originalOS;
+  });
+
+  it('calls onDismissStart when onCloseDialog ref is called', () => {
+    const onDismissStartMock = jest.fn();
+    const TestComponent = () => {
+      const ref = useRef<BottomSheetDialogRef>(null);
+
+      useEffect(() => {
+        if (ref.current) {
+          act(() => {
+            ref.current?.onCloseDialog();
+          });
+        }
+      }, []);
+
+      return (
+        <BottomSheetDialog ref={ref} onDismissStart={onDismissStartMock}>
+          <Text>Test Child</Text>
+        </BottomSheetDialog>
+      );
+    };
+
+    render(<TestComponent />);
+
+    expect(onDismissStartMock).toHaveBeenCalledTimes(1);
+  });
+
+  describe('pan gesture handler', () => {
+    const renderGestureSheet = (props?: {
+      onClose?: () => void;
+      onDismissStart?: () => void;
+    }) => {
+      const result = render(
+        <BottomSheetDialog {...props}>
+          <Text>Layout Content</Text>
+        </BottomSheetDialog>,
+      );
+      triggerSheetLayout(result.getByText);
+      return result;
+    };
+
+    it('tracks gesture start offset on pan start', () => {
+      renderGestureSheet();
+
+      act(() => {
+        capturedPanGestureCallbacks.onStart?.();
+      });
+
+      expect(capturedPanGestureCallbacks.onStart).toBeDefined();
+    });
+
+    it('updates offset during pan and clamps below sheet bottom', () => {
+      renderGestureSheet();
+
+      act(() => {
+        capturedPanGestureCallbacks.onStart?.();
+        capturedPanGestureCallbacks.onUpdate?.({ translationY: 500, velocityY: 0 });
+      });
+
+      expect(capturedPanGestureCallbacks.onUpdate).toBeDefined();
+    });
+
+    it('clamps offset above sheet top during pan update', () => {
+      renderGestureSheet();
+
+      act(() => {
+        capturedPanGestureCallbacks.onStart?.();
+        capturedPanGestureCallbacks.onUpdate?.({ translationY: -50, velocityY: 0 });
+      });
+
+      expect(capturedPanGestureCallbacks.onUpdate).toBeDefined();
+    });
+
+    it('dismisses on quick downward swipe', () => {
+      const onCloseMock = jest.fn();
+      renderGestureSheet({ onClose: onCloseMock });
+
+      act(() => {
+        capturedPanGestureCallbacks.onStart?.();
+        capturedPanGestureCallbacks.onEnd?.({ translationY: 50, velocityY: 500 });
+      });
+
+      expect(onCloseMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('snaps back open on quick upward swipe', () => {
+      const onCloseMock = jest.fn();
+      renderGestureSheet({ onClose: onCloseMock });
+
+      act(() => {
+        capturedPanGestureCallbacks.onStart?.();
+        capturedPanGestureCallbacks.onEnd?.({ translationY: -50, velocityY: -500 });
+      });
+
+      expect(onCloseMock).not.toHaveBeenCalled();
+    });
+
+    it('dismisses when drag exceeds dismiss offset threshold', () => {
+      const onCloseMock = jest.fn();
+      renderGestureSheet({ onClose: onCloseMock });
+
+      act(() => {
+        capturedPanGestureCallbacks.onStart?.();
+        capturedPanGestureCallbacks.onEnd?.({ translationY: 300, velocityY: 0 });
+      });
+
+      expect(onCloseMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('snaps back when drag is below dismiss offset threshold', () => {
+      const onCloseMock = jest.fn();
+      renderGestureSheet({ onClose: onCloseMock });
+
+      act(() => {
+        capturedPanGestureCallbacks.onStart?.();
+        capturedPanGestureCallbacks.onEnd?.({ translationY: 50, velocityY: 0 });
+      });
+
+      expect(onCloseMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.test.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.test.tsx
@@ -303,28 +303,7 @@ describe('BottomSheetDialog', () => {
       </BottomSheetDialog>,
     );
 
-    // Find the Animated.View parent that has onLayout
-    const content = getByText('Layout Content');
-    const findLayoutNode = (
-      current: typeof content | null,
-    ): typeof content | null => {
-      if (!current) {
-        return null;
-      }
-      if (current.props.onLayout) {
-        return current;
-      }
-      return findLayoutNode(current.parent);
-    };
-    const layoutNode = findLayoutNode(content.parent);
-    expect(layoutNode).toBeDefined();
-    if (layoutNode) {
-      act(() => {
-        fireEvent(layoutNode, 'layout', {
-          nativeEvent: { layout: { height: 400, width: 300, x: 0, y: 0 } },
-        });
-      });
-    }
+    triggerSheetLayout(getByText);
 
     expect(onOpenMock).toHaveBeenCalled();
   });
@@ -338,18 +317,7 @@ describe('BottomSheetDialog', () => {
     );
 
     const content = getByText('Layout Content');
-    const findLayoutNode = (
-      current: typeof content | null,
-    ): typeof content | null => {
-      if (!current) {
-        return null;
-      }
-      if (current.props.onLayout) {
-        return current;
-      }
-      return findLayoutNode(current.parent);
-    };
-    const layoutNode = findLayoutNode(content.parent);
+    const layoutNode = findLayoutNode(content.parent as never);
     expect(layoutNode).toBeDefined();
     if (layoutNode) {
       act(() => {
@@ -479,7 +447,10 @@ describe('BottomSheetDialog', () => {
 
       act(() => {
         capturedPanGestureCallbacks.onStart?.();
-        capturedPanGestureCallbacks.onUpdate?.({ translationY: 500, velocityY: 0 });
+        capturedPanGestureCallbacks.onUpdate?.({
+          translationY: 500,
+          velocityY: 0,
+        });
       });
 
       expect(capturedPanGestureCallbacks.onUpdate).toBeDefined();
@@ -490,7 +461,10 @@ describe('BottomSheetDialog', () => {
 
       act(() => {
         capturedPanGestureCallbacks.onStart?.();
-        capturedPanGestureCallbacks.onUpdate?.({ translationY: -50, velocityY: 0 });
+        capturedPanGestureCallbacks.onUpdate?.({
+          translationY: -50,
+          velocityY: 0,
+        });
       });
 
       expect(capturedPanGestureCallbacks.onUpdate).toBeDefined();
@@ -502,7 +476,10 @@ describe('BottomSheetDialog', () => {
 
       act(() => {
         capturedPanGestureCallbacks.onStart?.();
-        capturedPanGestureCallbacks.onEnd?.({ translationY: 50, velocityY: 500 });
+        capturedPanGestureCallbacks.onEnd?.({
+          translationY: 50,
+          velocityY: 500,
+        });
       });
 
       expect(onCloseMock).toHaveBeenCalledTimes(1);
@@ -514,7 +491,10 @@ describe('BottomSheetDialog', () => {
 
       act(() => {
         capturedPanGestureCallbacks.onStart?.();
-        capturedPanGestureCallbacks.onEnd?.({ translationY: -50, velocityY: -500 });
+        capturedPanGestureCallbacks.onEnd?.({
+          translationY: -50,
+          velocityY: -500,
+        });
       });
 
       expect(onCloseMock).not.toHaveBeenCalled();
@@ -526,7 +506,10 @@ describe('BottomSheetDialog', () => {
 
       act(() => {
         capturedPanGestureCallbacks.onStart?.();
-        capturedPanGestureCallbacks.onEnd?.({ translationY: 300, velocityY: 0 });
+        capturedPanGestureCallbacks.onEnd?.({
+          translationY: 300,
+          velocityY: 0,
+        });
       });
 
       expect(onCloseMock).toHaveBeenCalledTimes(1);

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.tsx
@@ -24,7 +24,8 @@ import Animated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
-  withTiming,
+  withSpring,
+  type WithSpringConfig,
 } from 'react-native-reanimated';
 import {
   useSafeAreaFrame,
@@ -33,9 +34,9 @@ import {
 
 // Internal dependencies.
 import {
-  DEFAULT_BOTTOMSHEETDIALOG_DISPLAY_DURATION,
   DEFAULT_BOTTOMSHEETDIALOG_DISMISSTHRESHOLD,
-  DEFAULT_BOTTOMSHEETDIALOG_SWIPETHRESHOLD_DURATION,
+  DEFAULT_BOTTOMSHEETDIALOG_SPRING_CONFIG,
+  DEFAULT_BOTTOMSHEETDIALOG_SWIPETHRESHOLD_VELOCITY,
 } from './BottomSheetDialog.constants';
 import type {
   BottomSheetDialogRef,
@@ -52,6 +53,7 @@ export const BottomSheetDialog = forwardRef<
       isFullscreen = false,
       isInteractable = true,
       keyboardAvoidingViewEnabled = true,
+      onDismissStart,
       onClose,
       onOpen,
       style,
@@ -87,21 +89,34 @@ export const BottomSheetDialog = forwardRef<
       onClose?.();
     }, [onClose]);
 
+    const animateSheetTo = (
+      target: number,
+      config?: WithSpringConfig,
+      onComplete?: () => void,
+    ) => {
+      currentYOffset.value = withSpring(
+        target,
+        { ...DEFAULT_BOTTOMSHEETDIALOG_SPRING_CONFIG, ...config },
+        (finished) => {
+          if (finished && onComplete) {
+            runOnJS(onComplete)();
+          }
+        },
+      );
+    };
+
     const onCloseDialog = useCallback(
       (callback?: () => void) => {
-        currentYOffset.value = withTiming(
-          bottomOfDialogYValue.value,
-          { duration: DEFAULT_BOTTOMSHEETDIALOG_DISPLAY_DURATION },
-          () => {
-            runOnJS(onCloseCB)();
-            if (callback) {
-              runOnJS(callback)();
-            }
-          },
-        );
+        onDismissStart?.();
+        animateSheetTo(bottomOfDialogYValue.value, undefined, () => {
+          onCloseCB();
+          if (callback) {
+            callback();
+          }
+        });
         // Ref values do not affect deps.
       },
-      [onCloseCB],
+      [onCloseCB, onDismissStart],
     );
 
     const gestureHandler = useMemo(() => {
@@ -155,7 +170,7 @@ export const BottomSheetDialog = forwardRef<
           // Check if the gesture's vertical speed has reached the threshold to determine a swipe action
           const hasReachedSwipeThreshold =
             Math.abs(velocityY) >
-            DEFAULT_BOTTOMSHEETDIALOG_SWIPETHRESHOLD_DURATION;
+            DEFAULT_BOTTOMSHEETDIALOG_SWIPETHRESHOLD_VELOCITY;
           const isQuickDismissing = velocityY > 0;
 
           // If user is swiping
@@ -177,9 +192,9 @@ export const BottomSheetDialog = forwardRef<
           if (isDismissed) {
             runOnJS(onCloseDialog)();
           } else {
-            // Only animate dialog to a certain Y position instead
-            currentYOffset.value = withTiming(finalYOffset, {
-              duration: DEFAULT_BOTTOMSHEETDIALOG_DISPLAY_DURATION,
+            currentYOffset.value = withSpring(finalYOffset, {
+              ...DEFAULT_BOTTOMSHEETDIALOG_SPRING_CONFIG,
+              velocity: velocityY,
             });
           }
         });
@@ -196,21 +211,13 @@ export const BottomSheetDialog = forwardRef<
 
     // Animate in sheet on initial render.
     const onOpenDialog = (callback?: () => void) => {
-      // Starts setting the Y position of the dialog to the bottom of the dialog
       currentYOffset.value = bottomOfDialogYValue.value;
-      // Animate the Y position to the top of the dialog, then call onOpenCB
-      currentYOffset.value = withTiming(
-        topOfDialogYValue.value,
-        {
-          duration: DEFAULT_BOTTOMSHEETDIALOG_DISPLAY_DURATION,
-        },
-        () => {
-          runOnJS(onOpenCB)();
-          if (callback) {
-            runOnJS(callback)();
-          }
-        },
-      );
+      animateSheetTo(topOfDialogYValue.value, undefined, () => {
+        onOpenCB();
+        if (callback) {
+          callback();
+        }
+      });
     };
 
     const onDebouncedCloseDialog = useMemo(

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.tsx
@@ -25,7 +25,6 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
-  type WithSpringConfig,
 } from 'react-native-reanimated';
 import {
   useSafeAreaFrame,
@@ -35,8 +34,8 @@ import {
 // Internal dependencies.
 import {
   DEFAULT_BOTTOMSHEETDIALOG_DISMISSTHRESHOLD,
-  DEFAULT_BOTTOMSHEETDIALOG_SPRING_CONFIG,
   DEFAULT_BOTTOMSHEETDIALOG_SWIPETHRESHOLD_VELOCITY,
+  getBottomSheetDialogSpringConfig,
 } from './BottomSheetDialog.constants';
 import type {
   BottomSheetDialogRef,
@@ -89,14 +88,10 @@ export const BottomSheetDialog = forwardRef<
       onClose?.();
     }, [onClose]);
 
-    const animateSheetTo = (
-      target: number,
-      config?: WithSpringConfig,
-      onComplete?: () => void,
-    ) => {
+    const animateSheetTo = (target: number, onComplete?: () => void) => {
       currentYOffset.value = withSpring(
         target,
-        { ...DEFAULT_BOTTOMSHEETDIALOG_SPRING_CONFIG, ...config },
+        getBottomSheetDialogSpringConfig(),
         (finished) => {
           if (finished && onComplete) {
             runOnJS(onComplete)();
@@ -108,7 +103,7 @@ export const BottomSheetDialog = forwardRef<
     const onCloseDialog = useCallback(
       (callback?: () => void) => {
         onDismissStart?.();
-        animateSheetTo(bottomOfDialogYValue.value, undefined, () => {
+        animateSheetTo(bottomOfDialogYValue.value, () => {
           onCloseCB();
           if (callback) {
             callback();
@@ -192,10 +187,10 @@ export const BottomSheetDialog = forwardRef<
           if (isDismissed) {
             runOnJS(onCloseDialog)();
           } else {
-            currentYOffset.value = withSpring(finalYOffset, {
-              ...DEFAULT_BOTTOMSHEETDIALOG_SPRING_CONFIG,
-              velocity: velocityY,
-            });
+            currentYOffset.value = withSpring(
+              finalYOffset,
+              getBottomSheetDialogSpringConfig({ velocity: velocityY }),
+            );
           }
         });
 
@@ -212,7 +207,7 @@ export const BottomSheetDialog = forwardRef<
     // Animate in sheet on initial render.
     const onOpenDialog = (callback?: () => void) => {
       currentYOffset.value = bottomOfDialogYValue.value;
-      animateSheetTo(topOfDialogYValue.value, undefined, () => {
+      animateSheetTo(topOfDialogYValue.value, () => {
         onOpenCB();
         if (callback) {
           callback();

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.types.ts
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.types.ts
@@ -30,6 +30,10 @@ export type BottomSheetDialogProps = {
    */
   keyboardAvoidingViewEnabled?: boolean;
   /**
+   * Optional callback invoked when the sheet begins closing (before animation).
+   */
+  onDismissStart?: () => void;
+  /**
    * Optional callback that gets triggered when the sheet is closed.
    */
   onClose?: (hasPendingAction?: boolean) => void;

--- a/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.constants.ts
+++ b/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.constants.ts
@@ -1,4 +1,7 @@
 import { AnimationDuration } from '@metamask/design-tokens';
+import { Easing } from 'react-native';
 
-// Defaults
-export const DEFAULT_OVERLAY_ANIMATION_DURATION = AnimationDuration.Fast;
+/** Matches UIKit `curveEaseInOut` for a native modal scrim fade-in. */
+export const DEFAULT_OVERLAY_ANIMATION_EASING = Easing.bezier(0.42, 0, 0.58, 1);
+
+export const DEFAULT_OVERLAY_ANIMATION_DURATION = AnimationDuration.Regularly;

--- a/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.test.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.test.tsx
@@ -1,12 +1,14 @@
-import { render, fireEvent } from '@testing-library/react-native';
-import React from 'react';
+import { act, render, fireEvent } from '@testing-library/react-native';
+import React, { useEffect, useRef } from 'react';
+import { Animated } from 'react-native';
 
 import { BottomSheetOverlay } from './BottomSheetOverlay';
+import type { BottomSheetOverlayRef } from './BottomSheetOverlay.types';
 
 describe('BottomSheetOverlay', () => {
   it('renders correctly', () => {
     const { getByTestId } = render(<BottomSheetOverlay testID="overlay" />);
-    expect(getByTestId('overlay')).toBeDefined();
+    expect(getByTestId('overlay')).toBeOnTheScreen();
   });
 
   it('calls onPress when pressed', () => {
@@ -21,5 +23,99 @@ describe('BottomSheetOverlay', () => {
 
     fireEvent.press(getByTestId(testID));
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  describe('imperative handle', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('exposes fadeIn and fadeOut via ref', () => {
+      const overlayRef: { current: BottomSheetOverlayRef | null } = {
+        current: null,
+      };
+      const TestComponent = () => {
+        const ref = useRef<BottomSheetOverlayRef>(null);
+        useEffect(() => {
+          overlayRef.current = ref.current;
+        }, []);
+        return <BottomSheetOverlay ref={ref} testID="overlay" />;
+      };
+
+      render(<TestComponent />);
+
+      expect(typeof overlayRef.current?.fadeIn).toBe('function');
+      expect(typeof overlayRef.current?.fadeOut).toBe('function');
+    });
+
+    it('fadeOut animates opacity to zero and invokes callback when finished', () => {
+      const callback = jest.fn();
+      const overlayRef: { current: BottomSheetOverlayRef | null } = {
+        current: null,
+      };
+      jest.spyOn(Animated, 'timing').mockImplementation(
+        () =>
+          ({
+            start: (completionCallback?: (result: { finished: boolean }) => void) => {
+              completionCallback?.({ finished: true });
+            },
+            stop: jest.fn(),
+            reset: jest.fn(),
+          }) as never,
+      );
+
+      const TestComponent = () => {
+        const ref = useRef<BottomSheetOverlayRef>(null);
+        useEffect(() => {
+          overlayRef.current = ref.current;
+        }, []);
+        return <BottomSheetOverlay ref={ref} testID="overlay" />;
+      };
+
+      render(<TestComponent />);
+
+      act(() => {
+        overlayRef.current?.fadeOut(callback);
+      });
+
+      expect(Animated.timing).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ toValue: 0 }),
+      );
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('fadeOut does not invoke callback when animation is interrupted', () => {
+      const callback = jest.fn();
+      const overlayRef: { current: BottomSheetOverlayRef | null } = {
+        current: null,
+      };
+      jest.spyOn(Animated, 'timing').mockImplementation(
+        () =>
+          ({
+            start: (completionCallback?: (result: { finished: boolean }) => void) => {
+              completionCallback?.({ finished: false });
+            },
+            stop: jest.fn(),
+            reset: jest.fn(),
+          }) as never,
+      );
+
+      const TestComponent = () => {
+        const ref = useRef<BottomSheetOverlayRef>(null);
+        useEffect(() => {
+          overlayRef.current = ref.current;
+        }, []);
+        return <BottomSheetOverlay ref={ref} testID="overlay" />;
+      };
+
+      render(<TestComponent />);
+
+      act(() => {
+        overlayRef.current?.fadeOut(callback);
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.test.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.test.tsx
@@ -56,7 +56,9 @@ describe('BottomSheetOverlay', () => {
       jest.spyOn(Animated, 'timing').mockImplementation(
         () =>
           ({
-            start: (completionCallback?: (result: { finished: boolean }) => void) => {
+            start: (
+              completionCallback?: (result: { finished: boolean }) => void,
+            ) => {
               completionCallback?.({ finished: true });
             },
             stop: jest.fn(),
@@ -93,7 +95,9 @@ describe('BottomSheetOverlay', () => {
       jest.spyOn(Animated, 'timing').mockImplementation(
         () =>
           ({
-            start: (completionCallback?: (result: { finished: boolean }) => void) => {
+            start: (
+              completionCallback?: (result: { finished: boolean }) => void,
+            ) => {
               completionCallback?.({ finished: false });
             },
             stop: jest.fn(),

--- a/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.tsx
@@ -1,28 +1,59 @@
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, { useEffect, useRef } from 'react';
-import { Animated, Easing, TouchableOpacity } from 'react-native';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import { Animated, TouchableOpacity } from 'react-native';
 
-import { DEFAULT_OVERLAY_ANIMATION_DURATION } from './BottomSheetOverlay.constants';
-import { BottomSheetOverlayProps } from './BottomSheetOverlay.types';
+import {
+  DEFAULT_OVERLAY_ANIMATION_DURATION,
+  DEFAULT_OVERLAY_ANIMATION_EASING,
+} from './BottomSheetOverlay.constants';
+import type {
+  BottomSheetOverlayProps,
+  BottomSheetOverlayRef,
+} from './BottomSheetOverlay.types';
 
-export const BottomSheetOverlay: React.FC<BottomSheetOverlayProps> = ({
-  style,
-  twClassName,
-  onPress,
-  touchableOpacityProps,
-  ...props
-}) => {
+export const BottomSheetOverlay = forwardRef<
+  BottomSheetOverlayRef,
+  BottomSheetOverlayProps
+>(({ style, twClassName, onPress, touchableOpacityProps, ...props }, ref) => {
   const tw = useTailwind();
   const opacityVal = useRef(new Animated.Value(0)).current;
 
-  useEffect(() => {
+  const fadeIn = useCallback(() => {
     Animated.timing(opacityVal, {
       toValue: 1,
       duration: DEFAULT_OVERLAY_ANIMATION_DURATION,
-      easing: Easing.linear,
+      easing: DEFAULT_OVERLAY_ANIMATION_EASING,
       useNativeDriver: true,
     }).start();
   }, [opacityVal]);
+
+  const fadeOut = useCallback(
+    (callback?: () => void) => {
+      Animated.timing(opacityVal, {
+        toValue: 0,
+        duration: DEFAULT_OVERLAY_ANIMATION_DURATION,
+        easing: DEFAULT_OVERLAY_ANIMATION_EASING,
+        useNativeDriver: true,
+      }).start(({ finished }) => {
+        if (finished) {
+          callback?.();
+        }
+      });
+    },
+    [opacityVal],
+  );
+
+  useImperativeHandle(ref, () => ({ fadeIn, fadeOut }), [fadeIn, fadeOut]);
+
+  useEffect(() => {
+    fadeIn();
+  }, [fadeIn]);
 
   return (
     <Animated.View
@@ -42,4 +73,6 @@ export const BottomSheetOverlay: React.FC<BottomSheetOverlayProps> = ({
       )}
     </Animated.View>
   );
-};
+});
+
+BottomSheetOverlay.displayName = 'BottomSheetOverlay';

--- a/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.types.ts
+++ b/packages/design-system-react-native/src/components/BottomSheetOverlay/BottomSheetOverlay.types.ts
@@ -19,3 +19,17 @@ export type BottomSheetOverlayProps = {
    */
   touchableOpacityProps?: Omit<TouchableOpacityProps, 'onPress' | 'style'>;
 } & ViewProps;
+
+/**
+ * Ref handle for imperative control of overlay fade animations.
+ */
+export type BottomSheetOverlayRef = {
+  /**
+   * Fade the overlay in.
+   */
+  fadeIn: () => void;
+  /**
+   * Fade the overlay out with an optional callback after animation completes.
+   */
+  fadeOut: (callback?: () => void) => void;
+};

--- a/packages/design-system-react-native/src/components/BottomSheetOverlay/index.ts
+++ b/packages/design-system-react-native/src/components/BottomSheetOverlay/index.ts
@@ -1,2 +1,5 @@
 export { BottomSheetOverlay } from './BottomSheetOverlay';
-export type { BottomSheetOverlayProps } from './BottomSheetOverlay.types';
+export type {
+  BottomSheetOverlayProps,
+  BottomSheetOverlayRef,
+} from './BottomSheetOverlay.types';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -78,7 +78,10 @@ export { BottomSheetHeader } from './BottomSheetHeader';
 export type { BottomSheetHeaderProps } from './BottomSheetHeader';
 
 export { BottomSheetOverlay } from './BottomSheetOverlay';
-export type { BottomSheetOverlayProps } from './BottomSheetOverlay';
+export type {
+  BottomSheetOverlayProps,
+  BottomSheetOverlayRef,
+} from './BottomSheetOverlay';
 
 export { Blockies } from './temp-components/Blockies';
 export type { BlockiesProps } from './temp-components/Blockies';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### What issues does this PR address?
Bottom sheet open and close transitions felt glitchy and performance-related, but the root cause may have been animation timing. This PR updates easing and spring configuration so enter/exit motion matches native iOS behavior.

### What are the key improvements?
Smoother, more natural animations throughout the bottom sheet lifecycle:
- Overlay: UIKit-style ease-in-out fade (replacing linear timing)
- Sheet: Spring-based open, close, and snap-back animations
- Dismiss: Overlay fade-out runs in parallel with sheet close on all dismiss paths (overlay tap, swipe, back button, imperative close)


## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/pull/32503
https://consensys.slack.com/archives/C09AYKX30P3/p1781279526405829
https://consensys.slack.com/archives/C02VD8QG0LT/p1781543949122609

## **Manual testing steps**

1. Run `yarn storybook:ios`
2. `Command + D` to open performance monitor - check there are no degradations
3. Test updates in Mobile: `@metamask-previews/design-system-react-native": "0.30.2-preview.808be73"`


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Animations**
In the `before` state, the exit is jerky (0:02). It is smoother in the after state, also 0.02.
<table>
  <tr>
    <td align="center" valign="top"><strong>Before</strong><br>
    <video src="https://github.com/user-attachments/assets/63952215-1f7c-4563-8fee-6015cb6ecd3e" controls width="320"></video></td>
    <td align="center" valign="top"><strong>After</strong><br>
    <video src="https://github.com/user-attachments/assets/6827dd87-f31c-4044-8407-3b031f487d7f" controls width="320"></video></td>
  </tr>
</table>

### **Performance**
No observable degradations - FPS remains at ~60

<table>
  <tr>
    <td align="center" valign="top"><strong>Before</strong><br>
    <video src="https://github.com/user-attachments/assets/2f0ad909-20d6-4525-9a87-552db33836f2" controls width="320"></video></td>
    <td align="center" valign="top"><strong>After</strong><br>
    <video src="https://github.com/user-attachments/assets/19bfa0cc-830f-48b0-9a38-babe85eadb30" controls width="320"></video></td>
  </tr>
</table>

### **Mobile**
There is a slight delay in the `before` state at 0:02. That is resolved in the `after` view.

<table>
  <tr>
    <td align="center" valign="top"><strong>Before</strong><br>
    <video src="https://github.com/user-attachments/assets/359946e1-958e-4227-9633-21e64cf0a3f3" controls width="320"></video></td>
    <td align="center" valign="top"><strong>After</strong><br>
    <video src="https://github.com/user-attachments/assets/bd11999f-5461-4513-9caf-91f2221a1e43" controls width="320"></video></td>
  </tr>
</table>

Note: The `Trade` bottom sheet has a separate implementation — it was built separately from all other DS components. The same logic was applied to ensure cross-feature consistency.










<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
