### PR TITLE
fix: Polish React BannerBase spacing for consistency

### DIFF
--- a/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
@@ -59,6 +59,8 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
     const shouldShowActionButton = Boolean(actionButtonOnClick);
     const isActionButtonLayoutEnd =
       actionButtonLayout === BannerBaseActionButtonLayout.End;
+    const hasActionButtonBelow =
+      shouldShowActionButton && !isActionButtonLayoutEnd;
 
     const actionButton = shouldShowActionButton ? (
       <Button
@@ -78,8 +80,10 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
         alignItems={BoxAlignItems.Start}
         gap={4}
         backgroundColor={BoxBackgroundColor.BackgroundDefault}
-        paddingVertical={3}
-        paddingHorizontal={4}
+        paddingTop={3}
+        paddingBottom={hasActionButtonBelow ? 4 : 3}
+        paddingLeft={4}
+        paddingRight={shouldShowCloseButton ? 2 : 4}
         className={twMerge('rounded-xl', className)}
         {...props}
       >
@@ -100,7 +104,7 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
             ))}
 
           {hasContent(description) && (
-            <Box>
+            <Box className={hasContent(title) ? 'mt-0.5' : undefined}>
               {isTextContent(description) ? (
                 <Text variant={TextVariant.BodySm} {...descriptionProps}>
                   {description}
@@ -120,7 +124,7 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
               children
             ))}
 
-          {shouldShowActionButton && !isActionButtonLayoutEnd && (
+          {hasActionButtonBelow && (
             <Box className="mt-2">{actionButton}</Box>
           )}
         </Box>

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.tsx
@@ -124,9 +124,7 @@ export const BannerBase = forwardRef<HTMLDivElement, BannerBaseProps>(
               children
             ))}
 
-          {hasActionButtonBelow && (
-            <Box className="mt-2">{actionButton}</Box>
-          )}
+          {hasActionButtonBelow && <Box className="mt-2">{actionButton}</Box>}
         </Box>
 
         {shouldShowActionButton && isActionButtonLayoutEnd && actionButton}


### PR DESCRIPTION
## **Description**

Polishes React `BannerBase` spacing so padding and content gaps match design more closely, aligning with the React Native updates in [#1393](https://github.com/MetaMask/metamask-design-system/pull/1393).

### Alignments

* **Top padding:** `paddingTop={3}` (12px)
* **Bottom padding:** `paddingBottom={4}` (16px) when an action button is below; otherwise `paddingBottom={3}` (12px)
* **Left padding:** `paddingLeft={4}` (16px)
* **Right padding:** `paddingRight={2}` (8px) when a close button is present; otherwise `paddingRight={4}` (16px)
* **Title → description gap:** `mt-0.5` (2px) when both title and description are present; no extra top margin for description-only
* **Action button (Below):** `mt-2` (8px) above the action button
* **Close button offset:** `-mt-1` on the close `ButtonIcon`

### Impacted components

* BannerAlert
* Toast

## **Related issues**

Related: https://github.com/MetaMask/metamask-design-system/pull/1393

## **Manual testing steps**

1. Run `yarn storybook` and open **BannerBase** / **BannerAlert** / **Toast** stories (they compose `BannerBase`).
2. Confirm default padding: 12px top/bottom, 16px left/right when there is no close button and no below action button.
3. With a close button: right padding is 8px; close button uses `-mt-1`.
4. With an action button in `Below` layout: bottom padding is 16px; action button has `mt-2` (8px) above it.
5. With title + description: 2px gap between them; description-only has no extra top margin.

## **Screenshots/Recordings**

### **Before**


https://github.com/user-attachments/assets/2a125449-1cb1-4127-896e-476dc2540f9e



### **After**


https://github.com/user-attachments/assets/7938476d-eecf-4309-a2ea-b26ae8e7583e



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)