### PR TITLE
fix(dsrn): move SectionHeader children below header row

### DIFF
--- a/packages/design-system-react-native/src/components/SectionHeader/README.md
+++ b/packages/design-system-react-native/src/components/SectionHeader/README.md
@@ -26,7 +26,7 @@ import { SectionHeader } from '@metamask/design-system-react-native';
 
 ### `titleAccessory`
 
-Optional node to the right of `title` in the inner row. Only visible when `title` is renderable.
+Optional node to the right of `title` in the **inner** title row. Only visible when `title` is renderable. Use for metadata or actions tied to the title itself (for example an info icon beside "Tokens"). **Do not** use for trailing row icons such as chevrons or navigation arrows; use `endIconName` / `endIconProps` or `endAccessory` on the **outer** header row instead.
 
 | TYPE        | REQUIRED | DEFAULT     |
 | ----------- | -------- | ----------- |
@@ -48,7 +48,7 @@ import {
 
 ### `children`
 
-Optional content rendered below the title row in the middle column, between `startAccessory` / `startIconName` and `endAccessory` / `endIconName`. Use for subtitles or other supporting content.
+Optional full-width content rendered below the header row. Use for subtitles or other supporting content.
 
 | TYPE        | REQUIRED | DEFAULT     |
 | ----------- | -------- | ----------- |
@@ -69,9 +69,37 @@ import {
 </SectionHeader>;
 ```
 
+## Accessory slots
+
+`SectionHeader` has two horizontal rows of concern:
+
+| Slot                 | Props                                                              | Use for                                                                   |
+| -------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| **Inner title row**  | `titleAccessory`                                                   | Inline metadata beside the title (info icon, badge, short label)          |
+| **Outer header row** | `startIconName` / `startAccessory`, `endIconName` / `endAccessory` | Leading avatars or icons; trailing chevrons, actions, or custom end nodes |
+
+When implementing designs or stories, map Figma trailing chevrons (`>`, `ArrowRight`) to `endIconName` (and `endIconProps`), not `titleAccessory`—even when the chevron appears visually close to the title.
+
+```tsx
+// Correct — trailing chevron on the outer row
+<SectionHeader
+  title="How it works"
+  endIconName={IconName.ArrowRight}
+  endIconProps={{ size: IconSize.Sm }}
+/>
+
+// Incorrect — chevron belongs on the outer row, not the title row
+<SectionHeader
+  title="How it works"
+  titleAccessory={<Icon name={IconName.ArrowRight} size={IconSize.Sm} />}
+/>
+```
+
+See the `Children` Storybook story for a title + description + trailing chevron example.
+
 ### `startIconName`
 
-Optional icon name for the start of the **outer** row. When set, an `Icon` is rendered instead of `startAccessory`. The icon defaults to `IconSize.Md` and `IconColor.IconDefault`; override with `startIconProps`.
+Optional icon name for the start of the **outer** row. When set, an `Icon` is rendered instead of `startAccessory`. The icon defaults to `IconSize.Sm` and `IconColor.IconDefault`; override with `startIconProps`.
 
 | TYPE       | REQUIRED | DEFAULT     |
 | ---------- | -------- | ----------- |
@@ -85,7 +113,7 @@ import { SectionHeader, IconName } from '@metamask/design-system-react-native';
 
 ### `endIconName`
 
-Optional icon name for the end of the **outer** row. When set, an `Icon` is rendered instead of `endAccessory`. The icon defaults to `IconSize.Md` and `IconColor.IconAlternative`; override with `endIconProps`.
+Optional icon name for the end of the **outer** header row. When set, an `Icon` is rendered instead of `endAccessory`. The icon defaults to `IconSize.Sm` and `IconColor.IconAlternative`; override with `endIconProps`. Use for trailing chevrons, disclosure arrows, and other row-level affordances (including beside titles like "How it works"). **Do not** place these icons in `titleAccessory`.
 
 | TYPE       | REQUIRED | DEFAULT     |
 | ---------- | -------- | ----------- |

--- a/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.stories.tsx
+++ b/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.stories.tsx
@@ -1,5 +1,4 @@
 import {
-  FontWeight,
   IconColor,
   IconName,
   IconSize,
@@ -115,15 +114,21 @@ export const TitleAccessory: Story = {
 
 export const Children: Story = {
   render: () => (
-    <SectionHeader title="Tokens">
-      <Text
-        variant={TextVariant.BodySm}
-        color={TextColor.TextAlternative}
-        fontWeight={FontWeight.Medium}
+    <Box twClassName="w-full bg-background-default">
+      <SectionHeader
+        title="How it works"
+        endIconName={IconName.ArrowRight}
       >
-        12 assets
-      </Text>
-    </SectionHeader>
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          Add mUSD and earn up to{' '}
+          <Text variant={TextVariant.BodySm} color={TextColor.SuccessDefault}>
+            4% APY
+          </Text>{' '}
+          (variable). Your balance is dollar-backed and ready to spend, trade,
+          or send anytime.
+        </Text>
+      </SectionHeader>
+    </Box>
   ),
 };
 

--- a/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.stories.tsx
+++ b/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.stories.tsx
@@ -115,10 +115,7 @@ export const TitleAccessory: Story = {
 export const Children: Story = {
   render: () => (
     <Box twClassName="w-full bg-background-default">
-      <SectionHeader
-        title="How it works"
-        endIconName={IconName.ArrowRight}
-      >
+      <SectionHeader title="How it works" endIconName={IconName.ArrowRight}>
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           Add mUSD and earn up to{' '}
           <Text variant={TextVariant.BodySm} color={TextColor.SuccessDefault}>

--- a/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.test.tsx
@@ -76,6 +76,43 @@ describe('SectionHeader', () => {
     return styleFn;
   };
 
+  const countDirectChildInstances = (instance: ReactTestInstance): number =>
+    instance.children.filter(
+      (child) =>
+        typeof child === 'object' && child !== null && 'props' in child,
+    ).length;
+
+  const findInstanceWithStyle = (
+    instance: ReactTestInstance,
+    expectedStyle: ReturnType<ReturnType<typeof useTailwind>>,
+  ): ReactTestInstance | null => {
+    const styles = flattenStyles(instance.props.style);
+
+    if (
+      styles.some((item) =>
+        Object.entries(expectedStyle as ViewStyle).every(
+          ([key, value]) => item[key as keyof ViewStyle] === value,
+        ),
+      )
+    ) {
+      return instance;
+    }
+
+    for (const child of instance.children) {
+      if (typeof child === 'object' && child !== null && 'props' in child) {
+        const found = findInstanceWithStyle(
+          child as ReactTestInstance,
+          expectedStyle,
+        );
+        if (found) {
+          return found;
+        }
+      }
+    }
+
+    return null;
+  };
+
   describe('rendering', () => {
     it('renders string title', () => {
       const { getByText } = render(<SectionHeader title="Assets" />);
@@ -134,7 +171,7 @@ describe('SectionHeader', () => {
       expect(getByTestId('section-header-title-acc')).toBeOnTheScreen();
     });
 
-    it('renders children below the title row', () => {
+    it('renders children below the header row', () => {
       const { getByText, getByTestId } = render(
         <SectionHeader title="Section">
           <Text testID={CHILDREN_TEST_ID}>Subtitle</Text>
@@ -143,6 +180,27 @@ describe('SectionHeader', () => {
 
       expect(getByText('Section')).toBeOnTheScreen();
       expect(getByTestId(CHILDREN_TEST_ID)).toBeOnTheScreen();
+    });
+
+    it('uses a vertical outer wrapper when children are provided', () => {
+      const { getByTestId } = render(
+        <SectionHeader title="Section" testID={ROOT_TEST_ID}>
+          <Text testID={CHILDREN_TEST_ID}>Subtitle</Text>
+        </SectionHeader>,
+      );
+
+      const rootInstance = getByTestId(ROOT_TEST_ID);
+
+      expect(rootInstance).not.toHaveStyle(tw`flex-row`);
+      expect(countDirectChildInstances(rootInstance)).toBe(2);
+    });
+
+    it('uses a horizontal outer wrapper when children are omitted', () => {
+      const { getByTestId } = render(
+        <SectionHeader title="Section" testID={ROOT_TEST_ID} />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`flex-row`);
     });
 
     it('renders children when title is an empty string', () => {
@@ -155,7 +213,7 @@ describe('SectionHeader', () => {
       expect(getByTestId(CHILDREN_TEST_ID)).toBeOnTheScreen();
     });
 
-    it('renders children between start and end accessories', () => {
+    it('renders children with start and end accessories', () => {
       const { getByTestId } = render(
         <SectionHeader
           title="Section"
@@ -303,6 +361,30 @@ describe('SectionHeader', () => {
       expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`gap-1`);
       expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`px-4 pb-2 pt-3`);
       expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw`mt-4`);
+    });
+
+    it('applies shrink and min-w-0 to mainContent when row accessories are present', () => {
+      const tree = createRenderer(
+        <SectionHeader title="Section" endIconName={IconName.ArrowRight} />,
+      );
+
+      expect(
+        findInstanceWithStyle(tree.root, tw`shrink min-w-0`),
+      ).not.toBeNull();
+    });
+
+    it('applies w-full shrink and min-w-0 to the title row when row accessories are present', () => {
+      const { getByTestId } = render(
+        <SectionHeader
+          title="Section"
+          endIconName={IconName.ArrowRight}
+          titleWrapperProps={{ testID: TITLE_ROW_TEST_ID }}
+        />,
+      );
+
+      expect(getByTestId(TITLE_ROW_TEST_ID)).toHaveStyle(tw`w-full`);
+      expect(getByTestId(TITLE_ROW_TEST_ID)).toHaveStyle(tw`shrink`);
+      expect(getByTestId(TITLE_ROW_TEST_ID)).toHaveStyle(tw`min-w-0`);
     });
   });
 

--- a/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.test.tsx
@@ -369,7 +369,7 @@ describe('SectionHeader', () => {
       );
 
       expect(
-        findInstanceWithStyle(tree.root, tw`shrink min-w-0`),
+        findInstanceWithStyle(tree.root, tw`min-w-0 shrink`),
       ).not.toBeNull();
     });
 
@@ -385,6 +385,21 @@ describe('SectionHeader', () => {
       expect(getByTestId(TITLE_ROW_TEST_ID)).toHaveStyle(tw`w-full`);
       expect(getByTestId(TITLE_ROW_TEST_ID)).toHaveStyle(tw`shrink`);
       expect(getByTestId(TITLE_ROW_TEST_ID)).toHaveStyle(tw`min-w-0`);
+    });
+
+    it('merges titleWrapperProps twClassName when row accessories are absent', () => {
+      const { getByTestId } = render(
+        <SectionHeader
+          title="Section"
+          titleWrapperProps={{
+            testID: TITLE_ROW_TEST_ID,
+            twClassName: 'mt-4',
+          }}
+        />,
+      );
+
+      expect(getByTestId(TITLE_ROW_TEST_ID)).toHaveStyle(tw`mt-4`);
+      expect(getByTestId(TITLE_ROW_TEST_ID)).not.toHaveStyle(tw`w-full`);
     });
   });
 

--- a/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.tsx
+++ b/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.tsx
@@ -23,15 +23,15 @@ import type { SectionHeaderProps } from './SectionHeader.types';
  *
  * @param sectionHeaderProps - Component props
  * @param sectionHeaderProps.title - Title content for the inner row (required)
- * @param sectionHeaderProps.titleAccessory - Optional node to the right of `title` in the inner row
- * @param sectionHeaderProps.children - Optional content below the title row in the middle column, between start and end accessories
+ * @param sectionHeaderProps.titleAccessory - Optional inline metadata beside `title` in the inner row (not for trailing chevrons; use `endIconName` / `endIconProps`)
+ * @param sectionHeaderProps.children - Optional full-width content below the header row
  * @param sectionHeaderProps.titleProps - Optional props merged into inner row `Text` when `title` is a string
  * @param sectionHeaderProps.titleWrapperProps - Optional props spread onto the inner `BoxRow`
  * @param sectionHeaderProps.startAccessory - Optional custom node before the title row on the outer row; used when no start icon is resolved
  * @param sectionHeaderProps.startIconName - Optional start icon; takes precedence over `startAccessory` when set
  * @param sectionHeaderProps.startIconProps - Props merged into the start `Icon` (defaults include medium size and default icon color)
  * @param sectionHeaderProps.endAccessory - Optional custom node after the title row on the outer row; used when no end icon is resolved
- * @param sectionHeaderProps.endIconName - Optional end icon; takes precedence over `endAccessory` when set. Defaults to `IconName.ArrowRight` when `isInteractive` is `true` and no end icon or `endAccessory` is provided
+ * @param sectionHeaderProps.endIconName - Optional end icon on the outer header row (trailing chevrons, disclosure arrows); takes precedence over `endAccessory` when set. Defaults to `IconName.ArrowRight` when `isInteractive` is `true` and no end icon or `endAccessory` is provided
  * @param sectionHeaderProps.endIconProps - Props merged into the end `Icon`
  * @param sectionHeaderProps.isInteractive - When `true`, wraps the header in a `Pressable` with reduced opacity on press
  * @param sectionHeaderProps.style - Optional style on the outer wrapper (`View` or `Pressable` style, including function form when interactive)
@@ -67,7 +67,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = (
 
   const resolvedStartAccessory = startIconName ? (
     <Icon
-      size={IconSize.Md}
+      size={IconSize.Sm}
       color={IconColor.IconDefault}
       twClassName="shrink-0"
       {...startIconProps}
@@ -79,7 +79,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = (
 
   const resolvedEndAccessory = resolvedEndIconName ? (
     <Icon
-      size={IconSize.Md}
+      size={IconSize.Sm}
       color={IconColor.IconAlternative}
       twClassName="shrink-0"
       {...endIconProps}
@@ -89,11 +89,18 @@ export const SectionHeader: React.FC<SectionHeaderProps> = (
     endAccessory
   );
 
+  const hasAccessories =
+    Boolean(resolvedStartAccessory) || Boolean(resolvedEndAccessory);
+
   const titleRow = title ? (
     <BoxRow
       {...titleWrapperProps}
       gap={1}
       endAccessory={titleAccessory}
+      twClassName={mergeTwClassName(
+        hasAccessories && 'w-full shrink min-w-0',
+        titleWrapperProps?.twClassName,
+      )}
       textProps={{
         variant: TextVariant.HeadingMd,
         color: TextColor.TextDefault,
@@ -104,16 +111,32 @@ export const SectionHeader: React.FC<SectionHeaderProps> = (
     </BoxRow>
   ) : null;
 
-  const hasAccessories =
-    Boolean(resolvedStartAccessory) || Boolean(resolvedEndAccessory);
+  const mainContent = titleRow ? (
+    hasAccessories ? (
+      <Box twClassName="shrink min-w-0">{titleRow}</Box>
+    ) : (
+      titleRow
+    )
+  ) : null;
 
-  const mainContent =
-    titleRow || children ? (
-      <Box gap={1} twClassName={hasAccessories ? 'flex-1 min-w-0' : undefined}>
-        {titleRow}
-        {children}
-      </Box>
-    ) : null;
+  const headerRow = (
+    <BoxRow
+      gap={1}
+      startAccessory={resolvedStartAccessory}
+      endAccessory={resolvedEndAccessory}
+    >
+      {mainContent}
+    </BoxRow>
+  );
+
+  const body = children ? (
+    <Box gap={1}>
+      {headerRow}
+      {children}
+    </Box>
+  ) : (
+    headerRow
+  );
 
   if (isInteractive) {
     const { disabled, accessibilityRole = 'button' } = sectionHeaderProps;
@@ -135,14 +158,22 @@ export const SectionHeader: React.FC<SectionHeaderProps> = (
         }}
         {...props}
       >
-        <BoxRow
-          gap={1}
-          startAccessory={resolvedStartAccessory}
-          endAccessory={resolvedEndAccessory}
-        >
-          {mainContent}
-        </BoxRow>
+        {body}
       </Pressable>
+    );
+  }
+
+  if (children) {
+    return (
+      <Box
+        {...props}
+        gap={1}
+        style={style}
+        twClassName={mergeTwClassName('px-4 pb-2 pt-3', twClassName)}
+      >
+        {headerRow}
+        {children}
+      </Box>
     );
   }
 

--- a/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.tsx
+++ b/packages/design-system-react-native/src/components/SectionHeader/SectionHeader.tsx
@@ -98,7 +98,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = (
       gap={1}
       endAccessory={titleAccessory}
       twClassName={mergeTwClassName(
-        hasAccessories && 'w-full shrink min-w-0',
+        hasAccessories ? 'w-full shrink min-w-0' : '',
         titleWrapperProps?.twClassName,
       )}
       textProps={{
@@ -111,13 +111,14 @@ export const SectionHeader: React.FC<SectionHeaderProps> = (
     </BoxRow>
   ) : null;
 
-  const mainContent = titleRow ? (
-    hasAccessories ? (
+  let mainContent = null;
+  if (titleRow) {
+    mainContent = hasAccessories ? (
       <Box twClassName="shrink min-w-0">{titleRow}</Box>
     ) : (
       titleRow
-    )
-  ) : null;
+    );
+  }
 
   const headerRow = (
     <BoxRow

--- a/packages/design-system-shared/src/types/SectionHeader/SectionHeader.types.ts
+++ b/packages/design-system-shared/src/types/SectionHeader/SectionHeader.types.ts
@@ -14,13 +14,14 @@ export type SectionHeaderPropsShared = {
    */
   title: ReactNode;
   /**
-   * Optional accessory rendered inline to the right of `title` in the title row.
+   * Optional accessory rendered inline to the right of `title` in the inner title row.
    * Only shown when the title row is shown (i.e. when `title` is renderable).
+   * Use for title-adjacent metadata (e.g. info icon). Do not use for trailing row chevrons or
+   * navigation arrows — use `endIconName` / `endIconProps` or `endAccessory` on the outer header row.
    */
   titleAccessory?: ReactNode;
   /**
-   * Optional content rendered below the title row in the middle column,
-   * between start and end accessories.
+   * Optional full-width content rendered below the header row.
    */
   children?: ReactNode;
   /**
@@ -37,8 +38,9 @@ export type SectionHeaderPropsShared = {
    */
   startIconName?: IconName;
   /**
-   * Optional icon name for the end of the header row.
+   * Optional icon name for the end of the outer header row.
    * When set (or implied via `endIconProps.name`), renders an icon instead of `endAccessory`.
+   * Use for trailing chevrons and row-level affordances; do not use `titleAccessory` for these.
    */
   endIconName?: IconName;
 };


### PR DESCRIPTION
## **Description**

Updates `SectionHeader` (React Native) so `children` render full-width below the header row, and fixes long-title overflow beside row accessories.

**Why**
- `children` previously rendered inside the middle column (under the title, between start/end accessories). Designs like "How it works" + description expect supporting copy to span the full header width.
- Long titles with an `endIconName` chevron could wrap under the icon because the title column lacked shrink constraints.

**What changed**
- **Layout:** `children` now render below the full header row (`title` + start/end accessories), not inside `mainContent`.
- **Overflow:** When row accessories are present, `mainContent` uses `shrink min-w-0` (not `flex-1`) so titles wrap before the end icon without pushing the chevron to the far edge on short titles.
- **Icons:** Default start/end icon size changed from `Md` to `Sm`.
- **Docs:** Added an "Accessory slots" section clarifying `titleAccessory` vs `endIconName` / `endIconProps` (trailing chevrons belong on the outer row).
- **Storybook:** Updated the `Children` story to match the "How it works" design.
- **Tests:** Added/updated layout tests for the new wrapper behavior and shrink styles.

**Breaking change (visual):** When `children` are used with start/end accessories, supporting content now spans full width instead of aligning only under the title column.

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Run React Native Storybook: `yarn storybook:ios` (or `yarn storybook:android`).
2. Open **Components/SectionHeader/Children** and confirm:
   - Title + trailing chevron on the header row
   - Description full-width below the header
   - `4% APY` highlighted in success green
3. In the same story, temporarily use a very long title and confirm wrapped lines respect space beside the chevron (no text running under the icon).
4. Open **Components/SectionHeader/TitleAccessory** and confirm info icons still render inline beside the title.
5. Open **Components/SectionHeader/Interactive** and confirm press behavior and default `ArrowRight` end icon still work.
6. Run unit tests: `yarn workspace @metamask/design-system-react-native run jest SectionHeader`

## **Screenshots/Recordings**

### **Before**

<img width="2108" height="688" alt="image" src="https://github.com/user-attachments/assets/9afef0b6-40c2-4c47-8f76-5b0fcd0d013c" />


### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-29 at 09 48 23" src="https://github.com/user-attachments/assets/23f1a5bb-3e7f-4a02-a902-6196e3ce3645" />

Overflow behavior
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-29 at 09 48 08" src="https://github.com/user-attachments/assets/fa04f1db-d47c-4140-bb71-7e729d856389" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Layout and default icon sizing are visual breaking changes for any screen using SectionHeader with children or row icons; scope is limited to the design-system component and its tests/docs.
> 
> **Overview**
> **`SectionHeader`** (React Native) now lays out **`children` full-width below the entire header row** (title plus start/end icons or accessories), instead of nesting them in the middle column under the title only. When **`children`** are present, the outer wrapper is a vertical **`Box`**; without them it stays a horizontal **`BoxRow`**.
> 
> **Overflow:** With row accessories, the title column uses **`shrink` / `min-w-0`** (and **`w-full`** on the inner title row) so long titles wrap beside a trailing chevron instead of under it; default start/end icon size changes from **`Md`** to **`Sm`**.
> 
> **Docs & examples:** README adds an **Accessory slots** table and guidance that trailing chevrons belong on **`endIconName`**, not **`titleAccessory`**; shared types and JSDoc match. Storybook **`Children`** story reflects the “How it works” pattern; tests cover vertical vs horizontal wrappers and shrink styles.
> 
> **Visual breaking change:** Headers with **`children`** and side accessories show supporting copy across the full width, not only under the title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a522350b4e06591cc4bfcde552938f4b217224e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->