### PR TITLE
fix: Polish React Toast background, description color and border radius

### DIFF
--- a/packages/design-system-react/src/components/Toast/Toast.test.tsx
+++ b/packages/design-system-react/src/components/Toast/Toast.test.tsx
@@ -164,6 +164,42 @@ describe('Toast', () => {
     expect(toast).not.toHaveClass('shadow-md');
   });
 
+  it('uses background section when nested under a .dark ancestor', () => {
+    render(
+      <div className="dark">
+        <Toast
+          data-testid="toast-root"
+          title="Dark class toast"
+          onClose={() => undefined}
+        />
+      </div>,
+    );
+
+    const toast = screen.getByTestId('toast-root');
+    expect(toast).toHaveClass('bg-section', 'rounded-2xl');
+    expect(toast).not.toHaveClass('shadow-md');
+  });
+
+  it('keeps light polish when data-theme=light is nested inside .dark', () => {
+    render(
+      <div className="dark">
+        <div data-theme="light">
+          <Toast
+            data-testid="toast-root"
+            title="Nested light toast"
+            onClose={() => undefined}
+          />
+        </div>
+      </div>,
+    );
+
+    expect(screen.getByTestId('toast-root')).toHaveClass(
+      'bg-default',
+      'shadow-md',
+      'rounded-2xl',
+    );
+  });
+
   it('applies text alternative color to description', () => {
     render(
       <Toast
@@ -184,5 +220,14 @@ describe('Toast', () => {
     render(<Toast ref={ref} title="Ref test" onClose={() => undefined} />);
 
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('forwards a callback ref to the root element', () => {
+    const ref = jest.fn();
+
+    render(<Toast ref={ref} title="Callback ref" onClose={() => undefined} />);
+
+    expect(ref).toHaveBeenCalled();
+    expect(ref.mock.calls[0]?.[0]).toBeInstanceOf(HTMLDivElement);
   });
 });

--- a/packages/design-system-react/src/components/Toast/Toast.test.tsx
+++ b/packages/design-system-react/src/components/Toast/Toast.test.tsx
@@ -1,4 +1,7 @@
-import { ToastSeverity } from '@metamask/design-system-shared';
+import {
+  TextColor,
+  ToastSeverity,
+} from '@metamask/design-system-shared';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';
@@ -130,16 +133,52 @@ describe('Toast', () => {
     expect(screen.getByTestId('toast-root')).toHaveClass('mx-2');
   });
 
-  it('always applies rounded-xl to the toast surface', () => {
+  it('uses background default, md shadow, and 16px radius in light theme', () => {
+    render(
+      <div data-theme="light">
+        <Toast
+          data-testid="toast-root"
+          title="Light toast"
+          onClose={() => undefined}
+        />
+      </div>,
+    );
+
+    expect(screen.getByTestId('toast-root')).toHaveClass(
+      'bg-default',
+      'shadow-md',
+      'rounded-2xl',
+    );
+  });
+
+  it('uses background section and no shadow in dark theme', () => {
+    render(
+      <div data-theme="dark">
+        <Toast
+          data-testid="toast-root"
+          title="Dark toast"
+          onClose={() => undefined}
+        />
+      </div>,
+    );
+
+    const toast = screen.getByTestId('toast-root');
+    expect(toast).toHaveClass('bg-section', 'rounded-2xl');
+    expect(toast).not.toHaveClass('shadow-md');
+  });
+
+  it('applies text alternative color to description', () => {
     render(
       <Toast
-        data-testid="toast-root"
-        title="Rounded"
+        title="Toast message"
+        description="Description of toast"
         onClose={() => undefined}
       />,
     );
 
-    expect(screen.getByTestId('toast-root')).toHaveClass('rounded-xl');
+    expect(screen.getByText('Description of toast')).toHaveClass(
+      TextColor.TextAlternative,
+    );
   });
 
   it('forwards ref to the root element', () => {

--- a/packages/design-system-react/src/components/Toast/Toast.test.tsx
+++ b/packages/design-system-react/src/components/Toast/Toast.test.tsx
@@ -1,7 +1,4 @@
-import {
-  TextColor,
-  ToastSeverity,
-} from '@metamask/design-system-shared';
+import { TextColor, ToastSeverity } from '@metamask/design-system-shared';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';

--- a/packages/design-system-react/src/components/Toast/Toast.tsx
+++ b/packages/design-system-react/src/components/Toast/Toast.tsx
@@ -39,12 +39,18 @@ const renderSeverityAccessory = ({
 };
 
 const resolveIsDarkTheme = (node: HTMLElement): boolean => {
-  const themeRoot = node.closest('[data-theme]') ?? document.documentElement;
+  // Prefer the closest explicit data-theme so a nested light surface inside a
+  // distant .dark ancestor keeps light toast polish (and matching CSS tokens).
+  const dataThemeRoot = node.closest('[data-theme]');
+  if (dataThemeRoot) {
+    return dataThemeRoot.getAttribute('data-theme') === 'dark';
+  }
 
-  return (
-    themeRoot.getAttribute('data-theme') === 'dark' ||
-    Boolean(node.closest('.dark'))
-  );
+  if (node.closest('.dark')) {
+    return true;
+  }
+
+  return document.documentElement.getAttribute('data-theme') === 'dark';
 };
 
 export const Toast = forwardRef<HTMLDivElement, ToastProps>(

--- a/packages/design-system-react/src/components/Toast/Toast.tsx
+++ b/packages/design-system-react/src/components/Toast/Toast.tsx
@@ -3,9 +3,15 @@ import {
   BoxBorderColor,
   ButtonSize,
   IconSize,
+  TextColor,
   ToastSeverity,
 } from '@metamask/design-system-shared';
-import React, { forwardRef } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useLayoutEffect,
+  useState,
+} from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
 import { BannerBase } from '../BannerBase';
@@ -32,6 +38,15 @@ const renderSeverityAccessory = ({
   return <Icon name={name} color={color} size={IconSize.Lg} {...iconProps} />;
 };
 
+const resolveIsDarkTheme = (node: HTMLElement): boolean => {
+  const themeRoot = node.closest('[data-theme]') ?? document.documentElement;
+
+  return (
+    themeRoot.getAttribute('data-theme') === 'dark' ||
+    Boolean(node.closest('.dark'))
+  );
+};
+
 export const Toast = forwardRef<HTMLDivElement, ToastProps>(
   (
     {
@@ -40,6 +55,7 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>(
       actionButtonProps,
       className,
       closeButtonProps,
+      descriptionProps = { color: TextColor.TextAlternative },
       iconProps,
       onClose,
       severity = ToastSeverity.Default,
@@ -48,6 +64,50 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>(
     },
     ref,
   ) => {
+    const [node, setNode] = useState<HTMLDivElement | null>(null);
+    const [isDarkTheme, setIsDarkTheme] = useState(false);
+
+    const setToastRef = useCallback(
+      (element: HTMLDivElement | null) => {
+        setNode(element);
+
+        if (typeof ref === 'function') {
+          ref(element);
+        } else if (ref) {
+          ref.current = element;
+        }
+      },
+      [ref],
+    );
+
+    useLayoutEffect(() => {
+      if (!node) {
+        return;
+      }
+
+      const syncTheme = () => {
+        setIsDarkTheme(resolveIsDarkTheme(node));
+      };
+
+      syncTheme();
+
+      const observer = new MutationObserver(syncTheme);
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['data-theme', 'class'],
+      });
+
+      const scopedThemeRoot = node.closest('[data-theme]');
+      if (scopedThemeRoot && scopedThemeRoot !== document.documentElement) {
+        observer.observe(scopedThemeRoot, {
+          attributes: true,
+          attributeFilter: ['data-theme', 'class'],
+        });
+      }
+
+      return () => observer.disconnect();
+    }, [node]);
+
     // Only pass action props through when both the label and handler are set so
     // BannerBase can keep its action button contract simple.
     const resolvedActionProps =
@@ -76,14 +136,23 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>(
     // banner layout and the React Native Toast API.
     return (
       <BannerBase
-        ref={ref}
+        ref={setToastRef}
         {...resolvedActionProps}
         {...props}
-        backgroundColor={BoxBackgroundColor.BackgroundSection}
+        backgroundColor={
+          isDarkTheme
+            ? BoxBackgroundColor.BackgroundSection
+            : BoxBackgroundColor.BackgroundDefault
+        }
         borderColor={BoxBorderColor.BorderMuted}
         borderWidth={1}
-        className={twMerge('rounded-xl', className)}
+        className={twMerge(
+          'rounded-2xl',
+          !isDarkTheme && 'shadow-md',
+          className,
+        )}
         closeButtonProps={resolvedCloseButtonProps}
+        descriptionProps={descriptionProps}
         onClose={onClose}
         startAccessory={renderSeverityAccessory({
           severity,

--- a/packages/design-system-react/src/components/Toast/Toast.tsx
+++ b/packages/design-system-react/src/components/Toast/Toast.tsx
@@ -82,7 +82,7 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>(
 
     useLayoutEffect(() => {
       if (!node) {
-        return;
+        return undefined;
       }
 
       const syncTheme = () => {


### PR DESCRIPTION
## **Description**

Polish React `Toast` surface styling so it stays aligned with the React Native Toast treatment from #1391.

**Why:** Toast was always using section background, 12px radius, and default description color, which didn’t match the desired visual spec.

**What changed:**
- Light theme: `background.default` + medium shadow (`shadow-md`)
- Dark theme: `background.section` (no shadow)
- Theme resolved from the closest `[data-theme]` ancestor first; falls back to `.dark`, then `document.documentElement` (React has no `useTheme` like RN). Nested `data-theme="light"` inside a distant `.dark` ancestor keeps light polish.
- Description defaults to `TextColor.TextAlternative`
- Border radius updated from 12px (`rounded-xl`) to 16px (`rounded-2xl`)
- Included unit tests for theme background/shadow, nested theme precedence, callback refs, radius, and description color

## **Related issues**

Related: https://github.com/MetaMask/metamask-design-system/pull/1391

## **Manual testing steps**

1. Run `yarn storybook` and open **Components → Toast**
2. In light theme, confirm toast uses default background, medium shadow, and 16px corners
3. In dark theme, confirm toast uses section background with no shadow
4. In Storybook “both” mode, confirm each panel’s toast matches that panel’s theme
5. Confirm description text uses the alternative text color
6. Spot-check Default, severity, action button, and close stories still behave as before

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/0383f870-f963-4ee0-aec2-352a92dddb29


### **After**


https://github.com/user-attachments/assets/5ba6b89f-fddc-4ad0-adbc-b4c614007fe0



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and presentation-only changes to Toast with unit test coverage; no auth, data, or API behavior changes.
> 
> **Overview**
> Aligns the React **Toast** surface with the RN treatment: **light** uses default background, `shadow-md`, and **16px** corners (`rounded-2xl`); **dark** uses section background with **no** shadow.
> 
> Theme is resolved at runtime via `resolveIsDarkTheme` (closest `[data-theme]`, then `.dark`, then `document.documentElement`), with a **MutationObserver** so changes to theme attributes stay in sync. Nested `data-theme="light"` inside a `.dark` ancestor keeps light styling.
> 
> Description text now defaults to **`TextColor.TextAlternative`** through `descriptionProps`. Ref forwarding is merged into a callback ref so theme detection still works with object and function refs.
> 
> Tests cover light/dark/nested theme classes, description color, and callback refs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 101460d8274a20a0cf7c03283acf28dbe4bfd38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->