### PR TITLE
Release/54.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "53.0.0",
+  "version": "54.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,12 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.36.0]
 
-### Uncategorized
+### Added
 
-- feat(dsrn): add themed mark colors and unified marks API to Slider ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
-- feat(BannerBase): add actionButtonLayout End option ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
-- fix: Fixed ListItemMultiSelect story for variants ([#1387](https://github.com/MetaMask/metamask-design-system/pull/1387))
-- feat(dsrn): replace ListItem verticalAlignment with variant layout ([#1384](https://github.com/MetaMask/metamask-design-system/pull/1384))
+- Added `actionButtonLayout` to `BannerBase` (inherited by `BannerAlert`) with `BannerBaseActionButtonLayout.Below` (default) and `BannerBaseActionButtonLayout.End` to place the action button beside the body, left of close ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
+- Added `SliderMarkColor` for themed `Slider` mark colors that interpolate with the thumb ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
+
+### Changed
+
+- **BREAKING:** Replaced `verticalAlignment` / `ContentVerticalAlignment` / `ListItemVerticalAlignment` on `Content` and `ListItem` with `variant` / `ContentVariant` / `ListItemVariant` (`OneLine`, `TwoLines`, `MultiLine`) for preset row heights, alignment, and secondary-slot gating ([#1384](https://github.com/MetaMask/metamask-design-system/pull/1384))
+  - See [Migration Guide](./MIGRATION.md#content-and-listitem-verticalalignment-replaced-by-variant)
+- **BREAKING:** Consolidated `Slider` mark configuration into a single `marks` prop; removed `rangeLabelSteps`, `formatStepLabel`, `stepToValue`, `tickThresholds`, `DEFAULT_RANGE_LABEL_STEPS`, and `DEFAULT_TICK_THRESHOLDS` ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
+  - See [Migration Guide](./MIGRATION.md#slider-mark-api-consolidation)
+
+### Fixed
+
+- Fixed `Slider` drag jerking when the controlled `value` updates mid-gesture ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
 
 ## [0.35.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0]
+
 ### Uncategorized
 
 - feat(dsrn): add themed mark colors and unified marks API to Slider ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
@@ -596,7 +598,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.35.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.36.0...HEAD
+[0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.35.0...@metamask/design-system-react-native@0.36.0
 [0.35.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.34.0...@metamask/design-system-react-native@0.35.0
 [0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.33.0...@metamask/design-system-react-native@0.34.0
 [0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.32.0...@metamask/design-system-react-native@0.33.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(dsrn): add themed mark colors and unified marks API to Slider ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
+- feat(BannerBase): add actionButtonLayout End option ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
+- fix: Fixed ListItemMultiSelect story for variants ([#1387](https://github.com/MetaMask/metamask-design-system/pull/1387))
+- feat(dsrn): replace ListItem verticalAlignment with variant layout ([#1384](https://github.com/MetaMask/metamask-design-system/pull/1384))
+
 ## [0.35.0]
 
 ### Added

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",
@@ -89,7 +89,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-twrnc-preset": "^0.7.0",
+    "@metamask/design-system-twrnc-preset": "^0.8.0",
     "@metamask/design-tokens": "^8.2.0",
     "@metamask/utils": "^11.11.0",
     "lodash": "^4.17.21",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0]
+
 ### Uncategorized
 
 - feat(BannerBase): add actionButtonLayout End option ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
@@ -425,7 +427,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.32.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.33.0...HEAD
+[0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.32.0...@metamask/design-system-react@0.33.0
 [0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.31.0...@metamask/design-system-react@0.32.0
 [0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.30.0...@metamask/design-system-react@0.31.0
 [0.30.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.29.0...@metamask/design-system-react@0.30.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,10 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.33.0]
 
-### Uncategorized
+### Added
 
-- feat(BannerBase): add actionButtonLayout End option ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
-- docs: add code example to React BannerBase README ([#1371](https://github.com/MetaMask/metamask-design-system/pull/1371))
+- Added `actionButtonLayout` to `BannerBase` (inherited by `BannerAlert`) with `BannerBaseActionButtonLayout.Below` (default) and `BannerBaseActionButtonLayout.End` to place the action button beside the body, left of close ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
 
 ## [0.32.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(BannerBase): add actionButtonLayout End option ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
+- docs: add code example to React BannerBase README ([#1371](https://github.com/MetaMask/metamask-design-system/pull/1371))
+
 ## [0.32.0]
 
 ### Added

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0]
+
 ### Uncategorized
 
 - feat(dsrn): add themed mark colors and unified marks API to Slider ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
@@ -300,7 +302,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.29.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.30.0...HEAD
+[0.30.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.29.0...@metamask/design-system-shared@0.30.0
 [0.29.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.28.0...@metamask/design-system-shared@0.29.0
 [0.28.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.27.0...@metamask/design-system-shared@0.28.0
 [0.27.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.26.0...@metamask/design-system-shared@0.27.0

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,11 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.30.0]
 
-### Uncategorized
+### Added
 
-- feat(dsrn): add themed mark colors and unified marks API to Slider ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
-- feat(BannerBase): add actionButtonLayout End option ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
-- feat(dsrn): replace ListItem verticalAlignment with variant layout ([#1384](https://github.com/MetaMask/metamask-design-system/pull/1384))
+- Added `BannerBaseActionButtonLayout` and `actionButtonLayout` to `BannerBasePropsShared` (`Below` default, `End` for beside-body placement) ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
+- Added `SliderMarkColor` and `SliderMark` for the unified `Slider` `marks` API ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
+
+### Changed
+
+- **BREAKING:** Replaced `ContentVerticalAlignment` / `verticalAlignment` on `ContentPropsShared` with `ContentVariant` / `variant` (`OneLine`, `TwoLines`, `MultiLine`) ([#1384](https://github.com/MetaMask/metamask-design-system/pull/1384))
+  - See [Migration Guide](./MIGRATION.md#content-verticalalignment-replaced-by-variant)
+- **BREAKING:** Consolidated `SliderPropsShared` mark props into `marks`; removed `rangeLabelSteps`, `formatStepLabel`, `stepToValue`, and `tickThresholds` ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
+  - See [Migration Guide](./MIGRATION.md#slider-mark-api-consolidation)
 
 ## [0.29.0]
 

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(dsrn): add themed mark colors and unified marks API to Slider ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
+- feat(BannerBase): add actionButtonLayout End option ([#1386](https://github.com/MetaMask/metamask-design-system/pull/1386))
+- feat(dsrn): replace ListItem verticalAlignment with variant layout ([#1384](https://github.com/MetaMask/metamask-design-system/pull/1384))
+
 ## [0.29.0]
 
 ### Added

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.0]
 
-### Uncategorized
+### Added
 
-- feat(dsrn): add themed mark colors and unified marks API to Slider ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
+- Exported `getThemeColors` for resolving theme color tokens (used by themed `Slider` marks) ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
 
 ## [0.7.0]
 

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0]
+
 ### Uncategorized
 
 - feat(dsrn): add themed mark colors and unified marks API to Slider ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
@@ -83,7 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MetaMask design token integration for React Native
 - TWRNC preset configuration with MetaMask styling utilities
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.7.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.8.0...HEAD
+[0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.7.0...@metamask/design-system-twrnc-preset@0.8.0
 [0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.6.0...@metamask/design-system-twrnc-preset@0.7.0
 [0.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.5.0...@metamask/design-system-twrnc-preset@0.6.0
 [0.5.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.4.2...@metamask/design-system-twrnc-preset@0.5.0

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(dsrn): add themed mark colors and unified marks API to Slider ([#1385](https://github.com/MetaMask/metamask-design-system/pull/1385))
+
 ## [0.7.0]
 
 ### Added

--- a/packages/design-system-twrnc-preset/package.json
+++ b/packages/design-system-twrnc-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-twrnc-preset",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Design System twrnc Preset",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3410,7 +3410,7 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-twrnc-preset": ^0.7.0
+    "@metamask/design-system-twrnc-preset": ^0.8.0
     "@metamask/design-tokens": ^8.2.0
     "@metamask/utils": ^11.11.0
     lodash: ^4.17.21


### PR DESCRIPTION
<!--
Release PR Template

Use this template for release PRs by creating your PR with:
https://github.com/MetaMask/metamask-design-system/compare/main...release/VERSION?template=release.md

Or use the default PR template and manually copy this structure.
-->

## Release 54.0.0

Banner action layout (`actionButtonLayout` End), React Native list-row `variant` presets, and a consolidated themed `Slider` `marks` API — with shared type updates and migration docs for the breaking changes.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.30.0**
- `@metamask/design-system-react`: **0.33.0**
- `@metamask/design-system-react-native`: **0.36.0**
- `@metamask/design-system-twrnc-preset`: **0.8.0**

### 🔄 Shared Type Updates (0.30.0)

#### Component Type Additions (#1384, #1385, #1386)

**What Changed:**

- Added `BannerBaseActionButtonLayout` and `actionButtonLayout` to `BannerBasePropsShared` (`Below` default, `End` for beside-body placement) (#1386)
- Added `SliderMarkColor` and `SliderMark` for the unified `Slider` `marks` API (#1385)
- **BREAKING:** Replaced `ContentVerticalAlignment` / `verticalAlignment` on `ContentPropsShared` with `ContentVariant` / `variant` (`OneLine`, `TwoLines`, `MultiLine`) (#1384)
- **BREAKING:** Consolidated `SliderPropsShared` mark props into `marks`; removed `rangeLabelSteps`, `formatStepLabel`, `stepToValue`, and `tickThresholds` (#1385)

**Impact:**

- Enables consistent Banner / ListItem / Slider APIs across React and React Native
- Continues ADR-0003/0004 const-object + string-union pattern adoption
- Consumers of shared types must migrate Content and Slider mark shapes (see Breaking Changes)

### 🌐 React Web Updates (0.33.0)

#### Added

- Added `actionButtonLayout` to `BannerBase` (inherited by `BannerAlert`) with `BannerBaseActionButtonLayout.Below` (default) and `BannerBaseActionButtonLayout.End` to place the action button beside the body, left of close (#1386)

### 📱 React Native Updates (0.36.0)

#### Added

- Added `actionButtonLayout` to `BannerBase` (inherited by `BannerAlert`) with `BannerBaseActionButtonLayout.Below` (default) and `BannerBaseActionButtonLayout.End` (#1386)
- Added `SliderMarkColor` for themed `Slider` mark colors that interpolate with the thumb (#1385)

#### Changed

- **BREAKING:** Replaced `verticalAlignment` / `ContentVerticalAlignment` / `ListItemVerticalAlignment` on `Content` and `ListItem` with `variant` / `ContentVariant` / `ListItemVariant` (`OneLine`, `TwoLines`, `MultiLine`) for preset row heights, alignment, and secondary-slot gating (#1384)
  - Migration: [Content / ListItem verticalAlignment → variant](./packages/design-system-react-native/MIGRATION.md#content-and-listitem-verticalalignment-replaced-by-variant)
- **BREAKING:** Consolidated `Slider` mark configuration into a single `marks` prop; removed `rangeLabelSteps`, `formatStepLabel`, `stepToValue`, `tickThresholds`, `DEFAULT_RANGE_LABEL_STEPS`, and `DEFAULT_TICK_THRESHOLDS` (#1385)
  - Migration: [Slider mark API consolidation](./packages/design-system-react-native/MIGRATION.md#slider-mark-api-consolidation)

#### Fixed

- Fixed `Slider` drag jerking when the controlled `value` updates mid-gesture (#1385)

### 🎨 TWRNC Preset Updates (0.8.0)

#### Added

- Exported `getThemeColors` for resolving theme color tokens (used by themed `Slider` marks) (#1385)

### ⚠️ Breaking Changes

#### `Content` / `ListItem`: `verticalAlignment` → `variant` (React Native + Shared)

**What Changed:**

- Removed `ContentVerticalAlignment`, `ListItemVerticalAlignment`, and `verticalAlignment`
- Added `ContentVariant` / `ListItemVariant` and `variant` (`OneLine`, `TwoLines`, `MultiLine`)

**Migration:**

```tsx
// Before (0.35.0)
import {
  ContentVerticalAlignment,
  ListItem,
} from '@metamask/design-system-react-native';

<ListItem
  verticalAlignment={ContentVerticalAlignment.Top}
  title="Network"
  description="Ethereum Mainnet"
  value="1.234 ETH"
  subvalue="~$2,500"
/>;

// After (0.36.0)
import {
  ListItem,
  ListItemVariant,
} from '@metamask/design-system-react-native';

<ListItem
  variant={ListItemVariant.MultiLine}
  title="Network"
  description="Ethereum Mainnet"
  value="1.234 ETH"
  subvalue="~$2,500"
/>;
```

**Impact:**

- Any `verticalAlignment` usage on `Content` / `ListItem` must update
- `ListItemVariant.OneLine` omits `description` and `subvalue` even when passed

See:

- [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#content-and-listitem-verticalalignment-replaced-by-variant)
- [Shared Migration Guide](./packages/design-system-shared/MIGRATION.md#content-verticalalignment-replaced-by-variant)

#### `Slider`: mark props → `marks` (React Native + Shared)

**What Changed:**

- Removed `rangeLabelSteps`, `formatStepLabel`, `stepToValue`, `tickThresholds`, `DEFAULT_RANGE_LABEL_STEPS`, `DEFAULT_TICK_THRESHOLDS`
- Added unified `marks` (`step`, `label`, `value`, `color`, `haptic`) plus `SliderMarkColor` / `DEFAULT_MARKS`

**Migration:**

```tsx
// Before (0.35.0)
import { Slider } from '@metamask/design-system-react-native';

<Slider
  value={leverage}
  onValueChange={setLeverage}
  rangeLabelSteps={[0, 50, 100]}
  formatStepLabel={(step) => ({ 0: '1x', 50: '20x', 100: '40x' })[step] ?? ''}
  stepToValue={(step) => ({ 0: 1, 50: 20, 100: 40 })[step] ?? leverage}
  tickThresholds={[50]}
  showRangeLabels
/>;

// After (0.36.0)
import { Slider, SliderMarkColor } from '@metamask/design-system-react-native';

<Slider
  value={leverage}
  onValueChange={setLeverage}
  marks={[
    { step: 0, label: '1x', value: 1, color: SliderMarkColor.SuccessDefault },
    { step: 50, label: '20x', value: 20, haptic: true },
    { step: 100, label: '40x', value: 40, color: SliderMarkColor.ErrorDefault },
  ]}
  showRangeLabels
/>;
```

**Impact:**

- Any usage of the removed mark props/exports must migrate to `marks`
- Prefer `SliderMarkColor` tokens for `marks[].color` (no raw hex in product UI)

See:

- [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#slider-mark-api-consolidation)
- [Shared Migration Guide](./packages/design-system-shared/MIGRATION.md#slider-mark-api-consolidation)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: minor (0.29.0 → 0.30.0) - shared type additions + breaking Content/Slider API
  - [x] design-system-react: minor (0.32.0 → 0.33.0) - BannerBase `actionButtonLayout` addition
  - [x] design-system-react-native: minor (0.35.0 → 0.36.0) - Banner layout + breaking ListItem/Slider APIs
  - [x] design-system-twrnc-preset: minor (0.7.0 → 0.8.0) - export `getThemeColors`
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples (if breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API changes on shared types and React Native `Content`/`ListItem`/`Slider` require consumer migrations; this PR itself is versioning and documentation only.
> 
> **Overview**
> **Release 54.0.0** cuts new versions of the design-system packages and records their consumer-facing changes in changelogs; the diff here is version bumps and release notes, not new implementation in this branch.
> 
> Published versions: `@metamask/design-system-shared` **0.30.0**, `@metamask/design-system-react` **0.33.0**, `@metamask/design-system-react-native` **0.36.0**, `@metamask/design-system-twrnc-preset` **0.8.0**, and the private monorepo root **54.0.0**. React Native’s peer on `@metamask/design-system-twrnc-preset` moves to **^0.8.0** (reflected in `yarn.lock`).
> 
> What this release documents for consumers: **`BannerBase` / `BannerAlert`** gain optional **`actionButtonLayout`** (`Below` vs **`End`** beside the body). **React Native** replaces **`Content` / `ListItem` `verticalAlignment`** with **`variant`** presets (`OneLine`, `TwoLines`, `MultiLine`) and consolidates **`Slider`** marks into a single **`marks`** API (with **`SliderMarkColor`** and a mid-gesture jerk fix). **TWRNC preset** exports **`getThemeColors`** for themed slider marks. Shared types mirror the banner, content, and slider breaking changes; migration guides are linked from the changelogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d9c9abe11ab539ac6658627484f211ff695e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->