### PR TITLE
fix: Polish React Native Toast background, description color and border radius

### DIFF
--- a/packages/design-system-react-native/src/components/Toast/Toast.test.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toast.test.tsx
@@ -190,14 +190,11 @@ describe('Toast', () => {
   });
 
   it('uses background section and no shadow in dark theme', () => {
-    const tw = renderHook(
-      () => useTailwind(),
-      {
-        wrapper: ({ children }) => (
-          <ThemeProvider theme={Theme.Dark}>{children}</ThemeProvider>
-        ),
-      },
-    ).result.current;
+    const tw = renderHook(() => useTailwind(), {
+      wrapper: ({ children }) => (
+        <ThemeProvider theme={Theme.Dark}>{children}</ThemeProvider>
+      ),
+    }).result.current;
 
     render(
       <ThemeProvider theme={Theme.Dark}>

--- a/packages/design-system-react-native/src/components/Toast/Toast.test.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toast.test.tsx
@@ -1,4 +1,10 @@
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { TextColor } from '@metamask/design-system-shared';
+import {
+  Theme,
+  ThemeProvider,
+  useTailwind,
+} from '@metamask/design-system-twrnc-preset';
+import { lightTheme } from '@metamask/design-tokens';
 import {
   render,
   screen,
@@ -162,5 +168,68 @@ describe('Toast', () => {
     );
 
     expect(screen.getByTestId('toast-root')).toHaveStyle(tw.style('mx-2'));
+  });
+
+  it('uses background default, md shadow, and 16px radius in light theme', () => {
+    const tw = renderHook(() => useTailwind()).result.current;
+
+    render(
+      <Toast
+        onClose={() => undefined}
+        testID="toast-root"
+        title="Light toast"
+      />,
+    );
+
+    expect(screen.getByTestId('toast-root')).toHaveStyle(
+      tw.style('bg-default rounded-2xl'),
+    );
+    expect(screen.getByTestId('toast-root')).toHaveStyle(
+      lightTheme.shadows.size.md,
+    );
+  });
+
+  it('uses background section and no shadow in dark theme', () => {
+    const tw = renderHook(
+      () => useTailwind(),
+      {
+        wrapper: ({ children }) => (
+          <ThemeProvider theme={Theme.Dark}>{children}</ThemeProvider>
+        ),
+      },
+    ).result.current;
+
+    render(
+      <ThemeProvider theme={Theme.Dark}>
+        <Toast
+          onClose={() => undefined}
+          testID="toast-root"
+          title="Dark toast"
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('toast-root')).toHaveStyle(
+      tw.style('bg-section rounded-2xl'),
+    );
+    expect(screen.getByTestId('toast-root')).not.toHaveStyle(
+      lightTheme.shadows.size.md,
+    );
+  });
+
+  it('applies text alternative color to description', () => {
+    const tw = renderHook(() => useTailwind()).result.current;
+
+    render(
+      <Toast
+        description="Description of toast"
+        onClose={() => undefined}
+        title="Toast message"
+      />,
+    );
+
+    expect(screen.getByText('Description of toast')).toHaveStyle(
+      tw.style(TextColor.TextAlternative),
+    );
   });
 });

--- a/packages/design-system-react-native/src/components/Toast/Toast.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toast.tsx
@@ -5,7 +5,10 @@ import {
   ButtonSize,
   IconSize,
   mergeTwClassName,
+  TextColor,
 } from '@metamask/design-system-shared';
+import { Theme, useTheme } from '@metamask/design-system-twrnc-preset';
+import { lightTheme } from '@metamask/design-tokens';
 import React from 'react';
 
 // External dependencies.
@@ -49,16 +52,19 @@ export const Toast: React.FC<ToastProps> = ({
   childrenWrapperProps,
   closeButtonProps,
   description,
-  descriptionProps,
+  descriptionProps = { color: TextColor.TextAlternative },
   onClose,
   iconAlertProps,
   severity = ToastSeverity.Default,
   startAccessory,
+  style,
   title,
   titleProps,
   twClassName,
   ...props
 }) => {
+  const theme = useTheme();
+  const isLightTheme = theme === Theme.Light;
   const actionProps =
     actionButtonLabel && actionButtonOnPress
       ? {
@@ -84,7 +90,11 @@ export const Toast: React.FC<ToastProps> = ({
     <BannerBase
       {...actionProps}
       {...props}
-      backgroundColor={BoxBackgroundColor.BackgroundSection}
+      backgroundColor={
+        isLightTheme
+          ? BoxBackgroundColor.BackgroundDefault
+          : BoxBackgroundColor.BackgroundSection
+      }
       borderColor={BoxBorderColor.BorderMuted}
       borderWidth={1}
       children={children}
@@ -98,9 +108,10 @@ export const Toast: React.FC<ToastProps> = ({
         severity,
         startAccessory,
       })}
+      style={[isLightTheme ? lightTheme.shadows.size.md : undefined, style]}
       title={title}
       titleProps={titleProps}
-      twClassName={mergeTwClassName('rounded-xl', twClassName)}
+      twClassName={mergeTwClassName('rounded-2xl', twClassName)}
     />
   );
 };


### PR DESCRIPTION
## **Description**

Polish React Native `Toast` surface styling so it matches the intended light/dark treatment.

**Why:** Toast was always using section background, 12px radius, and default description color, which didn’t match the desired visual spec.

**What changed:**
- Light theme: `background.default` + medium shadow
- Dark theme: `background.section` (no shadow)
- Description defaults to `TextColor.TextAlternative`
- Border radius updated from 12px (`rounded-xl`) to 16px (`rounded-2xl`)
- Included unit tests for theme background/shadow, radius, and description color

## **Related issues**

Fixes: 

https://github.com/MetaMask/metamask-design-system/pull/1304
https://github.com/MetaMask/metamask-mobile/pull/32933

## **Manual testing steps**

1. Run `yarn storybook:ios` (or Android) and open **Components → Toast**
2. In light theme, confirm toast uses default background, medium shadow, and 16px corners
3. In dark theme, confirm toast uses section background with no shadow
4. Confirm description text uses the alternative text color
5. Spot-check Default, severity, action button, and close stories still behave as before

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/f839c8de-8f1d-4f21-ab57-6f49d7e23637


### **After**

https://github.com/user-attachments/assets/b887a12c-1bee-4b12-ac38-a3aaf04ec8d3


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)