### PR TITLE
fix: Fixed ListItemMultiSelect story for variants

### DIFF
--- a/packages/design-system-react-native/src/components/ListItemMultiSelect/ListItemMultiSelect.stories.tsx
+++ b/packages/design-system-react-native/src/components/ListItemMultiSelect/ListItemMultiSelect.stories.tsx
@@ -118,8 +118,6 @@ const getVariantLeadingProps = (variant: ContentVariant) =>
       }
     : {
         avatar: listItemAvatar,
-        startAccessory: undefined,
-        accessoryGap: 0 as const,
       };
 
 const variantExamples: Record<


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `ListItemMultiSelect` Variant story was forcing `startAccessory: undefined` and `accessoryGap: 0` for non–one-line variants, which overrode component defaults and broke spacing/layout for the avatar-based two-line and multi-line examples.

**What changed:**
- Updated `getVariantLeadingProps` in `ListItemMultiSelect.stories.tsx` so only the one-line variant sets `startAccessory` and `accessoryGap`
- Two-line and multi-line variants now only pass `avatar`, allowing default accessory gap and start accessory behavior

## **Related issues**

Fixes: 

## **Manual testing steps**

1. From the repo root, run React Native Storybook (`yarn storybook:ios` or `yarn storybook:android`; build the native client first if needed).
2. Open **Components → ListItemMultiSelect → Variant**.
3. Confirm one-line shows the settings icon with the expected accessory gap.
4. Confirm two-line and multi-line show the avatar with normal spacing (not collapsed by `accessoryGap: 0`).
5. Optionally open **Default** / **WithStartAccessory** and confirm they still behave as before.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-15 at 08 22 36" src="https://github.com/user-attachments/assets/8effcf06-5b95-405e-81a3-fffcf9d2e0e8" />

### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-15 at 08 27 00" src="https://github.com/user-attachments/assets/91d0b883-6e2e-4348-bb77-c26b32fab470" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storybook-only change with no production component or API impact.
> 
> **Overview**
> Fixes the **Variant** Storybook story for `ListItemMultiSelect` so two-line and multi-line rows no longer pass `startAccessory: undefined` and `accessoryGap: 0`.
> 
> `getVariantLeadingProps` now only sets `startAccessory` and `accessoryGap` for the one-line case (settings icon, gap `4`). Avatar-based variants only pass `avatar`, so they use the component’s default accessory spacing (`accessoryGap` defaults to `3`) instead of collapsed layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04f03a9fd81e7f25d2fa8832ced2de9d382226df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->