### PR TITLE
fix(pure-black): screen surface hooks and BottomSheetDialog isElevatedSurface for numpad

### DIFF
--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.stories.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.stories.tsx
@@ -3,7 +3,7 @@ import React, { useRef } from 'react';
 import { View, Pressable } from 'react-native';
 
 import { Box } from '../Box';
-import { Text } from '../Text';
+import { Text, TextVariant } from '../Text';
 
 import { BottomSheetDialog } from './BottomSheetDialog';
 import type {
@@ -17,6 +17,7 @@ const meta: Meta<BottomSheetDialogProps> = {
   argTypes: {
     isFullscreen: { control: 'boolean' },
     isInteractable: { control: 'boolean' },
+    isElevatedSurface: { control: 'boolean' },
     keyboardAvoidingViewEnabled: { control: 'boolean' },
     onClose: { action: 'closed' },
     onOpen: { action: 'opened' },
@@ -99,5 +100,44 @@ export const ImperativeControl: Story = {
   render: (args) => <ImperativeControlTemplate {...args} />,
   args: {
     isInteractable: true,
+  },
+};
+
+const NUMPAD_KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '0', '⌫'];
+
+const ScreenLevelNumpadTemplate = (args: BottomSheetDialogProps) => (
+  <Box twClassName="w-full h-full relative bg-default">
+    <Box twClassName="flex-1 p-4">
+      <Text variant={TextVariant.HeadingMd}>Swap amount</Text>
+      <Text variant={TextVariant.AmountDisplayLg} twClassName="mt-2">
+        0.00
+      </Text>
+    </Box>
+    <BottomSheetDialog {...args} isInteractable={false} isElevatedSurface={false}>
+      <Box twClassName="px-4 pt-2 pb-0">
+        <Box twClassName="flex-row flex-wrap">
+          {NUMPAD_KEYS.map((key) => (
+            <Box
+              key={key}
+              twClassName="w-1/3 items-center justify-center py-4"
+            >
+              <Text variant={TextVariant.HeadingMd}>{key}</Text>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </BottomSheetDialog>
+  </Box>
+);
+
+export const ScreenLevelNumpad: Story = {
+  render: (args) => <ScreenLevelNumpadTemplate {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Screen-level bottom surfaces such as swap numpads should use `isElevatedSurface={false}` so the sheet matches the pure-black canvas (`#000000`) instead of the elevated `bg-alternative` surface.',
+      },
+    },
   },
 };

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.test.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.test.tsx
@@ -43,6 +43,11 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
   }),
   useTheme: () => mockThemeRef.current,
   usePureBlack: () => mockIsPureBlackRef.current,
+  useElevatedSurfaceClass: () =>
+    mockThemeRef.current === 'dark' && mockIsPureBlackRef.current
+      ? 'bg-alternative'
+      : 'bg-default',
+  useScreenSurfaceClass: () => 'bg-default',
 }));
 
 jest.mock('react-native-reanimated', () => {
@@ -381,6 +386,23 @@ describe('BottomSheetDialog', () => {
 
     expect(mockStyle).toHaveBeenCalledWith(
       'bg-alternative',
+      'rounded-t-3xl overflow-hidden border border-muted',
+      undefined,
+    );
+  });
+
+  it('uses default background class for screen-level sheets in pure black', () => {
+    mockThemeRef.current = 'dark';
+    mockIsPureBlackRef.current = true;
+
+    render(
+      <BottomSheetDialog isElevatedSurface={false}>
+        <Text>Screen Level Sheet</Text>
+      </BottomSheetDialog>,
+    );
+
+    expect(mockStyle).toHaveBeenCalledWith(
+      'bg-default',
       'rounded-t-3xl overflow-hidden border border-muted',
       undefined,
     );

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.tsx
@@ -1,6 +1,8 @@
 import {
   Theme,
+  useElevatedSurfaceClass,
   usePureBlack,
+  useScreenSurfaceClass,
   useTailwind,
   useTheme,
 } from '@metamask/design-system-twrnc-preset';
@@ -52,6 +54,7 @@ export const BottomSheetDialog = forwardRef<
       children,
       isFullscreen = false,
       isInteractable = true,
+      isElevatedSurface = true,
       keyboardAvoidingViewEnabled = true,
       onClose,
       onOpen,
@@ -64,6 +67,11 @@ export const BottomSheetDialog = forwardRef<
     const tw = useTailwind();
     const currentTheme = useTheme();
     const isPureBlack = usePureBlack();
+    const elevatedSurfaceClass = useElevatedSurfaceClass();
+    const screenSurfaceClass = useScreenSurfaceClass();
+    const surfaceClass = isElevatedSurface
+      ? elevatedSurfaceClass
+      : screenSurfaceClass;
     const shadowLg =
       currentTheme === Theme.Light
         ? lightTheme.shadows.size.lg
@@ -254,7 +262,7 @@ export const BottomSheetDialog = forwardRef<
     const sheetStyle = useMemo(
       () => [
         tw.style(
-          isPureBlack ? 'bg-alternative' : 'bg-default',
+          surfaceClass,
           'rounded-t-3xl overflow-hidden border border-muted',
           twClassName,
         ),
@@ -273,7 +281,7 @@ export const BottomSheetDialog = forwardRef<
 
       [
         tw,
-        isPureBlack,
+        surfaceClass,
         maxSheetHeight,
         screenBottomPadding,
         isFullscreen,

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.types.ts
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/BottomSheetDialog.types.ts
@@ -24,6 +24,14 @@ export type BottomSheetDialogProps = {
    */
   isInteractable?: boolean;
   /**
+   * When true, the sheet uses the elevated surface hierarchy in pure-black dark
+   * mode (`bg-alternative`). Set to false for screen-level surfaces such as
+   * swap numpads that should match the `#000000` canvas (`bg-default`).
+   *
+   * @default true
+   */
+  isElevatedSurface?: boolean;
+  /**
    * Optional boolean that indicates if the KeyboardAvoidingView is enabled.
    *
    * @default true

--- a/packages/design-system-react-native/src/components/BottomSheetDialog/README.md
+++ b/packages/design-system-react-native/src/components/BottomSheetDialog/README.md
@@ -69,6 +69,26 @@ Optional boolean that indicates if the sheet is swippable. This affects whether 
 </BottomSheetDialog>
 ```
 
+### `isElevatedSurface`
+
+When `true` (default), the sheet uses the elevated surface hierarchy in pure-black dark mode (`bg-alternative`). Set to `false` for screen-level surfaces such as swap numpads that should match the `#000000` canvas (`bg-default`).
+
+| TYPE      | REQUIRED | DEFAULT |
+| --------- | -------- | ------- |
+| `boolean` | No       | `true`  |
+
+```tsx
+// Elevated picker sheet (default)
+<BottomSheetDialog>
+  <Text>Pay with ETH</Text>
+</BottomSheetDialog>
+
+// Screen-level numpad that should blend with the pure-black canvas
+<BottomSheetDialog isElevatedSurface={false} isInteractable={false}>
+  <Numpad />
+</BottomSheetDialog>
+```
+
 ### `keyboardAvoidingViewEnabled`
 
 Optional boolean that indicates if the KeyboardAvoidingView is enabled. When enabled, the dialog adjusts its position to avoid being obscured by the keyboard.

--- a/packages/design-system-twrnc-preset/README.md
+++ b/packages/design-system-twrnc-preset/README.md
@@ -121,6 +121,32 @@ This provides:
 - 📝 **Type safety** - TypeScript definitions for all design tokens
 - ⚡ **Actual Design System Config** - Uses the same configuration as the TWRNC preset
 
+### Pure-black surface hierarchy
+
+In pure-black dark mode the screen canvas uses `background.default` (`#000000`). Not every surface should use that token:
+
+| Surface type | Hook / prop | Pure-black class | Example |
+| ------------ | ----------- | ---------------- | ------- |
+| Screen canvas, numpads, full-width footers | `useScreenSurfaceClass()` | `bg-default` | Swap numpad |
+| Elevated sheets and modals | `useElevatedSurfaceClass()` or `BottomSheetDialog` default | `bg-alternative` | Pay-with picker |
+| Rows on elevated sheets | `useElevatedListItemClass()` | transparent (inherits parent) | Asset list item |
+
+For `BottomSheetDialog`, pass `isElevatedSurface={false}` when the sheet should match the screen canvas instead of sitting above it.
+
+```tsx
+import {
+  useScreenSurfaceClass,
+  useTailwind,
+} from '@metamask/design-system-twrnc-preset';
+
+function SwapNumpad() {
+  const tw = useTailwind();
+  const surfaceClass = useScreenSurfaceClass();
+
+  return <View style={tw.style(surfaceClass, 'px-4 pt-2')}>{/* keys */}</View>;
+}
+```
+
 ## Contributing
 
 This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/metamask-design-system#readme).

--- a/packages/design-system-twrnc-preset/jest.config.js
+++ b/packages/design-system-twrnc-preset/jest.config.js
@@ -10,32 +10,25 @@ const baseConfig = require('../../jest.config.packages');
 
 const displayName = path.basename(__dirname);
 
-module.exports = merge(baseConfig, {
+const config = merge(baseConfig, {
   // The display name when running multiple projects
   displayName,
 
-  // TODO add tests to twrnc preset https://github.com/MetaMask/metamask-design-system/issues/90
   // Pass with no tests if no test files are found
   passWithNoTests: true,
 
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 75,
-      functions: 70,
-      lines: 84,
-      statements: 84,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
     },
   },
-  preset: 'react-native',
-  transform: {
-    '^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
-  },
-  transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation)/)',
-  ],
-  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
-  moduleNameMapper: {
-    '\\.(css|less|scss)$': 'identity-obj-proxy',
-  },
 });
+
+// Scoped coverage until the package has broader test coverage (issue #90).
+config.collectCoverageFrom = ['./src/surfaceHierarchy.ts'];
+
+module.exports = config;

--- a/packages/design-system-twrnc-preset/src/hooks.ts
+++ b/packages/design-system-twrnc-preset/src/hooks.ts
@@ -2,6 +2,12 @@ import { useContext } from 'react';
 
 import type { Theme } from './Theme.types';
 import { ThemeContext } from './ThemeContext';
+import {
+  getElevatedListItemClass,
+  getElevatedSurfaceClass,
+  getScreenSurfaceClass,
+} from './surfaceHierarchy';
+import type { ElevatedListItemOptions } from './surfaceHierarchy';
 
 /**
  * Hook that provides access to the current theme.
@@ -28,6 +34,24 @@ export const useTheme = (): Theme => {
 export const usePureBlack = (): boolean => {
   const { isPureBlack } = useContext(ThemeContext);
   return isPureBlack;
+};
+
+export const useElevatedSurfaceClass = (): string => {
+  const theme = useTheme();
+  const isPureBlack = usePureBlack();
+
+  return getElevatedSurfaceClass(theme, isPureBlack);
+};
+
+export const useScreenSurfaceClass = (): string => getScreenSurfaceClass();
+
+export const useElevatedListItemClass = (
+  options: ElevatedListItemOptions = {},
+): string => {
+  const theme = useTheme();
+  const isPureBlack = usePureBlack();
+
+  return getElevatedListItemClass(theme, isPureBlack, options);
 };
 
 /**

--- a/packages/design-system-twrnc-preset/src/index.ts
+++ b/packages/design-system-twrnc-preset/src/index.ts
@@ -3,7 +3,15 @@ export { ThemeProvider } from './ThemeProvider';
 export { Theme } from './Theme.types';
 
 // Hooks
-export { useTailwind, useTheme, usePureBlack } from './hooks';
+export {
+  useTailwind,
+  useTheme,
+  usePureBlack,
+  useElevatedSurfaceClass,
+  useElevatedListItemClass,
+  useScreenSurfaceClass,
+} from './hooks';
+export type { ElevatedListItemOptions } from './surfaceHierarchy';
 
 // Config generation
 export { generateTailwindConfig } from './tailwind.config';

--- a/packages/design-system-twrnc-preset/src/surfaceHierarchy.test.ts
+++ b/packages/design-system-twrnc-preset/src/surfaceHierarchy.test.ts
@@ -1,0 +1,46 @@
+import { Theme } from './Theme.types';
+import {
+  getElevatedListItemClass,
+  getElevatedSurfaceClass,
+  getScreenSurfaceClass,
+} from './surfaceHierarchy';
+
+describe('surfaceHierarchy', () => {
+  describe('getElevatedSurfaceClass', () => {
+    it('returns bg-default for light theme', () => {
+      expect(getElevatedSurfaceClass(Theme.Light, true)).toBe('bg-default');
+      expect(getElevatedSurfaceClass(Theme.Light, false)).toBe('bg-default');
+    });
+
+    it('returns bg-default for standard dark theme', () => {
+      expect(getElevatedSurfaceClass(Theme.Dark, false)).toBe('bg-default');
+    });
+
+    it('returns bg-alternative for pure-black dark theme', () => {
+      expect(getElevatedSurfaceClass(Theme.Dark, true)).toBe('bg-alternative');
+    });
+  });
+
+  describe('getScreenSurfaceClass', () => {
+    it('always returns bg-default', () => {
+      expect(getScreenSurfaceClass()).toBe('bg-default');
+    });
+  });
+
+  describe('getElevatedListItemClass', () => {
+    it('returns bg-section when selected', () => {
+      expect(
+        getElevatedListItemClass(Theme.Dark, true, { isSelected: true }),
+      ).toBe('bg-section');
+    });
+
+    it('returns empty string for unselected rows in pure-black dark mode', () => {
+      expect(getElevatedListItemClass(Theme.Dark, true)).toBe('');
+    });
+
+    it('returns bg-default for unselected rows outside pure-black dark mode', () => {
+      expect(getElevatedListItemClass(Theme.Dark, false)).toBe('bg-default');
+      expect(getElevatedListItemClass(Theme.Light, true)).toBe('bg-default');
+    });
+  });
+});

--- a/packages/design-system-twrnc-preset/src/surfaceHierarchy.ts
+++ b/packages/design-system-twrnc-preset/src/surfaceHierarchy.ts
@@ -1,0 +1,51 @@
+import { Theme } from './Theme.types';
+
+export type ElevatedListItemOptions = {
+  isSelected?: boolean;
+};
+
+/**
+ * Returns the TWRNC background class for elevated surfaces such as picker
+ * bottom sheets and modals. In pure-black dark mode, surfaces use
+ * `bg-alternative` so they read above the `#000000` screen background.
+ */
+export const getElevatedSurfaceClass = (
+  theme: Theme,
+  isPureBlack: boolean,
+): string => {
+  if (isPureBlack && theme === Theme.Dark) {
+    return 'bg-alternative';
+  }
+
+  return 'bg-default';
+};
+
+/**
+ * Returns the TWRNC background class for screen-level surfaces that should
+ * match the canvas background, such as swap numpads and full-width footers.
+ * In pure-black dark mode this resolves to `bg-default` (`#000000`).
+ */
+export const getScreenSurfaceClass = (): string => 'bg-default';
+
+/**
+ * Returns the TWRNC background class for list rows rendered on elevated
+ * surfaces. In pure-black dark mode, unselected rows should inherit the parent
+ * sheet background instead of painting `bg-default` (`#000000`) patches.
+ */
+export const getElevatedListItemClass = (
+  theme: Theme,
+  isPureBlack: boolean,
+  options: ElevatedListItemOptions = {},
+): string => {
+  const { isSelected = false } = options;
+
+  if (isSelected) {
+    return 'bg-section';
+  }
+
+  if (isPureBlack && theme === Theme.Dark) {
+    return '';
+  }
+
+  return 'bg-default';
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In pure-black dark mode, elevated bottom sheets correctly use `bg-alternative` (`#0d0d0f`) so they read above the `#000000` canvas. Screen-level bottom surfaces such as the Swaps numpad should **not** use that elevated token — they need `bg-default` (`#000000`) and must extend through the bottom safe area. When they don't, a visible black seam appears at the bottom of the screen.

**Solution (design system portion):**
- Add pure-black surface hierarchy helpers in `@metamask/design-system-twrnc-preset`:
  - `useScreenSurfaceClass()` — returns `bg-default` for numpads and full-width footers
  - `useElevatedSurfaceClass()` — returns `bg-alternative` in pure-black dark mode for picker/modal sheets
  - `useElevatedListItemClass()` — transparent rows on elevated sheets (pairs with TMCU-994 work)
- Add `isElevatedSurface` prop to `BottomSheetDialog` (default `true`). Pass `isElevatedSurface={false}` for screen-level sheets like swap numpads.
- Add `ScreenLevelNumpad` Storybook story and README guidance for the surface hierarchy.

This is **not** a safe-area-context bug — safe-area insets are working as intended. The issue is applying the elevated surface token to a screen-level surface.

**Mobile follow-up:** The Swaps numpad lives in MetaMask Mobile and will need to adopt `useScreenSurfaceClass()` / `isElevatedSurface={false}` in a separate PR.

## **Related issues**

Fixes [TMCU-1006](https://consensyssoftware.atlassian.net/browse/TMCU-1006)

Related to [TMCU-622](https://consensyssoftware.atlassian.net/browse/TMCU-622) (Epic: Pure Black Hex Background Schema)

## **Manual testing steps**

1. Check out this branch
2. Run `yarn storybook:ios` or `yarn storybook:android`
3. Enable **pure black** in Storybook theme controls
4. Open **Components/BottomSheetDialog → ScreenLevelNumpad**
5. Confirm the numpad sheet background matches the screen canvas (`#000000`) with no dark seam at the bottom
6. Compare with the default elevated BottomSheetDialog story — it should still use `bg-alternative`
7. Run tests:
   - `yarn workspace @metamask/design-system-twrnc-preset run test -- surfaceHierarchy.test.ts`
   - `yarn workspace @metamask/design-system-react-native run test -- BottomSheetDialog.test.tsx --coverage=false`

## **Screenshots/Recordings**

RN Storybook: `ScreenLevelNumpad` story with pure black enabled.

### **Before**

BottomSheetDialog always uses `bg-alternative` in pure-black mode, causing a visible seam for screen-level numpad surfaces.

### **After**

`isElevatedSurface={false}` keeps the sheet on `bg-default` (`#000000`) to match the pure-black canvas.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b54dcc59-b633-415c-80a2-4b81e894410b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b54dcc59-b633-415c-80a2-4b81e894410b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

