### PR TITLE
feat(BannerBase): add actionButtonLayout End option

### DIFF
--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -158,13 +158,26 @@ export const ActionButtonOnPress: Story = {
   },
 };
 
-export const ActionButtonLayoutEnd: Story = {
+export const ActionButtonLayout: Story = {
+  render: (args) => (
+    <View style={{ gap: 8 }}>
+      <BannerAlert
+        {...args}
+        title="End"
+        description="One-line description for short copy."
+        actionButtonLayout={BannerBaseActionButtonLayout.End}
+      />
+      <BannerAlert
+        {...args}
+        title="Below"
+        description="Use Below when the body is longer or wraps across multiple lines so the action stays under the content."
+        actionButtonLayout={BannerBaseActionButtonLayout.Below}
+      />
+    </View>
+  ),
   args: {
-    title: 'Action at the end',
-    description: 'Action sits to the right of the body, left of close.',
     actionButtonLabel: 'Action',
     actionButtonOnPress: () => undefined,
-    actionButtonLayout: BannerBaseActionButtonLayout.End,
     onClose: () => undefined,
   },
 };

--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -1,3 +1,4 @@
+import { BannerBaseActionButtonLayout } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import React from 'react';
 import { View } from 'react-native';
@@ -34,6 +35,13 @@ const meta: Meta<BannerAlertProps> = {
     actionButtonLabel: {
       control: 'text',
       description: 'Optional action button label',
+    },
+    actionButtonLayout: {
+      control: 'select',
+      options: Object.keys(BannerBaseActionButtonLayout),
+      mapping: BannerBaseActionButtonLayout,
+      description:
+        'Layout for the action button relative to the banner body (Below or End)',
     },
     actionButtonOnPress: {
       action: 'actionButtonOnPress',
@@ -147,6 +155,17 @@ export const ActionButtonOnPress: Story = {
     },
     children:
       'Use actionButtonLabel for the text and actionButtonOnPress for interaction.',
+  },
+};
+
+export const ActionButtonLayoutEnd: Story = {
+  args: {
+    title: 'Action at the end',
+    description: 'Action sits to the right of the body, left of close.',
+    actionButtonLabel: 'Action',
+    actionButtonOnPress: () => undefined,
+    actionButtonLayout: BannerBaseActionButtonLayout.End,
+    onClose: () => undefined,
   },
 };
 

--- a/packages/design-system-react-native/src/components/BannerAlert/README.md
+++ b/packages/design-system-react-native/src/components/BannerAlert/README.md
@@ -83,6 +83,19 @@ Optional press handler for the action button. When provided, `actionButtonLabel`
 
 See the **ActionButtonOnPress** story for an example.
 
+### `actionButtonLayout`
+
+Optional layout for the action button relative to the banner body.
+
+- `BannerBaseActionButtonLayout.Below` — under title / description / children (default).
+- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button.
+
+| PROP                 | TYPE                           | REQUIRED | DEFAULT                              |
+| -------------------- | ------------------------------ | -------- | ------------------------------------ |
+| `actionButtonLayout` | `BannerBaseActionButtonLayout` | No       | `BannerBaseActionButtonLayout.Below` |
+
+See the **ActionButtonLayoutEnd** story for an example.
+
 ### `onClose`
 
 Optional callback that renders the close icon; `closeButtonProps` customizes the button’s accessibility props or styles.

--- a/packages/design-system-react-native/src/components/BannerAlert/README.md
+++ b/packages/design-system-react-native/src/components/BannerAlert/README.md
@@ -87,14 +87,14 @@ See the **ActionButtonOnPress** story for an example.
 
 Optional layout for the action button relative to the banner body.
 
-- `BannerBaseActionButtonLayout.Below` — under title / description / children (default).
-- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button.
+- `BannerBaseActionButtonLayout.Below` — under title / description / children (default). Prefer when the body is longer or wraps.
+- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button. Prefer for short copy (roughly one-line title and one-line description).
 
 | PROP                 | TYPE                           | REQUIRED | DEFAULT                              |
 | -------------------- | ------------------------------ | -------- | ------------------------------------ |
 | `actionButtonLayout` | `BannerBaseActionButtonLayout` | No       | `BannerBaseActionButtonLayout.Below` |
 
-See the **ActionButtonLayoutEnd** story for an example.
+See the **ActionButtonLayout** story for Below and End examples.
 
 ### `onClose`
 

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.stories.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.stories.tsx
@@ -1,6 +1,7 @@
 import { BannerBaseActionButtonLayout } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import React from 'react';
+import { View } from 'react-native';
 
 import { Icon, IconName, IconSize } from '../Icon';
 import { Text } from '../Text';
@@ -129,24 +130,33 @@ export const ActionButtonOnPress: Story = {
   },
 };
 
