### PR TITLE
fix: Polish RN BannerBase spacing for consistency

### DIFF
--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -55,6 +55,8 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
   const shouldShowActionButton = Boolean(actionButtonOnPress);
   const isActionButtonLayoutEnd =
     actionButtonLayout === BannerBaseActionButtonLayout.End;
+  const hasActionButtonBelow =
+    shouldShowActionButton && !isActionButtonLayoutEnd;
 
   const actionButton = shouldShowActionButton ? (
     <Button
@@ -73,8 +75,10 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
       alignItems={BoxAlignItems.Start}
       gap={4}
       backgroundColor={BoxBackgroundColor.BackgroundDefault}
-      paddingVertical={3}
-      paddingHorizontal={4}
+      paddingTop={3}
+      paddingBottom={hasActionButtonBelow ? 4 : 3}
+      paddingLeft={4}
+      paddingRight={shouldShowCloseButton ? 2 : 4}
       twClassName={mergeTwClassName('rounded-xl', twClassName)}
       {...props}
     >
@@ -95,7 +99,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
           ))}
 
         {hasContent(description) && (
-          <Box>
+          <Box twClassName={hasContent(title) ? 'mt-0.5' : undefined}>
             {isTextContent(description) ? (
               <Text variant={TextVariant.BodySm} {...descriptionProps}>
                 {description}
@@ -115,7 +119,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
             children
           ))}
 
-        {shouldShowActionButton && !isActionButtonLayoutEnd && (
+        {hasActionButtonBelow && (
           <Box twClassName="mt-2">{actionButton}</Box>
         )}
       </Box>

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
@@ -119,9 +119,7 @@ export const BannerBase: React.FC<BannerBaseProps> = ({
             children
           ))}
 
-        {hasActionButtonBelow && (
-          <Box twClassName="mt-2">{actionButton}</Box>
-        )}
+        {hasActionButtonBelow && <Box twClassName="mt-2">{actionButton}</Box>}
       </Box>
 
       {shouldShowActionButton && isActionButtonLayoutEnd && actionButton}


### PR DESCRIPTION
## **Description**

Polishes React Native `BannerBase` spacing so padding and title/description gap match design more closely.

1. **Bottom padding:** When an action button is below content, use `paddingBottom={4}` (16px); otherwise keep `3` (12px).
2. **Right padding:** When a close button is present, use `paddingRight={2}` (8px); otherwise keep `4` (16px).
3. **Title → description gap:** When both are present, add `mt-0.5` (2px) above the description.

### Impacted components

* `BannerAlert`
* `Toast`

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-design-system/pull/1304
https://github.com/MetaMask/metamask-design-system/pull/1391
https://github.com/MetaMask/metamask-design-system/pull/1394

## **Manual testing steps**

1. Run `yarn storybook:ios` (or Android) and open **BannerBase** / **BannerAlert** / **Toast** stories (they compose `BannerBase`).
2. Confirm default padding: 12px vertical, 16px horizontal when there is no close button and no below action button.
3. With a close button: right padding is 8px.
4. With an action button in `Below` layout: bottom padding is 16px.
5. With title + description: 2px gap between them; description-only has no extra top margin.

## **Screenshots/Recordings**

### **Before**


https://github.com/user-attachments/assets/070f0754-9b52-45a7-b543-988e10ebbd6f



### **After**


https://github.com/user-attachments/assets/02764783-f984-4e4b-9f02-ba9e18206eca



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)