### PR TITLE
Release 51.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "50.0.0",
+  "version": "51.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0]
+
 ### Uncategorized
 
 - feat: update BottomSheetDialog for pure-black elevated surface ([#1307](https://github.com/MetaMask/metamask-design-system/pull/1307))
@@ -562,7 +564,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.32.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.33.0...HEAD
+[0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.32.0...@metamask/design-system-react-native@0.33.0
 [0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.31.0...@metamask/design-system-react-native@0.32.0
 [0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.2...@metamask/design-system-react-native@0.31.0
 [0.30.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.1...@metamask/design-system-react-native@0.30.2

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,11 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.33.0]
 
-### Uncategorized
+### Changed
 
-- feat: update BottomSheetDialog for pure-black elevated surface ([#1307](https://github.com/MetaMask/metamask-design-system/pull/1307))
-- chore: upgrade Storybook to 10.4.6 across monorepo ([#1309](https://github.com/MetaMask/metamask-design-system/pull/1309))
-- chore: Add Code Connect for MainActionButton ([#1250](https://github.com/MetaMask/metamask-design-system/pull/1250))
+- Updated `BottomSheetDialog` to use `background.alternative` and pure-black shadow tokens when pure-black mode is active via `usePureBlack` from `@metamask/design-system-twrnc-preset` ([#1307](https://github.com/MetaMask/metamask-design-system/pull/1307))
 
 ## [0.32.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: update BottomSheetDialog for pure-black elevated surface ([#1307](https://github.com/MetaMask/metamask-design-system/pull/1307))
+- chore: upgrade Storybook to 10.4.6 across monorepo ([#1309](https://github.com/MetaMask/metamask-design-system/pull/1309))
+- chore: Add Code Connect for MainActionButton ([#1250](https://github.com/MetaMask/metamask-design-system/pull/1250))
+
 ## [0.32.0]
 
 ### Added

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",
@@ -91,7 +91,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-twrnc-preset": "^0.6.0",
+    "@metamask/design-system-twrnc-preset": "^0.7.0",
     "@metamask/design-tokens": "^8.2.0",
     "@metamask/utils": "^11.11.0",
     "lodash": "^4.17.21",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: make PureBlackProvider context-only for web ([#1312](https://github.com/MetaMask/metamask-design-system/pull/1312))
+- feat: update ModalContent for pure-black elevated surface ([#1308](https://github.com/MetaMask/metamask-design-system/pull/1308))
+- feat: add PureBlackProvider and wire Storybook preview ([#1305](https://github.com/MetaMask/metamask-design-system/pull/1305))
+
 ## [0.30.0]
 
 ### Added

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.31.0]
 
-### Uncategorized
+### Added
 
-- fix: make PureBlackProvider context-only for web ([#1312](https://github.com/MetaMask/metamask-design-system/pull/1312))
-- feat: update ModalContent for pure-black elevated surface ([#1308](https://github.com/MetaMask/metamask-design-system/pull/1308))
-- feat: add PureBlackProvider and wire Storybook preview ([#1305](https://github.com/MetaMask/metamask-design-system/pull/1305))
+- Added `PureBlackProvider` and `usePureBlack` for OLED pure-black dark mode; on web, CSS token overrides come from `data-pure-black` on the document root while the provider supplies context for component logic ([#1305](https://github.com/MetaMask/metamask-design-system/pull/1305), [#1312](https://github.com/MetaMask/metamask-design-system/pull/1312))
+
+### Changed
+
+- Updated `ModalContent` to use `background.alternative` for the dialog surface when pure-black mode is active, giving modals visible elevation on OLED black backgrounds ([#1308](https://github.com/MetaMask/metamask-design-system/pull/1308))
 
 ## [0.30.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0]
+
 ### Uncategorized
 
 - fix: make PureBlackProvider context-only for web ([#1312](https://github.com/MetaMask/metamask-design-system/pull/1312))
@@ -410,7 +412,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.30.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.31.0...HEAD
+[0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.30.0...@metamask/design-system-react@0.31.0
 [0.30.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.29.0...@metamask/design-system-react@0.30.0
 [0.29.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.28.0...@metamask/design-system-react@0.29.0
 [0.28.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.27.1...@metamask/design-system-react@0.28.0

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0]
+
 ### Uncategorized
 
 - feat: add pureBlackDarkTheme and shared PureBlack context ([#1300](https://github.com/MetaMask/metamask-design-system/pull/1300))
@@ -280,7 +282,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.26.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.27.0...HEAD
+[0.27.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.26.0...@metamask/design-system-shared@0.27.0
 [0.26.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.25.0...@metamask/design-system-shared@0.26.0
 [0.25.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.24.0...@metamask/design-system-shared@0.25.0
 [0.24.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.23.0...@metamask/design-system-shared@0.24.0

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add pureBlackDarkTheme and shared PureBlack context ([#1300](https://github.com/MetaMask/metamask-design-system/pull/1300))
+
 ## [0.26.0]
 
 ### Added

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.27.0]
 
-### Uncategorized
+### Added
 
-- feat: add pureBlackDarkTheme and shared PureBlack context ([#1300](https://github.com/MetaMask/metamask-design-system/pull/1300))
+- Added `PureBlackContext`, `PureBlackContextValue`, and `PureBlackProviderProps` for cross-platform pure-black dark mode state ([#1300](https://github.com/MetaMask/metamask-design-system/pull/1300))
 
 ## [0.26.0]
 

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0]
+
 ### Uncategorized
 
 - feat: add isPureBlack to TWRNC ThemeProvider and RN Storybook ([#1306](https://github.com/MetaMask/metamask-design-system/pull/1306))
@@ -77,7 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MetaMask design token integration for React Native
 - TWRNC preset configuration with MetaMask styling utilities
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.6.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.7.0...HEAD
+[0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.6.0...@metamask/design-system-twrnc-preset@0.7.0
 [0.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.5.0...@metamask/design-system-twrnc-preset@0.6.0
 [0.5.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.4.2...@metamask/design-system-twrnc-preset@0.5.0
 [0.4.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.4.1...@metamask/design-system-twrnc-preset@0.4.2

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0]
 
-### Uncategorized
+### Added
 
-- feat: add isPureBlack to TWRNC ThemeProvider and RN Storybook ([#1306](https://github.com/MetaMask/metamask-design-system/pull/1306))
+- Added `isPureBlack` prop to `ThemeProvider` and `usePureBlack` hook so React Native apps can apply `pureBlackDarkTheme` token values through twrnc classes ([#1306](https://github.com/MetaMask/metamask-design-system/pull/1306))
 
 ## [0.6.0]
 

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add isPureBlack to TWRNC ThemeProvider and RN Storybook ([#1306](https://github.com/MetaMask/metamask-design-system/pull/1306))
+
 ## [0.6.0]
 
 ### Changed

--- a/packages/design-system-twrnc-preset/package.json
+++ b/packages/design-system-twrnc-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-twrnc-preset",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Design System twrnc Preset",
   "keywords": [
     "MetaMask",

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,11 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.7.0]
 
-### Uncategorized
+### Added
 
-- fix: make PureBlackProvider context-only for web ([#1312](https://github.com/MetaMask/metamask-design-system/pull/1312))
-- feat: add PureBlackProvider and wire Storybook preview ([#1305](https://github.com/MetaMask/metamask-design-system/pull/1305))
-- feat: add pureBlackDarkTheme and shared PureBlack context ([#1300](https://github.com/MetaMask/metamask-design-system/pull/1300))
+- Added `pureBlackDarkTheme` and `resolveDarkTheme(isPureBlack)` for OLED pure-black dark mode token values ([#1300](https://github.com/MetaMask/metamask-design-system/pull/1300))
 
 ## [8.6.0]
 

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.7.0]
+
 ### Uncategorized
 
 - fix: make PureBlackProvider context-only for web ([#1312](https://github.com/MetaMask/metamask-design-system/pull/1312))
@@ -453,7 +455,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.6.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.7.0...HEAD
+[8.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.6.0...@metamask/design-tokens@8.7.0
 [8.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.5.0...@metamask/design-tokens@8.6.0
 [8.5.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.4.0...@metamask/design-tokens@8.5.0
 [8.4.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.3.0...@metamask/design-tokens@8.4.0

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: make PureBlackProvider context-only for web ([#1312](https://github.com/MetaMask/metamask-design-system/pull/1312))
+- feat: add PureBlackProvider and wire Storybook preview ([#1305](https://github.com/MetaMask/metamask-design-system/pull/1305))
+- feat: add pureBlackDarkTheme and shared PureBlack context ([#1300](https://github.com/MetaMask/metamask-design-system/pull/1300))
+
 ## [8.6.0]
 
 ### Changed

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,7 +3412,7 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-twrnc-preset": ^0.6.0
+    "@metamask/design-system-twrnc-preset": ^0.7.0
     "@metamask/design-tokens": ^8.2.0
     "@metamask/utils": ^11.11.0
     lodash: ^4.17.21


### PR DESCRIPTION
## Release 51.0.0

This release adds opt-in pure-black dark mode support across design tokens, shared context, React web, React Native, and the TWRNC preset. `ModalContent` and `BottomSheetDialog` now use elevated surfaces when pure-black mode is active. No breaking changes.

### 📦 Package Versions

- `@metamask/design-tokens`: **8.7.0**
- `@metamask/design-system-shared`: **0.27.0**
- `@metamask/design-system-react`: **0.31.0**
- `@metamask/design-system-react-native`: **0.33.0**
- `@metamask/design-system-twrnc-preset`: **0.7.0**

### 🔄 Shared Type Updates (0.27.0)

#### PureBlack context (#1300)

**What Changed:**

- Added `PureBlackContext`, `PureBlackContextValue`, and `PureBlackProviderProps` for cross-platform pure-black dark mode state

**Impact:**

- Enables React web `PureBlackProvider` and shared context wiring without platform-specific type duplication

### 🌐 React Web Updates (0.31.0)

#### Added

- Added `PureBlackProvider` and `usePureBlack` for OLED pure-black dark mode; on web, CSS token overrides come from `data-pure-black` on the document root while the provider supplies context for component logic ([#1305](https://github.com/MetaMask/metamask-design-system/pull/1305), [#1312](https://github.com/MetaMask/metamask-design-system/pull/1312))

#### Changed

- Updated `ModalContent` to use `background.alternative` for the dialog surface when pure-black mode is active, giving modals visible elevation on OLED black backgrounds ([#1308](https://github.com/MetaMask/metamask-design-system/pull/1308))

### 📱 React Native Updates (0.33.0)

#### Changed

- Updated `BottomSheetDialog` to use `background.alternative` and pure-black shadow tokens when pure-black mode is active via `usePureBlack` from `@metamask/design-system-twrnc-preset` ([#1307](https://github.com/MetaMask/metamask-design-system/pull/1307))

### 🎨 Design Tokens (8.7.0)

#### Added

- Added `pureBlackDarkTheme` and `resolveDarkTheme(isPureBlack)` for OLED pure-black dark mode token values ([#1300](https://github.com/MetaMask/metamask-design-system/pull/1300))

### 📱 TWRNC Preset (0.7.0)

#### Added

- Added `isPureBlack` prop to `ThemeProvider` and `usePureBlack` hook so React Native apps can apply `pureBlackDarkTheme` token values through twrnc classes ([#1306](https://github.com/MetaMask/metamask-design-system/pull/1306))

### ⚠️ Breaking Changes

None in this release.

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-tokens: minor (8.6.0 → 8.7.0) - new `pureBlackDarkTheme` export and `resolveDarkTheme` helper
  - [x] design-system-shared: minor (0.26.0 → 0.27.0) - new PureBlack context types
  - [x] design-system-react: minor (0.30.0 → 0.31.0) - new `PureBlackProvider` and `ModalContent` pure-black styling
  - [x] design-system-react-native: minor (0.32.0 → 0.33.0) - `BottomSheetDialog` pure-black elevated surface
  - [x] design-system-twrnc-preset: minor (0.6.0 → 0.7.0) - `isPureBlack` ThemeProvider prop and `usePureBlack` hook
- [x] Breaking changes documented with migration guidance (N/A — no breaking changes)
- [x] Migration guides updated with before/after examples (N/A — no breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

Made with [Cursor](https://cursor.com)