-export const ActionButtonLayoutEnd: Story = {
+export const ActionButtonLayout: Story = {
+  render: (args) => (
+    <View style={{ gap: 8 }}>
+      <BannerBase
+        {...args}
+        title="End"
+        description="One-line description for short copy."
+        actionButtonLayout={BannerBaseActionButtonLayout.End}
+        startAccessory={<Icon name={IconName.Info} size={IconSize.Lg} />}
+      />
+      <BannerBase
+        {...args}
+        title="Below"
+        description="Use Below when the body is longer or wraps across multiple lines so the action stays under the content."
+        actionButtonLayout={BannerBaseActionButtonLayout.Below}
+        startAccessory={<Icon name={IconName.Info} size={IconSize.Lg} />}
+      />
+    </View>
+  ),
   args: {
-    title: 'Action at the end',
-    description: 'Action sits to the right of the body, left of close.',
     actionButtonLabel: 'Action',
     actionButtonOnPress: () => undefined,
-    actionButtonLayout: BannerBaseActionButtonLayout.End,
     onClose: () => undefined,
     closeButtonProps: {
       testID: 'banner-base-close-button',
     },
   },
-  render: (args) => (
-    <BannerBase
-      {...args}
-      startAccessory={<Icon name={IconName.Info} size={IconSize.Lg} />}
-    />
-  ),
 };
 
 export const OnClose: Story = {

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.stories.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.stories.tsx
@@ -1,3 +1,4 @@
+import { BannerBaseActionButtonLayout } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import React from 'react';
 
@@ -26,6 +27,13 @@ const meta: Meta<BannerBaseProps> = {
     actionButtonLabel: {
       control: 'text',
       description: 'Optional action button label',
+    },
+    actionButtonLayout: {
+      control: 'select',
+      options: Object.keys(BannerBaseActionButtonLayout),
+      mapping: BannerBaseActionButtonLayout,
+      description:
+        'Layout for the action button relative to the banner body (Below or End)',
     },
     actionButtonProps: {
       control: 'object',
@@ -119,6 +127,26 @@ export const ActionButtonOnPress: Story = {
     children:
       'Use actionButtonLabel for the text and the action handler prop for interaction.',
   },
+};
+
+export const ActionButtonLayoutEnd: Story = {
+  args: {
+    title: 'Action at the end',
+    description: 'Action sits to the right of the body, left of close.',
+    actionButtonLabel: 'Action',
+    actionButtonOnPress: () => undefined,
+    actionButtonLayout: BannerBaseActionButtonLayout.End,
+    onClose: () => undefined,
+    closeButtonProps: {
+      testID: 'banner-base-close-button',
+    },
+  },
+  render: (args) => (
+    <BannerBase
+      {...args}
+      startAccessory={<Icon name={IconName.Info} size={IconSize.Lg} />}
+    />
+  ),
 };
 
 export const OnClose: Story = {

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
@@ -1,3 +1,4 @@
+import { BannerBaseActionButtonLayout } from '@metamask/design-system-shared';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
@@ -70,6 +71,25 @@ describe('BannerBase', () => {
   it('does not render action button when actionButtonOnPress is not provided', () => {
     const { queryByText } = render(<BannerBase actionButtonLabel="Action" />);
     expect(queryByText('Action')).toBeNull();
+  });
+
+  it('renders action button at the end when actionButtonLayout is End', () => {
+    const onAction = jest.fn();
+    const { getByText, getByTestId } = render(
+      <BannerBase
+        title="End layout"
+        actionButtonLabel="Action"
+        actionButtonOnPress={onAction}
+        actionButtonLayout={BannerBaseActionButtonLayout.End}
+        onClose={() => undefined}
+        closeButtonProps={{ testID: closeButtonTestId }}
+      />,
+    );
+
+    expect(getByText('Action')).toBeDefined();
+    expect(getByTestId(closeButtonTestId)).toBeDefined();
+    fireEvent.press(getByText('Action'));
+    expect(onAction).toHaveBeenCalledTimes(1);
   });
 
   it('renders close button and triggers onClose', () => {

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -1,4 +1,5 @@
 import {
+  BannerBaseActionButtonLayout,
   BoxAlignItems,
   BoxBackgroundColor,
   BoxFlexDirection,
@@ -35,6 +36,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
   actionButtonLabel,
   actionButtonOnPress,
   actionButtonProps,
+  actionButtonLayout = BannerBaseActionButtonLayout.Below,
   startAccessory,
   onClose,
   closeButtonProps,
@@ -51,6 +53,19 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
 
   const shouldShowCloseButton = Boolean(onClose);
   const shouldShowActionButton = Boolean(actionButtonOnPress);
+  const isActionButtonLayoutEnd =
+    actionButtonLayout === BannerBaseActionButtonLayout.End;
+
+  const actionButton = shouldShowActionButton ? (
+    <Button
+      size={ButtonSize.Md}
+      onPress={actionButtonOnPress}
+      {...resolvedActionButtonProps}
+      variant={ButtonVariant.Secondary}
+    >
+      {actionButtonLabel}
+    </Button>
+  ) : null;
 
   return (
     <Box
@@ -100,19 +115,12 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
             children
           ))}
 
-        {shouldShowActionButton && (
-          <Box twClassName="mt-2">
-            <Button
-              size={ButtonSize.Md}
-              onPress={actionButtonOnPress}
-              {...resolvedActionButtonProps}
-              variant={ButtonVariant.Secondary}
-            >
-              {actionButtonLabel}
-            </Button>
-          </Box>
+        {shouldShowActionButton && !isActionButtonLayoutEnd && (
+          <Box twClassName="mt-2">{actionButton}</Box>
         )}
       </Box>
+
+      {shouldShowActionButton && isActionButtonLayoutEnd && actionButton}
 
       {shouldShowCloseButton && (
         <ButtonIcon

--- a/packages/design-system-react-native/src/components/BannerBase/README.md
+++ b/packages/design-system-react-native/src/components/BannerBase/README.md
@@ -97,8 +97,8 @@ When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass 
 
 Optional layout for the action button relative to the banner body.
 
-- `BannerBaseActionButtonLayout.Below` — under title / description / children (default).
-- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button.
+- `BannerBaseActionButtonLayout.Below` — under title / description / children (default). Prefer when the body is longer or wraps.
+- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button. Prefer for short copy (roughly one-line title and one-line description).
 
 | PROP                 | TYPE                           | REQUIRED | DEFAULT                              |
 | -------------------- | ------------------------------ | -------- | ------------------------------------ |
@@ -111,14 +111,16 @@ import {
 } from '@metamask/design-system-react-native';
 
 <BannerBase
-  title="Action at the end"
-  description="Action sits to the right of the body, left of close."
+  title="End"
+  description="One-line description for short copy."
   actionButtonLabel="Action"
   actionButtonOnPress={() => undefined}
   actionButtonLayout={BannerBaseActionButtonLayout.End}
   onClose={() => undefined}
 />;
 ```
+
+See the **ActionButtonLayout** story for Below and End examples.
 
 ### `onClose`
 

--- a/packages/design-system-react-native/src/components/BannerBase/README.md
+++ b/packages/design-system-react-native/src/components/BannerBase/README.md
@@ -93,6 +93,33 @@ When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass 
 />
 ```
 
+### `actionButtonLayout`
+
+Optional layout for the action button relative to the banner body.
+
+- `BannerBaseActionButtonLayout.Below` — under title / description / children (default).
+- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button.
+
+| PROP                 | TYPE                           | REQUIRED | DEFAULT                              |
+| -------------------- | ------------------------------ | -------- | ------------------------------------ |
+| `actionButtonLayout` | `BannerBaseActionButtonLayout` | No       | `BannerBaseActionButtonLayout.Below` |
+
+```tsx
+import {
+  BannerBase,
+  BannerBaseActionButtonLayout,
+} from '@metamask/design-system-react-native';
+
+<BannerBase
+  title="Action at the end"
+  description="Action sits to the right of the body, left of close."
+  actionButtonLabel="Action"
+  actionButtonOnPress={() => undefined}
+  actionButtonLayout={BannerBaseActionButtonLayout.End}
+  onClose={() => undefined}
+/>;
+```
+
 ### `onClose`
 
 Optional close callback. If passed, a close button is shown. Use `closeButtonProps` to pass additional non-behavioral props to the close `ButtonIcon`, including `testID`, accessibility props, and styling hooks when needed for testing.

--- a/packages/design-system-react-native/src/components/BannerBase/index.ts
+++ b/packages/design-system-react-native/src/components/BannerBase/index.ts
@@ -1,2 +1,4 @@
+export { BannerBaseActionButtonLayout } from '@metamask/design-system-shared';
+
 export { BannerBase } from './BannerBase';
 export type { BannerBaseProps } from './BannerBase.types';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -52,7 +52,7 @@ export type {
   BadgeWrapperCustomPosition,
 } from './BadgeWrapper';
 
-export { BannerBase } from './BannerBase';
+export { BannerBase, BannerBaseActionButtonLayout } from './BannerBase';
 export type { BannerBaseProps } from './BannerBase';
 
 export { BottomSheet } from './BottomSheet';

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -1,3 +1,4 @@
+import { BannerBaseActionButtonLayout } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
@@ -40,6 +41,13 @@ const meta: Meta<BannerAlertProps> = {
     actionButtonLabel: {
       control: 'text',
       description: 'Optional action button label',
+    },
+    actionButtonLayout: {
+      control: 'select',
+      options: Object.keys(BannerBaseActionButtonLayout),
+      mapping: BannerBaseActionButtonLayout,
+      description:
+        'Layout for the action button relative to the banner body (Below or End)',
     },
     actionButtonOnClick: {
       action: 'actionButtonOnClick',
@@ -153,6 +161,17 @@ export const ActionButtonOnClick: Story = {
     },
     children:
       'Use actionButtonLabel for the text and actionButtonOnClick for interaction.',
+  },
+};
+
+export const ActionButtonLayoutEnd: Story = {
+  args: {
+    title: 'Action at the end',
+    description: 'Action sits to the right of the body, left of close.',
+    actionButtonLabel: 'Action',
+    actionButtonOnClick: () => undefined,
+    actionButtonLayout: BannerBaseActionButtonLayout.End,
+    onClose: () => undefined,
   },
 };
 

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -164,13 +164,26 @@ export const ActionButtonOnClick: Story = {
   },
 };
 
-export const ActionButtonLayoutEnd: Story = {
+export const ActionButtonLayout: Story = {
+  render: (args: BannerAlertProps) => (
+    <div className="space-y-2">
+      <BannerAlert
+        {...args}
+        title="End"
+        description="One-line description for short copy."
+        actionButtonLayout={BannerBaseActionButtonLayout.End}
+      />
+      <BannerAlert
+        {...args}
+        title="Below"
+        description="Use Below when the body is longer or wraps across multiple lines so the action stays under the content."
+        actionButtonLayout={BannerBaseActionButtonLayout.Below}
+      />
+    </div>
+  ),
   args: {
-    title: 'Action at the end',
-    description: 'Action sits to the right of the body, left of close.',
     actionButtonLabel: 'Action',
     actionButtonOnClick: () => undefined,
-    actionButtonLayout: BannerBaseActionButtonLayout.End,
     onClose: () => undefined,
   },
 };

--- a/packages/design-system-react/src/components/BannerAlert/README.mdx
+++ b/packages/design-system-react/src/components/BannerAlert/README.mdx
@@ -255,8 +255,8 @@ Optional click handler for the action button. When provided, `actionButtonLabel`
 
 Optional layout for the action button relative to the banner body.
 
-- `BannerBaseActionButtonLayout.Below` — under title / description / children (default).
-- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button.
+- `BannerBaseActionButtonLayout.Below` — under title / description / children (default). Prefer when the body is longer or wraps.
+- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button. Prefer for short copy (roughly one-line title and one-line description).
 
 <table>
   <thead>
@@ -283,7 +283,7 @@ Optional layout for the action button relative to the banner body.
   </tbody>
 </table>
 
-<Canvas of={BannerAlertStories.ActionButtonLayoutEnd} />
+<Canvas of={BannerAlertStories.ActionButtonLayout} />
 
 ### `onClose`
 

--- a/packages/design-system-react/src/components/BannerAlert/README.mdx
+++ b/packages/design-system-react/src/components/BannerAlert/README.mdx
@@ -251,6 +251,40 @@ Optional click handler for the action button. When provided, `actionButtonLabel`
 
 <Canvas of={BannerAlertStories.ActionButtonOnClick} />
 
+### `actionButtonLayout`
+
+Optional layout for the action button relative to the banner body.
+
+- `BannerBaseActionButtonLayout.Below` — under title / description / children (default).
+- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">PROP</th>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>actionButtonLayout</code>
+      </td>
+      <td align="left">
+        <code>BannerBaseActionButtonLayout</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>BannerBaseActionButtonLayout.Below</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={BannerAlertStories.ActionButtonLayoutEnd} />
+
 ### `onClose`
 
 Optional callback that when provided renders a close icon in the top-right corner; `closeButtonProps` lets you adjust the icon’s accessibility label or classes.

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.stories.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.stories.tsx
@@ -1,3 +1,4 @@
+import { BannerBaseActionButtonLayout } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
@@ -32,6 +33,13 @@ const meta: Meta<BannerBaseProps> = {
     actionButtonLabel: {
       control: 'text',
       description: 'Optional action button label',
+    },
+    actionButtonLayout: {
+      control: 'select',
+      options: Object.keys(BannerBaseActionButtonLayout),
+      mapping: BannerBaseActionButtonLayout,
+      description:
+        'Layout for the action button relative to the banner body (Below or End)',
     },
     actionButtonProps: {
       control: 'object',
@@ -126,6 +134,26 @@ export const ActionButtonOnClick: Story = {
     children:
       'Use actionButtonLabel for the text and the action handler prop for interaction.',
   },
+};
+
+export const ActionButtonLayoutEnd: Story = {
+  args: {
+    title: 'Action at the end',
+    description: 'Action sits to the right of the body, left of close.',
+    actionButtonLabel: 'Action',
+    actionButtonOnClick: () => undefined,
+    actionButtonLayout: BannerBaseActionButtonLayout.End,
+    onClose: () => undefined,
+    closeButtonProps: {
+      'data-testid': 'banner-base-close-button',
+    },
+  },
+  render: (args) => (
+    <BannerBase
+      {...args}
+      startAccessory={<Icon name={IconName.Info} size={IconSize.Lg} />}
+    />
+  ),
 };
 
 export const OnClose: Story = {

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.stories.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.stories.tsx
@@ -136,24 +136,33 @@ export const ActionButtonOnClick: Story = {
   },
 };
 
-export const ActionButtonLayoutEnd: Story = {
+export const ActionButtonLayout: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      <BannerBase
+        {...args}
+        title="End"
+        description="One-line description for short copy."
+        actionButtonLayout={BannerBaseActionButtonLayout.End}
+        startAccessory={<Icon name={IconName.Info} size={IconSize.Lg} />}
+      />
+      <BannerBase
+        {...args}
+        title="Below"
+        description="Use Below when the body is longer or wraps across multiple lines so the action stays under the content."
+        actionButtonLayout={BannerBaseActionButtonLayout.Below}
+        startAccessory={<Icon name={IconName.Info} size={IconSize.Lg} />}
+      />
+    </div>
+  ),
   args: {
-    title: 'Action at the end',
-    description: 'Action sits to the right of the body, left of close.',
     actionButtonLabel: 'Action',
     actionButtonOnClick: () => undefined,
-    actionButtonLayout: BannerBaseActionButtonLayout.End,
     onClose: () => undefined,
     closeButtonProps: {
       'data-testid': 'banner-base-close-button',
     },
   },
-  render: (args) => (
-    <BannerBase
-      {...args}
-      startAccessory={<Icon name={IconName.Info} size={IconSize.Lg} />}
-    />
-  ),
 };
 
 export const OnClose: Story = {

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
@@ -1,3 +1,4 @@
+import { BannerBaseActionButtonLayout } from '@metamask/design-system-shared';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import type { ReactNode } from 'react';
@@ -82,6 +83,28 @@ describe('BannerBase', () => {
     expect(
       screen.queryByRole('button', { name: 'Action' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('renders action button at the end when actionButtonLayout is End', () => {
+    const onAction = jest.fn();
+    render(
+      <BannerBase
+        title="End layout"
+        actionButtonLabel="Action"
+        actionButtonOnClick={onAction}
+        actionButtonLayout={BannerBaseActionButtonLayout.End}
+        onClose={() => undefined}
+      />,
+    );
+
+    const actionButton = screen.getByRole('button', { name: 'Action' });
+    const closeButton = screen.getByRole('button', { name: 'Close banner' });
+    expect(actionButton.compareDocumentPosition(closeButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+
+    fireEvent.click(actionButton);
+    expect(onAction).toHaveBeenCalledTimes(1);
   });
 
   it('renders close button and triggers onClose', () => {

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
@@ -1,4 +1,5 @@
 import {
+  BannerBaseActionButtonLayout,
   BoxAlignItems,
   BoxBackgroundColor,
   BoxFlexDirection,
@@ -37,6 +38,7 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
       actionButtonLabel,
       actionButtonOnClick,
       actionButtonProps,
+      actionButtonLayout = BannerBaseActionButtonLayout.Below,
       startAccessory,
       onClose,
       closeButtonProps,
@@ -55,6 +57,19 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
 
     const shouldShowCloseButton = Boolean(onClose);
     const shouldShowActionButton = Boolean(actionButtonOnClick);
+    const isActionButtonLayoutEnd =
+      actionButtonLayout === BannerBaseActionButtonLayout.End;
+
+    const actionButton = shouldShowActionButton ? (
+      <Button
+        size={ButtonSize.Md}
+        onClick={actionButtonOnClick}
+        {...resolvedActionButtonProps}
+        variant={ButtonVariant.Secondary}
+      >
+        {actionButtonLabel}
+      </Button>
+    ) : null;
 
     return (
       <Box
@@ -105,19 +120,12 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
               children
             ))}
 
-          {shouldShowActionButton && (
-            <Box className="mt-2">
-              <Button
-                size={ButtonSize.Md}
-                onClick={actionButtonOnClick}
-                {...resolvedActionButtonProps}
-                variant={ButtonVariant.Secondary}
-              >
-                {actionButtonLabel}
-              </Button>
-            </Box>
+          {shouldShowActionButton && !isActionButtonLayoutEnd && (
+            <Box className="mt-2">{actionButton}</Box>
           )}
         </Box>
+
+        {shouldShowActionButton && isActionButtonLayoutEnd && actionButton}
 
         {shouldShowCloseButton && (
           <ButtonIcon

--- a/packages/design-system-react/src/components/BannerBase/README.mdx
+++ b/packages/design-system-react/src/components/BannerBase/README.mdx
@@ -220,6 +220,56 @@ When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass 
 
 <Canvas of={BannerBaseStories.ActionButtonOnClick} />
 
+### `actionButtonLayout`
+
+Optional layout for the action button relative to the banner body.
+
+- `BannerBaseActionButtonLayout.Below` — under title / description / children (default).
+- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">PROP</th>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>actionButtonLayout</code>
+      </td>
+      <td align="left">
+        <code>BannerBaseActionButtonLayout</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>BannerBaseActionButtonLayout.Below</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+```tsx
+import {
+  BannerBase,
+  BannerBaseActionButtonLayout,
+} from '@metamask/design-system-react';
+
+<BannerBase
+  title="Action at the end"
+  description="Action sits to the right of the body, left of close."
+  actionButtonLabel="Action"
+  actionButtonOnClick={() => undefined}
+  actionButtonLayout={BannerBaseActionButtonLayout.End}
+  onClose={() => undefined}
+/>;
+```
+
+<Canvas of={BannerBaseStories.ActionButtonLayoutEnd} />
+
 ### `onClose`
 
 Optional close callback. If passed, a close button is shown. Use `closeButtonProps` to pass additional non-behavioral props to the close `ButtonIcon`, including `data-testid`, accessibility props, and styling hooks when needed for testing.
@@ -251,7 +301,9 @@ Optional close callback. If passed, a close button is shown. Use `closeButtonPro
         <code>closeButtonProps</code>
       </td>
       <td align="left">
-        <code>Omit&lt;Partial&lt;ButtonIconProps&gt;, 'iconName' | 'onClick'&gt;</code>
+        <code>
+          Omit&lt;Partial&lt;ButtonIconProps&gt;, 'iconName' | 'onClick'&gt;
+        </code>
       </td>
       <td align="left">No</td>
       <td align="left">

--- a/packages/design-system-react/src/components/BannerBase/README.mdx
+++ b/packages/design-system-react/src/components/BannerBase/README.mdx
@@ -224,8 +224,8 @@ When provided, `actionButtonLabel` is required. Use `actionButtonProps` to pass 
 
 Optional layout for the action button relative to the banner body.
 
-- `BannerBaseActionButtonLayout.Below` — under title / description / children (default).
-- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button.
+- `BannerBaseActionButtonLayout.Below` — under title / description / children (default). Prefer when the body is longer or wraps.
+- `BannerBaseActionButtonLayout.End` — right of the body, left of the close button. Prefer for short copy (roughly one-line title and one-line description).
 
 <table>
   <thead>
@@ -259,8 +259,8 @@ import {
 } from '@metamask/design-system-react';
 
 <BannerBase
-  title="Action at the end"
-  description="Action sits to the right of the body, left of close."
+  title="End"
+  description="One-line description for short copy."
   actionButtonLabel="Action"
   actionButtonOnClick={() => undefined}
   actionButtonLayout={BannerBaseActionButtonLayout.End}
@@ -268,7 +268,7 @@ import {
 />;
 ```
 
-<Canvas of={BannerBaseStories.ActionButtonLayoutEnd} />
+<Canvas of={BannerBaseStories.ActionButtonLayout} />
 
 ### `onClose`
 

--- a/packages/design-system-react/src/components/BannerBase/index.ts
+++ b/packages/design-system-react/src/components/BannerBase/index.ts
@@ -1,2 +1,4 @@
+export { BannerBaseActionButtonLayout } from '@metamask/design-system-shared';
+
 export { BannerBase } from './BannerBase';
 export type { BannerBaseProps } from './BannerBase.types';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -49,7 +49,7 @@ export {
 } from './BadgeWrapper';
 export type { BadgeWrapperCustomPosition } from './BadgeWrapper';
 
-export { BannerBase } from './BannerBase';
+export { BannerBase, BannerBaseActionButtonLayout } from './BannerBase';
 export type { BannerBaseProps } from './BannerBase';
 
 export { Blockies } from './temp-components/Blockies';

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -53,8 +53,11 @@ export {
   type IconAlertPropsShared,
 } from './types/IconAlert';
 
-// BannerBase types (ADR-0004)
-export { type BannerBasePropsShared } from './types/BannerBase';
+// BannerBase types (ADR-0003 + ADR-0004)
+export {
+  BannerBaseActionButtonLayout,
+  type BannerBasePropsShared,
+} from './types/BannerBase';
 
 // TextOrChildren types (ADR-0004)
 export { type TextOrChildrenPropsShared } from './types/TextOrChildren';

--- a/packages/design-system-shared/src/types/BannerBase/BannerBase.types.ts
+++ b/packages/design-system-shared/src/types/BannerBase/BannerBase.types.ts
@@ -1,6 +1,20 @@
 import type { ReactNode } from 'react';
 
 /**
+ * BannerBase action button layout (ADR-0003).
+ * Controls where the action button renders relative to the banner body.
+ */
+export const BannerBaseActionButtonLayout = {
+  /** Action button below title / description / children (default). */
+  Below: 'below',
+  /** Action button to the right of the body, left of the close button. */
+  End: 'end',
+} as const;
+
+export type BannerBaseActionButtonLayout =
+  (typeof BannerBaseActionButtonLayout)[keyof typeof BannerBaseActionButtonLayout];
+
+/**
  * BannerBase component shared props (ADR-0004)
  * Platform-independent content and structure shared across React and React Native.
  */
@@ -21,6 +35,15 @@ export type BannerBasePropsShared = {
    * Optional text label for the action button.
    */
   actionButtonLabel?: string;
+  /**
+   * Layout for the action button relative to the banner body.
+   *
+   * - `below` — under title / description / children (default).
+   * - `end` — right of the body, left of the close button.
+   *
+   * @default BannerBaseActionButtonLayout.Below
+   */
+  actionButtonLayout?: BannerBaseActionButtonLayout;
   /**
    * Optional accessory rendered at the start of the banner.
    */

--- a/packages/design-system-shared/src/types/BannerBase/index.ts
+++ b/packages/design-system-shared/src/types/BannerBase/index.ts
@@ -1,1 +1,4 @@
-export { type BannerBasePropsShared } from './BannerBase.types';
+export {
+  BannerBaseActionButtonLayout,
+  type BannerBasePropsShared,
+} from './BannerBase.types';


### PR DESCRIPTION
## **Description**

Banner action buttons could only render below the title/description/children. Some banner layouts need the action beside the body (left of the close button).

Adds `actionButtonLayout` to `BannerBase` (shared across React and React Native):

- `BannerBaseActionButtonLayout.Below` — existing default (action under the body)
- `BannerBaseActionButtonLayout.End` — action to the right of the body, left of close

`BannerAlert` inherits the prop via BannerBase. Stories and docs are updated for BannerBase and BannerAlert on both platforms.

```tsx
import {
  BannerAlert,
  BannerBaseActionButtonLayout,
} from '@metamask/design-system-react-native';

<BannerAlert
  title="Action at the end"
  description="Action sits to the right of the body, left of close."
  actionButtonLabel="Action"
  actionButtonOnPress={() => undefined}
  actionButtonLayout={BannerBaseActionButtonLayout.End}
  onClose={() => undefined}
/>
```

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-927

## **Manual testing steps**

1. Run Storybook React (`yarn storybook`) and open **BannerBase** / **BannerAlert** → **ActionButtonLayoutEnd**.
2. Confirm the action button sits to the right of the title/description and to the left of the close button.
3. Run Storybook RN (`yarn storybook:ios` or Android) and check the same stories.
4. Open the Default / ActionButton stories and confirm the Below layout is unchanged.
5. Toggle `actionButtonLayout` in Storybook controls between Below and End.

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/09bd8e17-8e2a-4267-b9a0-c9bb912f3cec

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API with a default that preserves existing Below layout; limited to design-system banner presentation with tests on both platforms.
> 
> **Overview**
> Adds optional **`actionButtonLayout`** on shared **`BannerBase`** (and **`BannerAlert`** via composition) so banner actions can sit **beside** the body instead of only under it.
> 
> **`BannerBaseActionButtonLayout.Below`** stays the default (action under title/description/children). **`End`** renders the same action button as a sibling in the root row—**to the right of the flex body and left of close**—on both **React** and **React Native** `BannerBase` implementations. The action `Button` is extracted once and mounted in either place.
> 
> Shared types export the new enum; package entry points re-export **`BannerBaseActionButtonLayout`**. Storybook gains **`ActionButtonLayout`** stories and docs for **BannerBase** / **BannerAlert**; unit tests cover **End** layout and button order vs close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb26feac925a19e30f17b32e112ae3233a6c1ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->