### PR TITLE
Release 52.0.0

### DIFF
--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -33,7 +33,7 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.3.0",
     "react-native-web": "^0.21.0",
-    "react-native-worklets": "patch:react-native-worklets@npm%3A0.8.3#~/.yarn/patches/react-native-worklets-npm-0.8.3-89f34099cb.patch"
+    "react-native-worklets": "0.8.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "51.0.0",
+  "version": "52.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(icons): add CandlestickFilled icon ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))
+- chore: migrate design system to reanimated 4 ([#1216](https://github.com/MetaMask/metamask-design-system/pull/1216))
+- chore: add Storybook testing for React Native web stories ([#1315](https://github.com/MetaMask/metamask-design-system/pull/1315))
+- fix: hosted react native Storybook cold-load error ([#1310](https://github.com/MetaMask/metamask-design-system/pull/1310))
+
 ## [0.33.0]
 
 ### Changed

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
+## [0.34.0]
 
-- feat(icons): add CandlestickFilled icon ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))
-- chore: migrate design system to reanimated 4 ([#1216](https://github.com/MetaMask/metamask-design-system/pull/1216))
-- chore: add Storybook testing for React Native web stories ([#1315](https://github.com/MetaMask/metamask-design-system/pull/1315))
-- fix: hosted react native Storybook cold-load error ([#1310](https://github.com/MetaMask/metamask-design-system/pull/1310))
+### Added
+
+- Added `CandlestickFilled` to `IconName` ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))
+
+### Changed
+
+- **BREAKING:** Updated peer dependencies to require React Native Reanimated 4 and `react-native-worklets`; Reanimated 3 is no longer supported ([#1216](https://github.com/MetaMask/metamask-design-system/pull/1216))
+  - See [Migration Guide](./MIGRATION.md#reanimated-4-worklets-peer-dependencies)
 
 ## [0.33.0]
 
@@ -569,7 +573,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.33.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.34.0...HEAD
+[0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.33.0...@metamask/design-system-react-native@0.34.0
 [0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.32.0...@metamask/design-system-react-native@0.33.0
 [0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.31.0...@metamask/design-system-react-native@0.32.0
 [0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.30.2...@metamask/design-system-react-native@0.31.0

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -4,6 +4,7 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Table of Contents
 
+- [From version 0.33.0 to 0.34.0](#from-version-0330-to-0340)
 - [From version 0.29.0 to 0.30.0](#from-version-0290-to-0300)
 - [From version 0.28.0 to 0.29.0](#from-version-0280-to-0290)
 - [From version 0.27.0 to 0.28.0](#from-version-0270-to-0280)
@@ -63,6 +64,56 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Version Updates
 
+### From version 0.33.0 to 0.34.0
+
+<a id="from-version-0330-to-0340"></a>
+
+<a id="reanimated-4-worklets-peer-dependencies"></a>
+
+#### React Native Reanimated 4 and Worklets peer dependencies
+
+`@metamask/design-system-react-native` now requires **React Native Reanimated 4** and **`react-native-worklets`**. Reanimated 3 is no longer supported.
+
+**What changed:**
+
+| Before (0.33.0)                                       | After (0.34.0)                    |
+| ----------------------------------------------------- | --------------------------------- |
+| `react-native-reanimated >=3.17.0` (no worklets peer) | `react-native-reanimated >=4.2.0` |
+| —                                                     | `react-native-worklets >=0.7.4`   |
+
+**Migration:**
+
+Upgrade Reanimated and Worklets together in your app before bumping the design system. Match the versions bundled with your Expo SDK when using Expo Go, or use a dev build when your JS and native versions differ.
+
+| Expo SDK | `react-native-reanimated` | `react-native-worklets` |
+| -------- | ------------------------- | ----------------------- |
+| 54       | ~4.1.1                    | 0.5.1                   |
+| 55       | 4.2.1                     | 0.7.4                   |
+| 56       | 4.3.1                     | 0.8.3                   |
+
+1. Install compatible versions (example for Expo SDK 55 / MetaMask Mobile platform upgrade):
+
+   ```bash
+   npx expo install react-native-reanimated@~4.2.1 react-native-worklets@0.7.4
+   ```
+
+2. Update Babel to use the Worklets plugin (replace the Reanimated 3 plugin if present):
+
+   ```js
+   // babel.config.js
+   module.exports = {
+     plugins: ['react-native-worklets/plugin'],
+   };
+   ```
+
+3. Rebuild native apps after upgrading (required for Worklets native code).
+
+**Impact:**
+
+- Apps still on Reanimated 3 must complete the Reanimated 4 migration before upgrading to `@metamask/design-system-react-native` 0.34.0 or newer.
+- `BottomSheetDialog` and `Toaster` use `scheduleOnRN` from `react-native-worklets`; both packages must be present at runtime.
+- When using Expo Go, JS and native Worklets/Reanimated versions must match the SDK bundle — use a dev build if you need newer JS versions than Expo Go provides.
+
 ### From version 0.30.0 to 0.31.0
 
 <a id="titlealert-title-accessories-removed"></a>
@@ -117,52 +168,6 @@ If you import **`TitleAlertPropsShared`** from **`@metamask/design-system-shared
 **Impact:**
 
 - Any call site passing **`titleStartAccessory`** or **`titleEndAccessory`** on **`TitleAlert`** must be updated
-
-<a id="reanimated-4-worklets-peer-dependencies"></a>
-
-#### React Native Reanimated 4 and Worklets peer dependencies
-
-`@metamask/design-system-react-native` now requires **React Native Reanimated 4** and **`react-native-worklets`**. Reanimated 3 is no longer supported.
-
-**What changed:**
-
-| Before (0.x.0)                                        | After (0.x.0)                     |
-| ----------------------------------------------------- | --------------------------------- |
-| `react-native-reanimated >=3.17.0` (no worklets peer) | `react-native-reanimated >=4.2.0` |
-| —                                                     | `react-native-worklets >=0.7.4`   |
-
-**Migration:**
-
-Upgrade Reanimated and Worklets together in your app before bumping the design system. Match the versions bundled with your Expo SDK when using Expo Go, or use a dev build when your JS and native versions differ.
-
-| Expo SDK | `react-native-reanimated` | `react-native-worklets` |
-| -------- | ------------------------- | ----------------------- |
-| 54       | ~4.1.1                    | 0.5.1                   |
-| 55       | 4.2.1                     | 0.7.4                   |
-| 56       | 4.3.1                     | 0.8.3                   |
-
-1. Install compatible versions (example for Expo SDK 55 / MetaMask Mobile platform upgrade):
-
-   ```bash
-   npx expo install react-native-reanimated@~4.2.1 react-native-worklets@0.7.4
-   ```
-
-2. Update Babel to use the Worklets plugin (replace the Reanimated 3 plugin if present):
-
-   ```js
-   // babel.config.js
-   module.exports = {
-     plugins: ['react-native-worklets/plugin'],
-   };
-   ```
-
-3. Rebuild native apps after upgrading (required for Worklets native code).
-
-**Impact:**
-
-- Apps still on Reanimated 3 must complete the Reanimated 4 migration before upgrading to the next `@metamask/design-system-react-native` release that includes this change.
-- `BottomSheetDialog` and `Toaster` use `scheduleOnRN` from `react-native-worklets`; both packages must be present at runtime.
-- When using Expo Go, JS and native Worklets/Reanimated versions must match the SDK bundle — use a dev build if you need newer JS versions than Expo Go provides.
 
 ### From version 0.29.0 to 0.30.0
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",
@@ -81,7 +81,7 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-svg": "15.12.1",
     "react-native-svg-transformer": "^1.5.3",
-    "react-native-worklets": "patch:react-native-worklets@npm%3A0.8.3#~/.yarn/patches/react-native-worklets-npm-0.8.3-89f34099cb.patch",
+    "react-native-worklets": "0.8.3",
     "react-test-renderer": "19.1.0",
     "storybook": "10.4.6",
     "ts-jest": "^29.2.5",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(icons): add CandlestickFilled icon ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))
+- chore: re-enable Storybook test job in main workflow ([#1314](https://github.com/MetaMask/metamask-design-system/pull/1314))
+
 ## [0.31.0]
 
 ### Added

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
+## [0.32.0]
 
-- feat(icons): add CandlestickFilled icon ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))
-- chore: re-enable Storybook test job in main workflow ([#1314](https://github.com/MetaMask/metamask-design-system/pull/1314))
+### Added
+
+- Added `CandlestickFilled` to `IconName` ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))
 
 ## [0.31.0]
 
@@ -419,7 +420,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.31.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.32.0...HEAD
+[0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.31.0...@metamask/design-system-react@0.32.0
 [0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.30.0...@metamask/design-system-react@0.31.0
 [0.30.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.29.0...@metamask/design-system-react@0.30.0
 [0.29.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.28.0...@metamask/design-system-react@0.29.0

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(icons): add CandlestickFilled icon ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))
+
 ## [0.27.0]
 
 ### Added

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
+## [0.28.0]
 
-- feat(icons): add CandlestickFilled icon ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))
+### Added
+
+- Added `CandlestickFilled` to `IconName` ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))
 
 ## [0.27.0]
 
@@ -286,7 +288,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.27.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.28.0...HEAD
+[0.28.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.27.0...@metamask/design-system-shared@0.28.0
 [0.27.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.26.0...@metamask/design-system-shared@0.27.0
 [0.26.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.25.0...@metamask/design-system-shared@0.26.0
 [0.25.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.24.0...@metamask/design-system-shared@0.25.0

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3403,7 +3403,7 @@ __metadata:
     react-native-safe-area-context: "npm:~5.6.0"
     react-native-svg: "npm:15.12.1"
     react-native-svg-transformer: "npm:^1.5.3"
-    react-native-worklets: "patch:react-native-worklets@npm%3A0.8.3#~/.yarn/patches/react-native-worklets-npm-0.8.3-89f34099cb.patch"
+    react-native-worklets: "npm:0.8.3"
     react-test-renderer: "npm:19.1.0"
     storybook: "npm:10.4.6"
     ts-jest: "npm:^29.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3740,7 +3740,7 @@ __metadata:
     react-native-svg: "npm:15.12.1"
     react-native-svg-transformer: "npm:^1.5.3"
     react-native-web: "npm:^0.21.0"
-    react-native-worklets: "patch:react-native-worklets@npm%3A0.8.3#~/.yarn/patches/react-native-worklets-npm-0.8.3-89f34099cb.patch"
+    react-native-worklets: "npm:0.8.3"
     storybook: "npm:10.4.6"
     typescript: "npm:~5.2.2"
     vite: "npm:^8.0.14"


### PR DESCRIPTION
## Release 52.0.0

This release adds the `CandlestickFilled` icon across shared, React web, and React Native packages, and ships the React Native Reanimated 4 / Worklets peer dependency upgrade. React web has no breaking changes.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.28.0**
- `@metamask/design-system-react`: **0.32.0**
- `@metamask/design-system-react-native`: **0.34.0**

### 🔄 Shared Type Updates (0.28.0)

#### Icon additions (#1373)

**What Changed:**

- Added `CandlestickFilled` to `IconName`

**Impact:**

- Enables `CandlestickFilled` usage in React and React Native icon components

### 🌐 React Web Updates (0.32.0)

#### Added

- Added `CandlestickFilled` to `IconName` ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))

### 📱 React Native Updates (0.34.0)

#### Added

- Added `CandlestickFilled` to `IconName` ([#1373](https://github.com/MetaMask/metamask-design-system/pull/1373))

#### Changed

- **BREAKING:** Updated peer dependencies to require React Native Reanimated 4 and `react-native-worklets`; Reanimated 3 is no longer supported ([#1216](https://github.com/MetaMask/metamask-design-system/pull/1216))
  - `react-native-reanimated` peer range is now `>=4.2.0`
  - Added `react-native-worklets` peer dependency `>=0.7.4`
  - `BottomSheetDialog` and `Toaster` use `scheduleOnRN` from `react-native-worklets`
  - See [Migration Guide](./packages/design-system-react-native/MIGRATION.md#reanimated-4-worklets-peer-dependencies)

### ⚠️ Breaking Changes

#### React Native Reanimated 4 and Worklets peer dependencies (React Native Only)

**What Changed:**

- `react-native-reanimated >=3.17.0` (no worklets peer) → `react-native-reanimated >=4.2.0`
- No worklets peer → `react-native-worklets >=0.7.4`

**Migration:**

Upgrade Reanimated and Worklets together in your app before bumping `@metamask/design-system-react-native`. Match versions to your Expo SDK, or use a dev build when JS and native versions differ.

```bash
npx expo install react-native-reanimated@~4.2.1 react-native-worklets@0.7.4
```

```js
// babel.config.js
module.exports = {
  plugins: ['react-native-worklets/plugin'],
};
```

Rebuild native apps after upgrading.

**Impact:**

- Apps on Reanimated 3 must migrate before upgrading to `@metamask/design-system-react-native` 0.34.0+
- Both Reanimated 4 and Worklets must be present at runtime for animated components

See migration guides for complete instructions:

- [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0330-to-0340)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: minor (0.27.0 → 0.28.0) - new `CandlestickFilled` icon in `IconName`
  - [x] design-system-react: minor (0.31.0 → 0.32.0) - new `CandlestickFilled` icon in `IconName`
  - [x] design-system-react-native: minor (0.33.0 → 0.34.0) - new icon plus Reanimated 4 / Worklets peer dependency breaking change
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples (Reanimated 4 / Worklets)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

Made with [Cursor](https://cursor.com)