### PR TITLE
fix: add component-scoped size aliases and document prop const convention

### DIFF
--- a/.cursor/rules/component-architecture.md
+++ b/.cursor/rules/component-architecture.md
@@ -8,6 +8,7 @@ This file defines the architectural patterns that ALL component workflows must f
 
 - [ADR-0003](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0003-enum-to-string-union-migration.md): String unions with const objects (no enums)
 - [ADR-0004](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0004-centralized-types-architecture.md): Centralized types in shared package
+- **Component-scoped prop const objects:** `ComponentName` + `PropName` exports (e.g. `SegmentedControlSize`) — canonical detail in **Component-Scoped Prop Const Objects** below
 - Platform-Specific Props: Layered architecture pattern
 - Cross-platform consistency principles
 
@@ -32,6 +33,64 @@ export enum ButtonVariant {
 ```
 
 **Reference:** [ADR-0003: Enum to String Union Migration](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0003-enum-to-string-union-migration.md)
+
+## Component-Scoped Prop Const Objects
+
+Every public prop that accepts a fixed set of values must expose a **component-scoped** const object named `ComponentName` + `PropName` (PascalCase). Consumers import the const for the component they are using — not a shared base type from another component.
+
+**Why:** Discoverability at the import site. When using `SegmentedControl`, consumers look for `SegmentedControlSize` — not `ButtonBaseSize` or `ButtonSize`.
+
+### Naming and aliasing
+
+When values match an existing base scale, **alias** the base const in shared — do not reference the base type on public prop interfaces:
+
+```tsx
+import { ButtonBaseSize } from '../ButtonBase/ButtonBase.types';
+
+/**
+ * SelectButton size options (ADR-0003).
+ * Alias to ButtonBaseSize to keep values in sync.
+ */
+export const SelectButtonSize = ButtonBaseSize;
+export type SelectButtonSize = ButtonBaseSize;
+
+export type SelectButtonPropsShared = {
+  /** @default SelectButtonSize.Sm */
+  size?: SelectButtonSize;
+};
+```
+
+**Golden path:** @packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
+
+Other examples: `FilterButtonSize`, `SegmentedControlSize` (alias `ButtonBaseSize`); `AvatarNetworkSize`, `AvatarTokenSize` (alias `AvatarBaseSize`); `ButtonSize`, `ButtonHeroSize` (alias `ButtonBaseSize`).
+
+### Rules
+
+| Rule                   | Detail                                                                                                                       |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Naming                 | `ComponentName` + `PropName`: `FilterButtonVariant`, `SelectButtonEndArrow`                                                  |
+| Prop typing            | Shared props use the **scoped** type (`SegmentedControlSize`), not `ButtonBaseSize` / `AvatarBaseSize`                       |
+| Exports                | Export scoped const from shared `index.ts` and component `index.ts` (single export location — unchanged)                     |
+| Stories / docs / Figma | Examples import and use scoped consts — never `ButtonBaseSize` in consumer-facing snippets                                   |
+| Internal only          | `ButtonBaseSize` is valid inside `ButtonBase`, button variants, and other internal implementations                           |
+| Platform extension     | A component may extend `ButtonBaseProps` on the platform layer but must still export `FilterButtonSize` (etc.) for consumers |
+| Future migration       | Plain string unions (e.g. `size="md"`) may arrive via an explicit ADR announcement — until then, ship scoped const objects   |
+
+### Anti-patterns
+
+```tsx
+// ❌ Wrong - base type on public shared prop (requires internal knowledge)
+export type SegmentedControlPropsShared = {
+  size?: ButtonBaseSize;
+};
+
+// ❌ Wrong - sibling component's const on a different component (compiles but confuses)
+<SegmentedControl size={ButtonSize.Md} />
+
+// ✅ Correct
+<SegmentedControl size={SegmentedControlSize.Md} />
+<FilterButton size={FilterButtonSize.Sm} />
+```
 
 ## ADR-0004: Centralized Types Architecture
 
@@ -254,6 +313,8 @@ Both `Input` and `Text` are _consumers_ of `TextVariant` — neither owns it. Im
 - [ ] Platform `src/types/index.ts` does NOT re-export shared types
 - [ ] NO className/twClassName in shared package
 - [ ] NO unified event handlers in shared package
+- [ ] Each public prop union has a component-scoped const object export (`ComponentNameSize`, `ComponentNameVariant`, etc.)
+- [ ] Shared props reference scoped types, not base types (`ButtonBaseSize`, `AvatarBaseSize`)
 
 ## Optional slot rendering (`ReactNode`)
 

--- a/.cursor/rules/component-architecture.md
+++ b/.cursor/rules/component-architecture.md
@@ -89,6 +89,7 @@ Two base scales exist in shared. Each public component aliases its own const —
 | ---------------------- | ---------------- |
 | `ButtonSize`           | Button           |
 | `ButtonHeroSize`       | ButtonHero       |
+| `ButtonSemanticSize`   | ButtonSemantic   |
 | `SelectButtonSize`     | SelectButton     |
 | `FilterButtonSize`     | FilterButton     |
 | `SegmentedControlSize` | SegmentedControl |

--- a/.cursor/rules/component-architecture.md
+++ b/.cursor/rules/component-architecture.md
@@ -62,9 +62,45 @@ export type SelectButtonPropsShared = {
 
 **Golden path:** @packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts
 
-Other examples: `FilterButtonSize`, `SegmentedControlSize` (alias `ButtonBaseSize`); `AvatarNetworkSize`, `AvatarTokenSize` (alias `AvatarBaseSize`); `ButtonSize`, `ButtonHeroSize` (alias `ButtonBaseSize`).
+### Current alias examples in the monorepo
 
-### Rules
+Two base scales exist in shared. Each public component aliases its own const — consumers never import the base type for another component's props.
+
+**Avatars** — all alias `AvatarBaseSize`:
+
+| Export              | Component     |
+| ------------------- | ------------- |
+| `AvatarAccountSize` | AvatarAccount |
+| `AvatarTokenSize`   | AvatarToken   |
+| `AvatarNetworkSize` | AvatarNetwork |
+| `AvatarFaviconSize` | AvatarFavicon |
+| `AvatarGroupSize`   | AvatarGroup   |
+| `AvatarIconSize`    | AvatarIcon    |
+
+**Button-scale controls** — all alias `ButtonBaseSize`:
+
+| Export                 | Component        |
+| ---------------------- | ---------------- |
+| `ButtonSize`           | Button           |
+| `ButtonHeroSize`       | ButtonHero       |
+| `SelectButtonSize`     | SelectButton     |
+| `FilterButtonSize`     | FilterButton     |
+| `SegmentedControlSize` | SegmentedControl |
+
+**Usage:**
+
+```tsx
+<AvatarToken size={AvatarTokenSize.Lg} />
+<Button size={ButtonSize.Md} />
+<SelectButton size={SelectButtonSize.Sm} />
+<SegmentedControl size={SegmentedControlSize.Md} />
+```
+
+### Future: plain string union props
+
+We may eventually roll out plain string unions (e.g. `size="md"` instead of `size={ButtonSize.Md}`) per [ADR-0003](https://github.com/MetaMask/decisions/blob/main/decisions/design-system/0003-enum-to-string-union-migration.md). That requires a **team announcement and coordinated migration** — do not ship `size="md"` on new components until that decision is published and existing const-object exports are deprecated with a clear timeline.
+
+**Until then:** always add component-scoped const objects for new prop unions, even when values alias `AvatarBaseSize` or `ButtonBaseSize`.
 
 | Rule                   | Detail                                                                                                                       |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
@@ -74,7 +110,7 @@ Other examples: `FilterButtonSize`, `SegmentedControlSize` (alias `ButtonBaseSiz
 | Stories / docs / Figma | Examples import and use scoped consts — never `ButtonBaseSize` in consumer-facing snippets                                   |
 | Internal only          | `ButtonBaseSize` is valid inside `ButtonBase`, button variants, and other internal implementations                           |
 | Platform extension     | A component may extend `ButtonBaseProps` on the platform layer but must still export `FilterButtonSize` (etc.) for consumers |
-| Future migration       | Plain string unions (e.g. `size="md"`) may arrive via an explicit ADR announcement — until then, ship scoped const objects   |
+| Future migration       | Plain string unions (e.g. `size="md"`) require an explicit team announcement — until then, ship scoped const objects only    |
 
 ### Anti-patterns
 

--- a/.cursor/rules/component-architecture.md
+++ b/.cursor/rules/component-architecture.md
@@ -36,7 +36,13 @@ export enum ButtonVariant {
 
 ## Component-Scoped Prop Const Objects
 
-Every public prop that accepts a fixed set of values must expose a **component-scoped** const object named `ComponentName` + `PropName` (PascalCase). Consumers import the const for the component they are using — not a shared base type from another component.
+Every public prop that accepts a fixed set of values must expose a **component-scoped** const object named `ComponentName` + `PropNameInPascalCase`, where `PropNameInPascalCase` matches the **prop name** (not an abbreviated concept). Consumers import the const for the component they are using — not a shared base type from another component.
+
+| Prop name           | Const export                                                 |
+| ------------------- | ------------------------------------------------------------ |
+| `size`              | `SegmentedControlSize`                                       |
+| `variant`           | `FilterButtonVariant`                                        |
+| `endArrowDirection` | `SelectButtonEndArrowDirection` (not `SelectButtonEndArrow`) |
 
 **Why:** Discoverability at the import site. When using `SegmentedControl`, consumers look for `SegmentedControlSize` — not `ButtonBaseSize` or `ButtonSize`.
 
@@ -102,9 +108,13 @@ We may eventually roll out plain string unions (e.g. `size="md"` instead of `siz
 
 **Until then:** always add component-scoped const objects for new prop unions, even when values alias `AvatarBaseSize` or `ButtonBaseSize`.
 
+### Legacy naming to avoid copying
+
+`SelectButtonEndArrow` is shipped for the `endArrowDirection` prop but **does not follow** the convention (prop → `SelectButtonEndArrowDirection`). Do not use it as a template for new components. Renaming may happen in a future breaking release; new work should use the full prop name in the const export.
+
 | Rule                   | Detail                                                                                                                       |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Naming                 | `ComponentName` + `PropName`: `FilterButtonVariant`, `SelectButtonEndArrow`                                                  |
+| Naming                 | `ComponentName` + prop name in PascalCase: `FilterButtonVariant`, `SegmentedControlSize`, `AvatarTokenSize`                  |
 | Prop typing            | Shared props use the **scoped** type (`SegmentedControlSize`), not `ButtonBaseSize` / `AvatarBaseSize`                       |
 | Exports                | Export scoped const from shared `index.ts` and component `index.ts` (single export location — unchanged)                     |
 | Stories / docs / Figma | Examples import and use scoped consts — never `ButtonBaseSize` in consumer-facing snippets                                   |

--- a/.cursor/rules/component-creation.md
+++ b/.cursor/rules/component-creation.md
@@ -73,6 +73,8 @@ mkdir -p packages/design-system-shared/src/types/MyComponent
 - ✅ Create in `packages/design-system-shared/src/types/ComponentName/`
 - ✅ Use const objects (ADR-0003): `export const MyComponentVariant = { Primary: 'primary' } as const;`
 - ✅ Derive types: `export type MyComponentVariant = (typeof MyComponentVariant)[keyof typeof MyComponentVariant];`
+- ✅ Name prop const objects `ComponentName` + `PropName` (e.g. `MyComponentSize`, `MyComponentVariant`) — see @.cursor/rules/component-architecture.md **Component-Scoped Prop Const Objects**
+- ✅ When values alias a base scale (`ButtonBaseSize`, `AvatarBaseSize`), export a scoped alias (`export const MyComponentSize = ButtonBaseSize`) and type shared props with the scoped name — never `ButtonBaseSize` on public shared props
 - ✅ Use `type` not `interface` for props (enforced by ESLint for better composition and intersection patterns)
 - ✅ Add "Shared" suffix: `ComponentNamePropsShared`
 - ✅ Platform-independent properties only (no className/twClassName, no onClick/onPress)
@@ -177,6 +179,7 @@ Follow @.cursor/rules/component-documentation.md:
 - ✅ Default story with all controls wired up (FIRST)
 - ✅ Story per major prop (Variant, Size, IsDisabled)
 - ✅ Meta with proper argTypes
+- ✅ Use component-scoped const objects in stories (`MyComponentSize.Md`), not base types like `ButtonBaseSize`
 
 ### Step 8: Write Tests
 
@@ -328,6 +331,12 @@ export type { MyComponentProps } from './MyComponent.types';
 
 **Why this matters:** Duplicate const object exports create uncovered code paths, failing Jest coverage thresholds (see BadgeCount PR).
 
+### ❌ Using Base Types in Public API
+
+Do not type public shared props or story/README examples with `ButtonBaseSize` / `AvatarBaseSize`, and do not use a sibling component's const (e.g. `ButtonSize` on `SegmentedControl`). Export and use `ComponentNameSize` / `ComponentNameVariant` instead.
+
+See @.cursor/rules/component-architecture.md **Component-Scoped Prop Const Objects** (golden path: @packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts).
+
 ## Verification Checklist
 
 ### Setup & Scaffolding
@@ -339,6 +348,8 @@ export type { MyComponentProps } from './MyComponent.types';
 
 - [ ] Types in `@metamask/design-system-shared/src/types/ComponentName/`
 - [ ] Const objects used, NOT enums
+- [ ] Each public prop union has a component-scoped const (`ComponentNameSize`, `ComponentNameVariant`, etc.)
+- [ ] Shared props use scoped types, not base types (`ButtonBaseSize`, `AvatarBaseSize`)
 - [ ] Shared type named `ComponentNamePropsShared` (with "Shared" suffix)
 - [ ] Used `type` not `interface` for shared props
 - [ ] Exported from `@metamask/design-system-shared/src/index.ts`
@@ -396,6 +407,16 @@ export type { MyComponentProps } from './MyComponent.types';
 - @packages/design-system-shared/src/types/BadgeStatus/ (Shared types - SOURCE OF TRUTH)
 - @packages/design-system-react/src/components/BadgeStatus/ (React)
 - @packages/design-system-react-native/src/components/BadgeStatus/ (React Native)
+
+**SelectButton** (scoped prop const aliases to a base type):
+
+- @packages/design-system-shared/src/types/SelectButton/SelectButton.types.ts (`SelectButtonSize`, `SelectButtonVariant`)
+- @packages/design-system-react-native/src/components/SelectButton/ (React Native implementation)
+
+**FilterButton / SegmentedControl** (button-scale size aliases):
+
+- @packages/design-system-shared/src/types/FilterButton/FilterButton.types.ts (`FilterButtonSize`)
+- @packages/design-system-shared/src/types/SegmentedControl/SegmentedControl.types.ts (`SegmentedControlSize`)
 
 ### Required Reading
 

--- a/.cursor/rules/component-creation.md
+++ b/.cursor/rules/component-creation.md
@@ -73,7 +73,7 @@ mkdir -p packages/design-system-shared/src/types/MyComponent
 - ✅ Create in `packages/design-system-shared/src/types/ComponentName/`
 - ✅ Use const objects (ADR-0003): `export const MyComponentVariant = { Primary: 'primary' } as const;`
 - ✅ Derive types: `export type MyComponentVariant = (typeof MyComponentVariant)[keyof typeof MyComponentVariant];`
-- ✅ Name prop const objects `ComponentName` + `PropName` (e.g. `MyComponentSize`, `MyComponentVariant`) — see @.cursor/rules/component-architecture.md **Component-Scoped Prop Const Objects**
+- ✅ Name prop const objects `ComponentName` + prop name in PascalCase (e.g. `MyComponentSize` for `size`, `MyComponentVariant` for `variant`) — see @.cursor/rules/component-architecture.md **Component-Scoped Prop Const Objects**
 - ✅ When values alias a base scale (`ButtonBaseSize`, `AvatarBaseSize`), export a scoped alias (`export const MyComponentSize = ButtonBaseSize`) and type shared props with the scoped name — never `ButtonBaseSize` on public shared props
 - ✅ Use `type` not `interface` for props (enforced by ESLint for better composition and intersection patterns)
 - ✅ Add "Shared" suffix: `ComponentNamePropsShared`

--- a/.cursor/rules/component-documentation.md
+++ b/.cursor/rules/component-documentation.md
@@ -86,7 +86,8 @@ Follow **Storybook controls (cross-platform)** above; mobile panels work best wi
 
 **DSRN-specific patterns:**
 
-- For shared **const-object** unions (`ButtonBaseSize`, `IconName`, etc.), use `options: Object.keys(Const)` with `mapping: Const` so TypeScript and Storybook stay aligned (never pass the whole object as `options`).
+- For shared **const-object** unions (`SegmentedControlSize`, `IconName`, etc.), use `options: Object.keys(Const)` with `mapping: Const` so TypeScript and Storybook stay aligned (never pass the whole object as `options`).
+- **ALWAYS** use the **component-scoped** const in story imports and README usage examples (e.g. `SegmentedControlSize.Md`), not base types like `ButtonBaseSize` or sibling consts like `ButtonSize` on non-Button components.
 - Keep **descriptions** on `argTypes` entries where they help consumers scanning the controls panel.
 
 **Default story:** Wire only props that have real on-device controls. Do not require every component prop to appear in `argTypes`.
@@ -98,6 +99,7 @@ Follow **Storybook controls (cross-platform)** above; mobile panels work best wi
 - **ALWAYS** document same props in both platforms
 - **ALWAYS** use same section headings (Props, Usage, Accessibility)
 - **ALWAYS** use same enum names and values across platforms
+- **ALWAYS** use component-scoped const names in usage examples (`FilterButtonSize`, not `ButtonBaseSize`)
 - **Web**: Interactive Canvas examples, minimal written examples
 - **Native**: Comprehensive written examples, multiple usage patterns
 

--- a/.cursor/rules/component-enum-union-migration.md
+++ b/.cursor/rules/component-enum-union-migration.md
@@ -51,7 +51,7 @@ export enum BadgeStatusStatus { Active = 'active', ... } // Duplicate!
 
    - Use const objects (ADR-0003): `export const ComponentVariant = { Primary: 'primary' } as const;`
    - Derive types: `export type ComponentVariant = (typeof ComponentVariant)[keyof typeof ComponentVariant];`
-   - Name prop consts `ComponentName` + `PropName`; alias base scales when values match (`ComponentNameSize = ButtonBaseSize`) — see @.cursor/rules/component-architecture.md **Component-Scoped Prop Const Objects**
+   - Name prop consts `ComponentName` + prop name in PascalCase (`size` → `MyComponentSize`); alias base scales when values match — see @.cursor/rules/component-architecture.md **Component-Scoped Prop Const Objects**
    - Use `type` not `interface` for props
    - Add "Shared" suffix: `ComponentNamePropsShared`
    - Export from `packages/design-system-shared/src/index.ts` with inline `type` keyword

--- a/.cursor/rules/component-enum-union-migration.md
+++ b/.cursor/rules/component-enum-union-migration.md
@@ -51,6 +51,7 @@ export enum BadgeStatusStatus { Active = 'active', ... } // Duplicate!
 
    - Use const objects (ADR-0003): `export const ComponentVariant = { Primary: 'primary' } as const;`
    - Derive types: `export type ComponentVariant = (typeof ComponentVariant)[keyof typeof ComponentVariant];`
+   - Name prop consts `ComponentName` + `PropName`; alias base scales when values match (`ComponentNameSize = ButtonBaseSize`) — see @.cursor/rules/component-architecture.md **Component-Scoped Prop Const Objects**
    - Use `type` not `interface` for props
    - Add "Shared" suffix: `ComponentNamePropsShared`
    - Export from `packages/design-system-shared/src/index.ts` with inline `type` keyword
@@ -209,6 +210,7 @@ export type BadgeStatusProps = ComponentProps<'div'> &
 
 - [ ] Types in `packages/design-system-shared/src/types/ComponentName/`
 - [ ] Const objects used (ADR-0003), NOT enums
+- [ ] Each public prop union has a component-scoped const export (not `ButtonBaseSize` on shared prop interfaces)
 - [ ] Shared type named `ComponentNamePropsShared` (with "Shared" suffix)
 - [ ] Used `type` not `interface` for shared props
 - [ ] Exported from `packages/design-system-shared/src/index.ts`

--- a/.cursor/rules/component-migration.md
+++ b/.cursor/rules/component-migration.md
@@ -81,12 +81,13 @@ Use this workflow when:
 
 2. **Create comparison table:**
 
-| Concern        | Extension API | Mobile API   | Decision                  |
-| -------------- | ------------- | ------------ | ------------------------- |
-| Prop names     | Document      | Document     | Choose unified            |
-| Types          | Document      | Document     | Align or unify            |
-| Event handlers | `onClick`     | `onPress`    | Keep both (platform)      |
-| Styling        | `className`   | style object | Use className/twClassName |
+| Concern        | Extension API | Mobile API   | Decision                                                                      |
+| -------------- | ------------- | ------------ | ----------------------------------------------------------------------------- |
+| Prop names     | Document      | Document     | Choose unified                                                                |
+| Types          | Document      | Document     | Align or unify                                                                |
+| Size / variant | Document      | Document     | `ComponentNameSize` alias if values match `ButtonBaseSize` / `AvatarBaseSize` |
+| Event handlers | `onClick`     | `onPress`    | Keep both (platform)                                                          |
+| Styling        | `className`   | style object | Use className/twClassName                                                     |
 
 3. **Answer key questions:**
    - Which props are cross-platform? (variant, size, isDisabled)
@@ -122,6 +123,7 @@ Use this workflow when:
 - Shared props type with "Shared" suffix
 - Platform-independent properties only
 - Use `type` not `interface`
+- **Component-scoped prop consts:** When `size` or `variant` maps to an existing base scale, create `ComponentNameSize` / `ComponentNameVariant` aliases in shared (e.g. `export const FilterButtonSize = ButtonBaseSize`) — do not type public shared props with `ButtonBaseSize`. See @.cursor/rules/component-architecture.md **Component-Scoped Prop Const Objects**.
 
 **Platform packages pattern:**
 

--- a/.cursor/rules/figma-integration.md
+++ b/.cursor/rules/figma-integration.md
@@ -89,6 +89,35 @@ props: {
 }
 ```
 
+### Component-Scoped Const Imports
+
+Import prop const objects from the **component barrel** (`'.'`), using the component-scoped name — not base types from `@metamask/design-system-shared`.
+
+```tsx
+// ✅ Button — scoped size from component barrel
+import { ButtonVariant, ButtonSize } from '.';
+
+// ✅ FilterButton — same pattern (aliases ButtonBaseSize in shared)
+import { FilterButtonVariant, FilterButtonSize } from '.';
+
+props: {
+  variant: figma.enum('variant', {
+    primary: FilterButtonVariant.Primary,
+    secondary: FilterButtonVariant.Secondary,
+  }),
+  size: figma.enum('size', {
+    Lg: FilterButtonSize.Lg,
+    Md: FilterButtonSize.Md,
+    Sm: FilterButtonSize.Sm,
+  }),
+}
+
+// ❌ Wrong — base type from shared in Code Connect (consumer-facing leak)
+import { ButtonBaseSize, FilterButtonVariant } from '@metamask/design-system-shared';
+```
+
+See @.cursor/rules/component-architecture.md **Component-Scoped Prop Const Objects**.
+
 ### Realistic Example Props
 
 - **ALWAYS** provide realistic, meaningful prop values in examples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,6 @@ Repository-specific conventions and patterns:
 
 See @docs/ai-agents.md for comprehensive strategy explanation.
 
-**Component prop consts:** Avatars use `AvatarTokenSize`, etc. (alias `AvatarBaseSize`); buttons use `ButtonSize`, `SelectButtonSize`, etc. (alias `ButtonBaseSize`). Do not expose base types on public APIs. Future `size="md"` unions require a team-wide rollout first — see @.cursor/rules/component-architecture.md (**Component-Scoped Prop Const Objects**).
-
 ## Monorepo Structure
 
 **This is a yarn workspaces monorepo.** Run all commands from the repository root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ Repository-specific conventions and patterns:
 
 See @docs/ai-agents.md for comprehensive strategy explanation.
 
+**Component prop consts:** Export scoped names (`ComponentNameSize`, `ComponentNameVariant`) on public APIs — not base types like `ButtonBaseSize`. Details: @.cursor/rules/component-architecture.md (**Component-Scoped Prop Const Objects**).
+
 ## Monorepo Structure
 
 **This is a yarn workspaces monorepo.** Run all commands from the repository root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Repository-specific conventions and patterns:
 
 See @docs/ai-agents.md for comprehensive strategy explanation.
 
-**Component prop consts:** Export scoped names (`ComponentNameSize`, `ComponentNameVariant`) on public APIs — not base types like `ButtonBaseSize`. Details: @.cursor/rules/component-architecture.md (**Component-Scoped Prop Const Objects**).
+**Component prop consts:** Avatars use `AvatarTokenSize`, etc. (alias `AvatarBaseSize`); buttons use `ButtonSize`, `SelectButtonSize`, etc. (alias `ButtonBaseSize`). Do not expose base types on public APIs. Future `size="md"` unions require a team-wide rollout first — see @.cursor/rules/component-architecture.md (**Component-Scoped Prop Const Objects**).
 
 ## Monorepo Structure
 

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -62,7 +62,7 @@ Engineers can reference `.cursor/rules/` directly when needed, but the primary i
 
 **Current Rule Files**
 
-- `component-architecture.md` - Component architectural patterns (ADR-0003/0004, layered architecture, cross-platform)
+- `component-architecture.md` - Component architectural patterns (ADR-0003/0004, layered architecture, cross-platform, **component-scoped prop const objects** — e.g. `SegmentedControlSize` not `ButtonBaseSize` on public props)
 - `component-creation.md` - Component scaffolding HOW-TO guide
 - `component-migration.md` - Extension/mobile component migration (priority workflow)
 - `component-enum-union-migration.md` - Internal ADR-0003/0004 migration
@@ -165,6 +165,18 @@ Every line must prevent a mistake or provide essential guidance. Remove anything
 ### 4. Iterative Improvement
 
 Add rules when observing AI agents make repeated mistakes. Test with agents and refine based on their behavior.
+
+**Recent example:** `SegmentedControl` and `FilterButton` shipped with `size` typed as `ButtonBaseSize`, so consumers had to guess the correct import. The guardrail now lives in @.cursor/rules/component-architecture.md (**Component-Scoped Prop Const Objects**); sibling component rules link there instead of duplicating the full convention.
+
+### Reference hierarchy for component API types
+
+| Layer                                                           | Role                                                                        |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| @.cursor/rules/component-architecture.md                        | **Canonical** ADR patterns + scoped prop const naming                       |
+| Other `component-*.md` rules                                    | Checklists and workflow steps; `@`-link architecture for type-naming detail |
+| Golden path files in `packages/design-system-shared/src/types/` | Code agents should read when implementing (e.g. `SelectButton.types.ts`)    |
+
+This follows **Reference Over Duplication**: strategy docs describe _where_ rules live; rules point to _code_, not long copied snippets.
 
 ## References
 

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -62,7 +62,7 @@ Engineers can reference `.cursor/rules/` directly when needed, but the primary i
 
 **Current Rule Files**
 
-- `component-architecture.md` - Component architectural patterns (ADR-0003/0004, layered architecture, cross-platform, **component-scoped prop const objects** — e.g. `SegmentedControlSize` not `ButtonBaseSize` on public props)
+- `component-architecture.md` - Component architectural patterns (ADR-0003/0004, layered architecture, cross-platform)
 - `component-creation.md` - Component scaffolding HOW-TO guide
 - `component-migration.md` - Extension/mobile component migration (priority workflow)
 - `component-enum-union-migration.md` - Internal ADR-0003/0004 migration
@@ -165,18 +165,6 @@ Every line must prevent a mistake or provide essential guidance. Remove anything
 ### 4. Iterative Improvement
 
 Add rules when observing AI agents make repeated mistakes. Test with agents and refine based on their behavior.
-
-**Recent example:** `SegmentedControl` and `FilterButton` shipped with `size` typed as `ButtonBaseSize`, so consumers had to guess the correct import. The guardrail now lives in @.cursor/rules/component-architecture.md (**Component-Scoped Prop Const Objects**); sibling component rules link there instead of duplicating the full convention.
-
-### Reference hierarchy for component API types
-
-| Layer                                                           | Role                                                                        |
-| --------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| @.cursor/rules/component-architecture.md                        | **Canonical** ADR patterns + scoped prop const naming                       |
-| Other `component-*.md` rules                                    | Checklists and workflow steps; `@`-link architecture for type-naming detail |
-| Golden path files in `packages/design-system-shared/src/types/` | Code agents should read when implementing (e.g. `SelectButton.types.ts`)    |
-
-This follows **Reference Over Duplication**: strategy docs describe _where_ rules live; rules point to _code_, not long copied snippets.
 
 ## References
 

--- a/packages/design-system-react-native/src/components/Button/README.md
+++ b/packages/design-system-react-native/src/components/Button/README.md
@@ -66,19 +66,19 @@ The size of the button.
 
 Available sizes:
 
-- `ButtonBaseSize.Sm` (32px height)
-- `ButtonBaseSize.Md` (40px height)
-- `ButtonBaseSize.Lg` (48px height)
+- `ButtonSize.Sm` (32px height)
+- `ButtonSize.Md` (40px height)
+- `ButtonSize.Lg` (48px height)
 
-| TYPE             | REQUIRED | DEFAULT             |
-| ---------------- | -------- | ------------------- |
-| `ButtonBaseSize` | No       | `ButtonBaseSize.Lg` |
+| TYPE         | REQUIRED | DEFAULT         |
+| ------------ | -------- | --------------- |
+| `ButtonSize` | No       | `ButtonSize.Lg` |
 
 ```tsx
-<Button variant={ButtonVariant.Primary} size={ButtonBaseSize.Sm} onPress={() => {}}>
+<Button variant={ButtonVariant.Primary} size={ButtonSize.Sm} onPress={() => {}}>
   Small Button
 </Button>
-<Button variant={ButtonVariant.Primary} size={ButtonBaseSize.Lg} onPress={() => {}}>
+<Button variant={ButtonVariant.Primary} size={ButtonSize.Lg} onPress={() => {}}>
   Large Button
 </Button>
 ```

--- a/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.stories.tsx
+++ b/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-native';
+import { ButtonSemanticSize } from '@metamask/design-system-shared';
 import React from 'react';
 import { View } from 'react-native';
 
 import { Box } from '../Box';
-import { ButtonBaseSize } from '../ButtonBase';
 import { Text, TextVariant, TextColor } from '../Text';
 
 import { ButtonSemantic } from './ButtonSemantic';
@@ -26,8 +26,8 @@ const meta: Meta<ButtonSemanticProps> = {
     },
     size: {
       control: 'select',
-      options: Object.keys(ButtonBaseSize),
-      mapping: ButtonBaseSize,
+      options: Object.keys(ButtonSemanticSize),
+      mapping: ButtonSemanticSize,
     },
     isDisabled: {
       control: 'boolean',
@@ -60,7 +60,7 @@ type Story = StoryObj<ButtonSemanticProps>;
 export const Default: Story = {
   args: {
     severity: ButtonSemanticSeverity.Success,
-    size: ButtonBaseSize.Lg,
+    size: ButtonSemanticSize.Lg,
     isDisabled: false,
     isLoading: false,
     isFullWidth: false,
@@ -83,11 +83,11 @@ export const Severity: Story = {
 export const Size: Story = {
   render: (args) => (
     <Box gap={4}>
-      {Object.keys(ButtonBaseSize).map((sizeKey) => (
+      {Object.keys(ButtonSemanticSize).map((sizeKey) => (
         <ButtonSemantic
           key={sizeKey}
           {...args}
-          size={ButtonBaseSize[sizeKey as keyof typeof ButtonBaseSize]}
+          size={ButtonSemanticSize[sizeKey as keyof typeof ButtonSemanticSize]}
         >
           {sizeKey}
         </ButtonSemantic>

--- a/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.stories.tsx
+++ b/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react-native';
 import { ButtonSemanticSize } from '@metamask/design-system-shared';
+import type { Meta, StoryObj } from '@storybook/react-native';
 import React from 'react';
 import { View } from 'react-native';
 

--- a/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.test.tsx
@@ -1,7 +1,6 @@
+import { ButtonSemanticSize } from '@metamask/design-system-shared';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
-
-import { ButtonBaseSize } from '../ButtonBase';
 
 import { ButtonSemantic } from './ButtonSemantic';
 import { ButtonSemanticSeverity } from './ButtonSemantic.types';
@@ -40,22 +39,23 @@ describe('ButtonSemantic', () => {
       expect(getByText('Danger Button')).toBeDefined();
     });
 
-    it.each([ButtonBaseSize.Sm, ButtonBaseSize.Md, ButtonBaseSize.Lg])(
-      'renders with %s size',
-      (size) => {
-        const { getByText } = render(
-          <ButtonSemantic
-            severity={ButtonSemanticSeverity.Success}
-            size={size}
-            onPress={mockOnPress}
-          >
-            Button
-          </ButtonSemantic>,
-        );
+    it.each([
+      ButtonSemanticSize.Sm,
+      ButtonSemanticSize.Md,
+      ButtonSemanticSize.Lg,
+    ])('renders with %s size', (size) => {
+      const { getByText } = render(
+        <ButtonSemantic
+          severity={ButtonSemanticSeverity.Success}
+          size={size}
+          onPress={mockOnPress}
+        >
+          Button
+        </ButtonSemantic>,
+      );
 
-        expect(getByText('Button')).toBeDefined();
-      },
-    );
+      expect(getByText('Button')).toBeDefined();
+    });
 
     it('uses large size by default', () => {
       const { getByText } = render(

--- a/packages/design-system-react-native/src/components/ButtonSemantic/README.md
+++ b/packages/design-system-react-native/src/components/ButtonSemantic/README.md
@@ -6,6 +6,7 @@ ButtonSemantic is a semantic button component that provides predefined color sch
 import {
   ButtonSemantic,
   ButtonSemanticSeverity,
+  ButtonSemanticSize,
 } from '@metamask/design-system-react-native';
 
 <ButtonSemantic
@@ -46,22 +47,22 @@ Optional prop to control the size of the button.
 
 Available sizes:
 
-- `ButtonBaseSize.Sm` (32px)
-- `ButtonBaseSize.Md` (40px)
-- `ButtonBaseSize.Lg` (48px)
+- `ButtonSemanticSize.Sm` (32px)
+- `ButtonSemanticSize.Md` (40px)
+- `ButtonSemanticSize.Lg` (48px)
 
-| TYPE             | REQUIRED | DEFAULT             |
-| ---------------- | -------- | ------------------- |
-| `ButtonBaseSize` | No       | `ButtonBaseSize.Lg` |
+| TYPE                 | REQUIRED | DEFAULT                 |
+| -------------------- | -------- | ----------------------- |
+| `ButtonSemanticSize` | No       | `ButtonSemanticSize.Lg` |
 
 ```tsx
-<ButtonSemantic severity={ButtonSemanticSeverity.Success} size={ButtonBaseSize.Sm}>
+<ButtonSemantic severity={ButtonSemanticSeverity.Success} size={ButtonSemanticSize.Sm}>
   Small
 </ButtonSemantic>
 <ButtonSemantic severity={ButtonSemanticSeverity.Success}>
   Large (default)
 </ButtonSemantic>
-<ButtonSemantic severity={ButtonSemanticSeverity.Success} size={ButtonBaseSize.Lg}>
+<ButtonSemantic severity={ButtonSemanticSeverity.Success} size={ButtonSemanticSize.Lg}>
   Large
 </ButtonSemantic>
 ```

--- a/packages/design-system-react-native/src/components/ButtonSemantic/index.ts
+++ b/packages/design-system-react-native/src/components/ButtonSemantic/index.ts
@@ -1,3 +1,4 @@
+export { ButtonSemanticSize } from '@metamask/design-system-shared';
 export { ButtonSemantic } from './ButtonSemantic';
 export { ButtonSemanticSeverity } from './ButtonSemantic.types';
 export type { ButtonSemanticProps } from './ButtonSemantic.types';

--- a/packages/design-system-react-native/src/components/Content/README.md
+++ b/packages/design-system-react-native/src/components/Content/README.md
@@ -77,7 +77,7 @@ Default string styles: `TextVariant.BodySm`, `FontWeight.Medium`, `TextColor.Tex
 <Content
   avatar={<AvatarToken name="ETH" src={ethIcon} size={AvatarTokenSize.Lg} />}
   subvalue={
-    <Button variant={ButtonVariant.Secondary} size={ButtonBaseSize.Sm}>
+    <Button variant={ButtonVariant.Secondary} size={ButtonSize.Sm}>
       3% bonus
     </Button>
   }

--- a/packages/design-system-react-native/src/components/FilterButton/FilterButton.figma.tsx
+++ b/packages/design-system-react-native/src/components/FilterButton/FilterButton.figma.tsx
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import-x/no-named-as-default
 import figma from '@figma/code-connect';
 import {
-  ButtonBaseSize,
+  FilterButtonSize,
   FilterButtonVariant,
 } from '@metamask/design-system-shared';
 import React from 'react';
@@ -30,9 +30,9 @@ figma.connect(
         false: false,
       }),
       size: figma.enum('size', {
-        Lg: ButtonBaseSize.Lg,
-        Md: ButtonBaseSize.Md,
-        Sm: ButtonBaseSize.Sm,
+        Lg: FilterButtonSize.Lg,
+        Md: FilterButtonSize.Md,
+        Sm: FilterButtonSize.Sm,
       }),
       buttonBase: figma.nestedProps('_ButtonBase', {
         label: figma.string('label'),

--- a/packages/design-system-react-native/src/components/FilterButton/FilterButton.stories.tsx
+++ b/packages/design-system-react-native/src/components/FilterButton/FilterButton.stories.tsx
@@ -1,9 +1,13 @@
-import { FilterButtonVariant } from '@metamask/design-system-shared';
+import {
+  FilterButtonSize,
+  FilterButtonVariant,
+} from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import type { ViewProps } from 'react-native';
 import { View } from 'react-native';
 
+import { Box } from '../Box';
 import { Icon, IconName, IconSize } from '../Icon';
 
 import { FilterButton } from './FilterButton';
@@ -21,6 +25,11 @@ const meta: Meta<FilterButtonProps> = {
     },
     isSelected: {
       control: 'boolean',
+    },
+    size: {
+      control: 'select',
+      options: Object.keys(FilterButtonSize),
+      mapping: FilterButtonSize,
     },
     isDisabled: {
       control: 'boolean',
@@ -88,6 +97,24 @@ export const Variant: Story = {
         onPress={noopPress}
       />
     </FilterButtonStoryWrapper>
+  ),
+};
+
+export const Size: Story = {
+  render: () => (
+    <Box gap={4} twClassName="p-4">
+      {Object.keys(FilterButtonSize).map((sizeKey) => (
+        <FilterButton
+          key={sizeKey}
+          variant={FilterButtonVariant.Primary}
+          isSelected
+          size={FilterButtonSize[sizeKey as keyof typeof FilterButtonSize]}
+          onPress={noopPress}
+        >
+          {sizeKey}
+        </FilterButton>
+      ))}
+    </Box>
   ),
 };
 

--- a/packages/design-system-react-native/src/components/FilterButton/FilterButton.test.tsx
+++ b/packages/design-system-react-native/src/components/FilterButton/FilterButton.test.tsx
@@ -1,5 +1,5 @@
 import {
-  ButtonBaseSize,
+  FilterButtonSize,
   IconColor,
   IconName,
   IconSize,
@@ -435,7 +435,7 @@ describe('FilterButton', () => {
         <SegmentedControl
           value="a"
           onChange={noopPress}
-          size={ButtonBaseSize.Md}
+          size={FilterButtonSize.Md}
           testID="group"
         >
           <FilterButton value="a" testID="filter-a" onPress={noopPress}>

--- a/packages/design-system-react-native/src/components/FilterButton/FilterButton.tsx
+++ b/packages/design-system-react-native/src/components/FilterButton/FilterButton.tsx
@@ -1,5 +1,5 @@
 import {
-  ButtonBaseSize,
+  FilterButtonSize,
   FilterButtonVariant,
   FilterButtonGroupContext,
 } from '@metamask/design-system-shared';
@@ -34,7 +34,7 @@ export const FilterButton = ({
   const effectiveVariant =
     variant ?? filterButtonGroup?.variant ?? FilterButtonVariant.Primary;
 
-  const effectiveSize = size ?? filterButtonGroup?.size ?? ButtonBaseSize.Sm;
+  const effectiveSize = size ?? filterButtonGroup?.size ?? FilterButtonSize.Sm;
 
   const effectiveIsFullWidth =
     isFullWidth ?? filterButtonGroup?.isEqualWidth ?? false;

--- a/packages/design-system-react-native/src/components/FilterButton/README.md
+++ b/packages/design-system-react-native/src/components/FilterButton/README.md
@@ -113,6 +113,33 @@ export const Example = () => {
 };
 ```
 
+### `size`
+
+Height of the filter button row. Matches the button scale used by **`Button`**, **`SelectButton`**, and **`SegmentedControl`**.
+
+Available sizes:
+
+- `FilterButtonSize.Sm` (32px height)
+- `FilterButtonSize.Md` (40px height)
+- `FilterButtonSize.Lg` (48px height)
+
+When used under **`SegmentedControl`**, segment size comes from the control’s **`size`** prop unless overridden on an individual **`FilterButton`**.
+
+| TYPE               | REQUIRED | DEFAULT               |
+| ------------------ | -------- | --------------------- |
+| `FilterButtonSize` | No       | `FilterButtonSize.Sm` |
+
+```tsx
+import {
+  FilterButton,
+  FilterButtonSize,
+} from '@metamask/design-system-react-native';
+
+<FilterButton size={FilterButtonSize.Md} onPress={() => {}}>
+  Medium
+</FilterButton>;
+```
+
 ### `twClassName`
 
 Use the `twClassName` prop to add Tailwind CSS classes to the root pressable. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
@@ -157,7 +184,7 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 
 ### Other `ButtonBase` props
 
-`FilterButton` accepts the rest of **`ButtonBase`** props (for example **`size`**, **`isLoading`**, **`isDisabled`**, **`startIconName`**, **`startAccessory`**, **`textProps`**, **`startIconProps`**, **`endIconProps`**). The full props contract is **`FilterButtonProps`** from **`@metamask/design-system-react-native`**.
+`FilterButton` accepts the rest of **`ButtonBase`** props (for example **`isLoading`**, **`isDisabled`**, **`startIconName`**, **`startAccessory`**, **`textProps`**, **`startIconProps`**, **`endIconProps`**). Use **`FilterButtonSize`** for **`size`** (documented above). The full props contract is **`FilterButtonProps`** from **`@metamask/design-system-react-native`**.
 
 ## References
 

--- a/packages/design-system-react-native/src/components/FilterButton/README.md
+++ b/packages/design-system-react-native/src/components/FilterButton/README.md
@@ -115,7 +115,7 @@ export const Example = () => {
 
 ### `size`
 
-Height of the filter button row. Matches the button scale used by **`Button`**, **`SelectButton`**, and **`SegmentedControl`**.
+Height of the filter button row. Matches the universal button scale (`sm` / `md` / `lg`). See the **Size** story in React Native Storybook (**Components / FilterButton**) for a vertical comparison of all three heights.
 
 Available sizes:
 
@@ -133,11 +133,33 @@ When used under **`SegmentedControl`**, segment size comes from the control’s 
 import {
   FilterButton,
   FilterButtonSize,
+  FilterButtonVariant,
 } from '@metamask/design-system-react-native';
 
-<FilterButton size={FilterButtonSize.Md} onPress={() => {}}>
-  Medium
-</FilterButton>;
+<FilterButton
+  variant={FilterButtonVariant.Primary}
+  isSelected
+  size={FilterButtonSize.Sm}
+  onPress={() => {}}
+>
+  Sm
+</FilterButton>
+<FilterButton
+  variant={FilterButtonVariant.Primary}
+  isSelected
+  size={FilterButtonSize.Md}
+  onPress={() => {}}
+>
+  Md
+</FilterButton>
+<FilterButton
+  variant={FilterButtonVariant.Primary}
+  isSelected
+  size={FilterButtonSize.Lg}
+  onPress={() => {}}
+>
+  Lg
+</FilterButton>
 ```
 
 ### `twClassName`

--- a/packages/design-system-react-native/src/components/FilterButton/index.ts
+++ b/packages/design-system-react-native/src/components/FilterButton/index.ts
@@ -1,3 +1,6 @@
-export { FilterButtonVariant } from '@metamask/design-system-shared';
+export {
+  FilterButtonSize,
+  FilterButtonVariant,
+} from '@metamask/design-system-shared';
 export { FilterButton } from './FilterButton';
 export type { FilterButtonProps } from './FilterButton.types';

--- a/packages/design-system-react-native/src/components/SegmentedControl/README.md
+++ b/packages/design-system-react-native/src/components/SegmentedControl/README.md
@@ -83,25 +83,29 @@ Size of the control and all child **`FilterButton`** segments. Also sets the con
 
 Available sizes:
 
-- `ButtonBaseSize.Sm` (32px segment height, 12px container radius)
-- `ButtonBaseSize.Md` (40px segment height, 16px container radius)
-- `ButtonBaseSize.Lg` (48px segment height, 16px container radius)
+- `SegmentedControlSize.Sm` (32px segment height, 12px container radius)
+- `SegmentedControlSize.Md` (40px segment height, 16px container radius)
+- `SegmentedControlSize.Lg` (48px segment height, 16px container radius)
 
-| TYPE             | REQUIRED | DEFAULT             |
-| ---------------- | -------- | ------------------- |
-| `ButtonBaseSize` | No       | `ButtonBaseSize.Sm` |
+| TYPE                   | REQUIRED | DEFAULT                   |
+| ---------------------- | -------- | ------------------------- |
+| `SegmentedControlSize` | No       | `SegmentedControlSize.Sm` |
 
 ```tsx
 import { useState } from 'react';
 import {
-  ButtonBaseSize,
   FilterButton,
   SegmentedControl,
+  SegmentedControlSize,
 } from '@metamask/design-system-react-native';
 
 const [value, setValue] = useState('a');
 
-<SegmentedControl value={value} onChange={setValue} size={ButtonBaseSize.Md}>
+<SegmentedControl
+  value={value}
+  onChange={setValue}
+  size={SegmentedControlSize.Md}
+>
   <FilterButton value="a" onPress={() => {}}>
     A
   </FilterButton>

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.constants.ts
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.constants.ts
@@ -1,14 +1,14 @@
-import { ButtonBaseSize } from '@metamask/design-system-shared';
+import { SegmentedControlSize } from '@metamask/design-system-shared';
 
 export const TWCLASSMAP_SEGMENTEDCONTROL_BORDER_RADIUS: Record<
-  ButtonBaseSize,
+  SegmentedControlSize,
   string
 > = {
-  [ButtonBaseSize.Sm]: 'rounded-xl',
-  [ButtonBaseSize.Md]: 'rounded-2xl',
-  [ButtonBaseSize.Lg]: 'rounded-2xl',
+  [SegmentedControlSize.Sm]: 'rounded-xl',
+  [SegmentedControlSize.Md]: 'rounded-2xl',
+  [SegmentedControlSize.Lg]: 'rounded-2xl',
 };
 
 export const getSegmentedControlBorderRadiusTwClass = (
-  size: ButtonBaseSize,
+  size: SegmentedControlSize,
 ): string => TWCLASSMAP_SEGMENTEDCONTROL_BORDER_RADIUS[size];

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.figma.tsx
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.figma.tsx
@@ -1,7 +1,7 @@
 // import figma needs to remain as figma otherwise it breaks code connect
 // eslint-disable-next-line import-x/no-named-as-default
 import figma from '@figma/code-connect';
-import { ButtonBaseSize } from '@metamask/design-system-shared';
+import { SegmentedControlSize } from '@metamask/design-system-shared';
 import React, { useEffect, useState } from 'react';
 
 import { FilterButton } from '../FilterButton';
@@ -22,9 +22,9 @@ figma.connect(
   {
     props: {
       size: figma.enum('size', {
-        Sm: ButtonBaseSize.Sm,
-        Md: ButtonBaseSize.Md,
-        Lg: ButtonBaseSize.Lg,
+        Sm: SegmentedControlSize.Sm,
+        Md: SegmentedControlSize.Md,
+        Lg: SegmentedControlSize.Lg,
       }),
       isFullWidth: figma.enum('isFullWidth', {
         true: true,

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,4 +1,4 @@
-import { ButtonBaseSize } from '@metamask/design-system-shared';
+import { SegmentedControlSize } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
@@ -22,8 +22,8 @@ const meta: Meta<SegmentedControlProps> = {
     },
     size: {
       control: 'select',
-      options: Object.keys(ButtonBaseSize),
-      mapping: ButtonBaseSize,
+      options: Object.keys(SegmentedControlSize),
+      mapping: SegmentedControlSize,
       description: 'Size of the control and child FilterButton segments.',
     },
     isFullWidth: {
@@ -70,7 +70,7 @@ const ControlledSegmentedControl = ({
 export const Default: Story = {
   args: {
     value: 'reaches',
-    size: ButtonBaseSize.Sm,
+    size: SegmentedControlSize.Sm,
     isFullWidth: false,
   },
   render: (args) => <ControlledSegmentedControl {...args} />,
@@ -87,7 +87,7 @@ export const Size: Story = {
         <SegmentedControl
           value={smValue}
           onChange={setSmValue}
-          size={ButtonBaseSize.Sm}
+          size={SegmentedControlSize.Sm}
         >
           <FilterButton value="reaches" onPress={noopPress}>
             Small
@@ -99,7 +99,7 @@ export const Size: Story = {
         <SegmentedControl
           value={mdValue}
           onChange={setMdValue}
-          size={ButtonBaseSize.Md}
+          size={SegmentedControlSize.Md}
         >
           <FilterButton value="reaches" onPress={noopPress}>
             Medium
@@ -111,7 +111,7 @@ export const Size: Story = {
         <SegmentedControl
           value={lgValue}
           onChange={setLgValue}
-          size={ButtonBaseSize.Lg}
+          size={SegmentedControlSize.Lg}
         >
           <FilterButton value="reaches" onPress={noopPress}>
             Large

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,4 +1,4 @@
-import { ButtonBaseSize } from '@metamask/design-system-shared';
+import { SegmentedControlSize } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { fireEvent, render, renderHook } from '@testing-library/react-native';
 import React, { useState } from 'react';
@@ -95,9 +95,9 @@ describe('SegmentedControl', () => {
 
     describe('when size is provided', () => {
       it.each([
-        [ButtonBaseSize.Sm, 'rounded-xl'],
-        [ButtonBaseSize.Md, 'rounded-2xl'],
-        [ButtonBaseSize.Lg, 'rounded-2xl'],
+        [SegmentedControlSize.Sm, 'rounded-xl'],
+        [SegmentedControlSize.Md, 'rounded-2xl'],
+        [SegmentedControlSize.Lg, 'rounded-2xl'],
       ] as const)(
         'applies %s container border radius',
         (size, borderRadiusClass) => {
@@ -116,7 +116,7 @@ describe('SegmentedControl', () => {
 
       it('propagates size to child filter buttons', () => {
         const { getByTestId } = renderSegmentedControl({
-          size: ButtonBaseSize.Md,
+          size: SegmentedControlSize.Md,
         });
 
         expect(getByTestId(FILTER_A_TEST_ID)).toHaveStyle(tw`h-10`);

--- a/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/design-system-react-native/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,7 +1,7 @@
 import {
-  ButtonBaseSize,
   FilterButtonGroupContext,
   FilterButtonVariant,
+  SegmentedControlSize,
   mergeTwClassName,
 } from '@metamask/design-system-shared';
 import React, { Children, useMemo } from 'react';
@@ -14,7 +14,7 @@ import type { SegmentedControlProps } from './SegmentedControl.types';
 export const SegmentedControl = ({
   value,
   onChange,
-  size = ButtonBaseSize.Sm,
+  size = SegmentedControlSize.Sm,
   isFullWidth = false,
   children,
   twClassName,

--- a/packages/design-system-react-native/src/components/SegmentedControl/index.ts
+++ b/packages/design-system-react-native/src/components/SegmentedControl/index.ts
@@ -1,2 +1,3 @@
+export { SegmentedControlSize } from '@metamask/design-system-shared';
 export { SegmentedControl } from './SegmentedControl';
 export type { SegmentedControlProps } from './SegmentedControl.types';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -118,7 +118,11 @@ export type { ButtonProps } from './Button';
 export { ButtonIcon, ButtonIconSize, ButtonIconVariant } from './ButtonIcon';
 export type { ButtonIconProps } from './ButtonIcon';
 
-export { ButtonSemantic, ButtonSemanticSeverity } from './ButtonSemantic';
+export {
+  ButtonSemantic,
+  ButtonSemanticSeverity,
+  ButtonSemanticSize,
+} from './ButtonSemantic';
 export type { ButtonSemanticProps } from './ButtonSemantic';
 
 export { Checkbox } from './Checkbox';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -200,7 +200,11 @@ export type { MainActionButtonProps } from './MainActionButton';
 export { SectionDivider } from './SectionDivider';
 export type { SectionDividerProps } from './SectionDivider';
 
-export { FilterButton, FilterButtonVariant } from './FilterButton';
+export {
+  FilterButton,
+  FilterButtonSize,
+  FilterButtonVariant,
+} from './FilterButton';
 export type { FilterButtonProps } from './FilterButton';
 
 export { FilterButtonGroup } from './FilterButtonGroup';
@@ -290,7 +294,7 @@ export type { BannerAlertProps } from './BannerAlert';
 export { SectionHeader } from './SectionHeader';
 export type { SectionHeaderProps } from './SectionHeader';
 
-export { SegmentedControl } from './SegmentedControl';
+export { SegmentedControl, SegmentedControlSize } from './SegmentedControl';
 export type { SegmentedControlProps } from './SegmentedControl';
 
 export { Switch } from './Switch';

--- a/packages/design-system-shared/src/contexts/FilterButtonGroup/FilterButtonGroup.context.test.ts
+++ b/packages/design-system-shared/src/contexts/FilterButtonGroup/FilterButtonGroup.context.test.ts
@@ -1,8 +1,10 @@
 import { createElement, useContext } from 'react';
 import { act, create } from 'react-test-renderer';
 
-import { ButtonBaseSize } from '../../types/ButtonBase/ButtonBase.types';
-import { FilterButtonVariant } from '../../types/FilterButton/FilterButton.types';
+import {
+  FilterButtonSize,
+  FilterButtonVariant,
+} from '../../types/FilterButton/FilterButton.types';
 
 import type { FilterButtonGroupContextValue } from '.';
 import { FilterButtonGroupContext } from '.';
@@ -105,7 +107,7 @@ describe('FilterButtonGroupContext', () => {
       const providerValue: FilterButtonGroupContextValue = {
         value: 'a',
         onChange: jest.fn(),
-        size: ButtonBaseSize.Md,
+        size: FilterButtonSize.Md,
         isEqualWidth: true,
       };
 

--- a/packages/design-system-shared/src/contexts/FilterButtonGroup/FilterButtonGroup.context.ts
+++ b/packages/design-system-shared/src/contexts/FilterButtonGroup/FilterButtonGroup.context.ts
@@ -1,13 +1,15 @@
 import { createContext } from 'react';
 
-import type { ButtonBaseSize } from '../../types/ButtonBase/ButtonBase.types';
-import type { FilterButtonVariant } from '../../types/FilterButton/FilterButton.types';
+import type {
+  FilterButtonSize,
+  FilterButtonVariant,
+} from '../../types/FilterButton/FilterButton.types';
 
 export type FilterButtonGroupContextValue = {
   value: string;
   onChange: (nextValue: string) => void;
   variant?: FilterButtonVariant;
-  size?: ButtonBaseSize;
+  size?: FilterButtonSize;
   isEqualWidth?: boolean;
 };
 

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -230,6 +230,7 @@ export {
 
 // FilterButton types (ADR-0003 + ADR-0004)
 export {
+  FilterButtonSize,
   FilterButtonVariant,
   type FilterButtonPropsShared,
 } from './types/FilterButton';
@@ -238,7 +239,10 @@ export {
 export { type FilterButtonGroupPropsShared } from './types/FilterButtonGroup';
 
 // SegmentedControl types (ADR-0004)
-export { type SegmentedControlPropsShared } from './types/SegmentedControl';
+export {
+  SegmentedControlSize,
+  type SegmentedControlPropsShared,
+} from './types/SegmentedControl';
 
 // Switch types (ADR-0004)
 export { type SwitchPropsShared } from './types/Switch';

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -110,6 +110,7 @@ export { type ButtonFilterPropsShared } from './types/ButtonFilter';
 export {
   ButtonBaseSize,
   ButtonHeroSize,
+  ButtonSemanticSize,
   ButtonSize,
   type ButtonBasePropsShared,
 } from './types/ButtonBase';

--- a/packages/design-system-shared/src/types/ButtonBase/ButtonBase.types.ts
+++ b/packages/design-system-shared/src/types/ButtonBase/ButtonBase.types.ts
@@ -25,6 +25,9 @@ export type ButtonSize = ButtonBaseSize;
 export const ButtonHeroSize = ButtonBaseSize;
 export type ButtonHeroSize = ButtonBaseSize;
 
+export const ButtonSemanticSize = ButtonBaseSize;
+export type ButtonSemanticSize = ButtonBaseSize;
+
 /**
  * ButtonBase component shared props (ADR-0004)
  * Platform-independent properties shared across React and React Native

--- a/packages/design-system-shared/src/types/ButtonBase/index.ts
+++ b/packages/design-system-shared/src/types/ButtonBase/index.ts
@@ -1,6 +1,7 @@
 export {
   ButtonBaseSize,
   ButtonHeroSize,
+  ButtonSemanticSize,
   ButtonSize,
   type ButtonBasePropsShared,
 } from './ButtonBase.types';

--- a/packages/design-system-shared/src/types/FilterButton/FilterButton.types.ts
+++ b/packages/design-system-shared/src/types/FilterButton/FilterButton.types.ts
@@ -1,3 +1,12 @@
+import { ButtonBaseSize } from '../ButtonBase/ButtonBase.types';
+
+/**
+ * FilterButton size options (ADR-0003).
+ * Alias to ButtonBaseSize to keep values in sync.
+ */
+export const FilterButtonSize = ButtonBaseSize;
+export type FilterButtonSize = ButtonBaseSize;
+
 /**
  * FilterButton visual variant (ADR-0003).
  * Maps to combinations of ButtonPrimary / ButtonSecondary / ButtonTertiary presentation with `isSelected`.

--- a/packages/design-system-shared/src/types/FilterButton/index.ts
+++ b/packages/design-system-shared/src/types/FilterButton/index.ts
@@ -1,4 +1,5 @@
 export {
+  FilterButtonSize,
   FilterButtonVariant,
   type FilterButtonPropsShared,
 } from './FilterButton.types';

--- a/packages/design-system-shared/src/types/SegmentedControl/SegmentedControl.types.ts
+++ b/packages/design-system-shared/src/types/SegmentedControl/SegmentedControl.types.ts
@@ -1,4 +1,11 @@
-import type { ButtonBaseSize } from '../ButtonBase/ButtonBase.types';
+import { ButtonBaseSize } from '../ButtonBase/ButtonBase.types';
+
+/**
+ * SegmentedControl size options (ADR-0003).
+ * Alias to ButtonBaseSize to keep values in sync.
+ */
+export const SegmentedControlSize = ButtonBaseSize;
+export type SegmentedControlSize = ButtonBaseSize;
 
 /**
  * SegmentedControl component shared props (ADR-0004).
@@ -16,9 +23,9 @@ export type SegmentedControlPropsShared = {
   /**
    * Size of the control and child filter buttons.
    *
-   * @default ButtonBaseSize.Sm
+   * @default SegmentedControlSize.Sm
    */
-  size?: ButtonBaseSize;
+  size?: SegmentedControlSize;
   /**
    * When true, the control stretches to the width of its parent and segments share equal width.
    *

--- a/packages/design-system-shared/src/types/SegmentedControl/index.ts
+++ b/packages/design-system-shared/src/types/SegmentedControl/index.ts
@@ -1,1 +1,4 @@
-export { type SegmentedControlPropsShared } from './SegmentedControl.types';
+export {
+  SegmentedControlSize,
+  type SegmentedControlPropsShared,
+} from './SegmentedControl.types';


### PR DESCRIPTION
## **Description**

Recent React Native components (`FilterButton`, `SegmentedControl`) exposed `size` using the underlying `ButtonBaseSize` type rather than component-scoped const objects. That breaks the established consumer pattern used across the design system:

```tsx
// Established pattern (Button, SelectButton, AvatarNetwork, etc.)
<Button size={ButtonSize.Md} />
<SelectButton size={SelectButtonSize.Sm} />

// What we shipped (requires internal knowledge)
<SegmentedControl size={ButtonBaseSize.Sm} />
<FilterButton size={ButtonBaseSize.Md} />

// Also confusing — works at runtime but wrong namespace
<SegmentedControl size={ButtonSize.Md} />
```

This PR restores consistency by adding **component-scoped size aliases** in `@metamask/design-system-shared`, matching the existing `SelectButtonSize` pattern, and documents the convention in agent rules so future components follow the same approach.

| Component | Export | Aliases |
|-----------|--------|---------|
| `FilterButton` | `FilterButtonSize` | `ButtonBaseSize` |
| `SegmentedControl` | `SegmentedControlSize` | `ButtonBaseSize` |
| `ButtonSemantic` | `ButtonSemanticSize` | `ButtonBaseSize` |

### Changes

- **`design-system-shared`**
  - Add `FilterButtonSize`, `SegmentedControlSize`, and `ButtonSemanticSize` const objects (ADR-0003) aliasing `ButtonBaseSize`
  - Type `SegmentedControlPropsShared.size` as `SegmentedControlSize`
  - Type `FilterButtonGroupContextValue.size` as `FilterButtonSize`
  - Export all scoped size aliases from package root
- **`design-system-react-native`**
  - Export scoped size consts from component barrels and package index
  - Update `FilterButton`, `SegmentedControl`, and `ButtonSemantic` implementation, stories, tests, and Figma Code Connect to use component-scoped sizes
  - Align consumer READMEs (`Button`, `Content`, `FilterButton`, `SegmentedControl`, `ButtonSemantic`) to document scoped exports instead of `ButtonBaseSize`
- **Agent rules (`.cursor/rules/`)**
  - Add **Component-Scoped Prop Const Objects** guidance to `component-architecture.md` (naming, aliasing, avatar/button-scale tables, anti-patterns)
  - Update `component-creation.md`, `component-migration.md`, `component-enum-union-migration.md`, `component-documentation.md`, and `figma-integration.md` with checklists and examples for scoped const exports

### Backwards compatibility

No breaking changes. `ButtonBaseSize` values remain identical (`'sm' | 'md' | 'lg'`). Existing code using `ButtonBaseSize` or `ButtonSize` continues to compile and behave the same.

### Follow-up (team discussion)

We may eventually migrate all components to plain string union props (e.g. `size="md"`) per ADR-0003 direction, but that should be an explicit, communicated API change. Until then, new components should continue exporting `ComponentName + PropName` const objects for discoverability and consistency.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Pull branch and run `yarn build`
2. Run `yarn workspace @metamask/design-system-react-native run test --testPathPattern="SegmentedControl|FilterButton|ButtonSemantic"`
3. Run `yarn workspace @metamask/design-system-shared run test --testPathPattern="FilterButtonGroup.context"`
4. Open React Native Storybook and verify **SegmentedControl → Size** and **ButtonSemantic → Size** story controls still work
5. Confirm TypeScript autocomplete suggests `SegmentedControlSize`, `FilterButtonSize`, and `ButtonSemanticSize` when importing from `@metamask/design-system-react-native`

## **Screenshots/Recordings**

### **Before**

<img width="1110" height="748" alt="Screenshot 2026-06-29 at 9 45 47 AM" src="https://github.com/user-attachments/assets/18337cbd-6c4a-4bd3-b06d-06368500126a" />

### **After**

<img width="1111" height="839" alt="Screenshot 2026-06-29 at 2 44 32 PM" src="https://github.com/user-attachments/assets/7b3127f3-c00a-4b15-9224-5c3b274037e4" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive type aliases and internal import swaps with no API value changes; existing ButtonBaseSize usage remains valid.
> 
> **Overview**
> Adds **component-scoped size const objects** (`FilterButtonSize`, `SegmentedControlSize`, `ButtonSemanticSize`) in `@metamask/design-system-shared`, each aliasing `ButtonBaseSize` like existing `SelectButtonSize`, and wires shared types (`SegmentedControlPropsShared.size`, `FilterButtonGroupContextValue.size`) to those scoped types instead of `ButtonBaseSize`.
> 
> React Native **FilterButton**, **SegmentedControl**, and **ButtonSemantic** now default, implement, test, story, Figma Code Connect, and README examples against the scoped exports; package and component barrels re-export them. Consumer docs for **Button** and **Content** switch from `ButtonBaseSize` to `ButtonSize`. A new **FilterButton** Size story and README `size` section document the scale.
> 
> **`.cursor/rules/`** gains a **Component-Scoped Prop Const Objects** section in `component-architecture.md` (naming, aliasing, anti-patterns) and aligned checklists/examples across creation, migration, enum migration, documentation, and Figma integration rules.
> 
> No runtime or string-value break: `'sm' | 'md' | 'lg'` unchanged; `ButtonBaseSize` / `ButtonSize` still work at call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c215692d37e76423d9458e7819787e4e49b8aa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->