### PR TITLE
tokens(pure-black): increase border.muted contrast for better separators

### DIFF
--- a/packages/design-tokens/src/css/pure-black-dark-theme-colors.css
+++ b/packages/design-tokens/src/css/pure-black-dark-theme-colors.css
@@ -28,7 +28,7 @@
   --color-text-muted: var(--brand-colors-grey-grey500);
   --color-icon-muted: var(--brand-colors-grey-grey500);
   --color-icon-inverse: #0d0d0f;
-  --color-border-muted: #e2e2ff26;
+  --color-border-muted: #e2e2ff33;
   --color-primary-inverse: #0d0d0f;
   --color-error-inverse: #0d0d0f;
   --color-warning-inverse: #0d0d0f;

--- a/packages/design-tokens/src/js/themes/pureBlackDarkTheme/colorOverrides.ts
+++ b/packages/design-tokens/src/js/themes/pureBlackDarkTheme/colorOverrides.ts
@@ -28,7 +28,7 @@ export const pureBlackDarkColorOverrides = {
     inverse: '#0d0d0f',
   },
   border: {
-    muted: '#e2e2ff26',
+    muted: '#e2e2ff33',
   },
   primary: {
     inverse: '#0d0d0f',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Increase the `border.muted` contrast in the pure black dark theme to improve the visibility of dividers and subtle separators on `#000000` backgrounds. This directly addresses low-contrast separators observed in settings-like lists (e.g., the “Region” area) when pure black is enabled by default.

Changes:
- JS tokens: `pureBlackDarkTheme.colors.border.muted` from `#e2e2ff26` → `#e2e2ff33`
- CSS tokens: `--color-border-muted` from `#e2e2ff26` → `#e2e2ff33`

This is a safe, global token-level adjustment that benefits both React Native (twrnc) and Web (CSS variables) consumers without altering component APIs.

## **Related issues**

- Epic: TMCU-622 – Pure Black Hex Background Schema
- Fixes: TMCU-1081 – Region in settings not styled correctly on pure black (nightly)

## **Manual testing steps**

1. React Web Storybook (`yarn storybook`):
   - Switch to dark theme and enable Pure Black in the toolbar.
   - Inspect components that use subtle separators (e.g., lists, banners, dialogs) and verify divider visibility has improved.
2. React Native Storybook (`yarn storybook:ios`/`android`):
   - Toggle dark + pure black (Both mode is fine).
   - Open `SectionDivider`, `ListItem`, and settings-like list stories; confirm muted borders are more legible.
3. App consumers (nightly):
   - Navigate to Settings → Region and observe clearer separation between rows/sections under pure black.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable (token change covered by existing build/tests)
- [x] I’ve documented my code using JSDoc format if applicable

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C09AYKX30P3/p1783697958581129?thread_ts=1783697958.581129&cid=C09AYKX30P3)

<div><a href="https://cursor.com/agents/bc-27f43af9-4ab6-5242-bb37-3afbfafa45b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27f43af9-4ab6-5242-bb37-3afbfafa45b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

