### PR TITLE
chore: upgrade shell-quote to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@xmldom/xmldom": "0.7.7",
     "@babel/traverse": "7.25.9",
     "simple-plist": "1.3.1",
-    "shell-quote": "1.7.3",
+    "shell-quote": "1.8.4",
     "cross-spawn": "7.0.5",
     "form-data": "4.0.4",
     "get-intrinsic": "1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15599,10 +15599,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.7.3":
-  version: 1.7.3
-  resolution: "shell-quote@npm:1.7.3"
-  checksum: 10/0ab00c37c84ea3ac13d5f0d45c6850701254fd1d6653d0604a48973ba3911ad0dd9f414672253a01f68fe48bb651a7138317ed4543b75ce4192c1d610e453d4c
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10/a3e3796385f2cd5cf0b78207a4439f0c7395c0833fc75b2473084b5d298c109c5c0fa687fcd1c04e4b4484866e5bb8eaae7efae443b80fff71ea7e29baf11f0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

This PR upgrades `shell-quote` from `1.7.3` to `1.8.4` via the root `resolutions` field to address a shell command injection vulnerability in `quote()`.

The vulnerability (Dependabot #167) allowed newline characters in object `.op` values to pass through unescaped into shell output, enabling command injection when the quoted result is passed to a shell. Version `1.8.4` fixes this with strict allowlist validation on object-token inputs.

The previous resolution pinned `shell-quote` to `1.7.3`, which blocked Dependabot from upgrading to the patched version because the resolution overrode transitive dependency resolution.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/security/dependabot/167

## **Manual testing steps**

1. Run `yarn install` and confirm `shell-quote@1.8.4` is resolved in `yarn.lock`
2. Run `node -e "console.log(require('shell-quote/package.json').version)"` and verify output is `1.8.4`
3. Run `yarn dedupe --check` to confirm no duplicate dependency issues

## **Screenshots/Recordings**

N/A — dependency resolution change only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ee58a96-8010-4911-9adb-e3d9a0160ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ee58a96-8010-4911-9adb-e3d9a0160ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

