### PR TITLE
docs: Add Toast topOffset migration notes for next release

### DIFF
--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -80,11 +80,11 @@ Toast now slides in from the **top** of the screen (below the safe area), aligni
 
 **What changed:**
 
-| Before                  | After                |
-| ----------------------- | -------------------- |
-| `bottomOffset`          | `topOffset`          |
-| `customTopOffset`       | `topOffset`          |
-| `TOAST_BOTTOM_PADDING`  | `TOAST_TOP_PADDING`  |
+| Before                 | After               |
+| ---------------------- | ------------------- |
+| `bottomOffset`         | `topOffset`         |
+| `customTopOffset`      | `topOffset`         |
+| `TOAST_BOTTOM_PADDING` | `TOAST_TOP_PADDING` |
 
 - **`topOffset`** is optional extra offset from the **top** (in addition to the safe-area inset and default top padding), not from the bottom.
 - **`TOAST_TOP_PADDING`** replaces the exported **`TOAST_BOTTOM_PADDING`** constant. The default padding value also changes (36 → 8) to match top placement.
@@ -94,7 +94,10 @@ Toast now slides in from the **top** of the screen (below the safe area), aligni
 
 ```tsx
 // Before
-import { TOAST_BOTTOM_PADDING, toast } from '@metamask/design-system-react-native';
+import {
+  TOAST_BOTTOM_PADDING,
+  toast,
+} from '@metamask/design-system-react-native';
 
 toast({
   hasNoTimeout: false,
@@ -4783,11 +4786,11 @@ toast({
 
 Toasts appear from the **top** of the screen. The per-toast offset prop maps as follows:
 
-| Source API | Design System |
-| ---------- | ------------- |
-| Mobile `customBottomOffset` | `topOffset` |
-| Mobile `customTopOffset` | `topOffset` |
-| Design system `bottomOffset` (0.23.0–0.36.0) | `topOffset` |
+| Source API                                   | Design System |
+| -------------------------------------------- | ------------- |
+| Mobile `customBottomOffset`                  | `topOffset`   |
+| Mobile `customTopOffset`                     | `topOffset`   |
+| Design system `bottomOffset` (0.23.0–0.36.0) | `topOffset`   |
 
 `topOffset` is extra offset from the top (in addition to the safe-area inset and default top padding). The exported padding constant is **`TOAST_TOP_PADDING`** (replacing **`TOAST_BOTTOM_PADDING`**).
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -4,6 +4,7 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Table of Contents
 
+- [From version 0.x.0 to 0.x.0](#from-version-0x0-to-0x0)
 - [From version 0.35.0 to 0.36.0](#from-version-0350-to-0360)
 - [From version 0.33.0 to 0.34.0](#from-version-0330-to-0340)
 - [From version 0.29.0 to 0.30.0](#from-version-0290-to-0300)
@@ -47,6 +48,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TabEmptyState Component](#tabemptystate-component)
   - [Toast Component](#toast-component)
 - [Version Updates](#version-updates)
+  - [From version 0.x.0 to 0.x.0](#from-version-0x0-to-0x0)
   - [From version 0.35.0 to 0.36.0](#from-version-0350-to-0360)
   - [From version 0.30.0 to 0.31.0](#from-version-0300-to-0310)
   - [From version 0.26.0 to 0.27.0](#from-version-0260-to-0270)
@@ -65,6 +67,61 @@ This guide provides detailed instructions for migrating your project from one ve
   - [From version 0.1.0 to 0.2.0](#from-version-010-to-020)
 
 ## Version Updates
+
+### From version 0.x.0 to 0.x.0
+
+<a id="from-version-0x0-to-0x0"></a>
+
+<a id="toast-bottomoffset-to-topoffset"></a>
+
+#### Toast: top placement and `bottomOffset` / `TOAST_BOTTOM_PADDING` renames
+
+Toast now slides in from the **top** of the screen (below the safe area), aligning with iOS system banners and avoiding overlap with bottom actions. Two public names that reflected bottom placement are renamed accordingly.
+
+**What changed:**
+
+| Before                  | After                |
+| ----------------------- | -------------------- |
+| `bottomOffset`          | `topOffset`          |
+| `customTopOffset`       | `topOffset`          |
+| `TOAST_BOTTOM_PADDING`  | `TOAST_TOP_PADDING`  |
+
+- **`topOffset`** is optional extra offset from the **top** (in addition to the safe-area inset and default top padding), not from the bottom.
+- **`TOAST_TOP_PADDING`** replaces the exported **`TOAST_BOTTOM_PADDING`** constant. The default padding value also changes (36 → 8) to match top placement.
+- Enter/exit motion uses a spring (`withSpring`) instead of `withTiming`; call sites do not need to change for that alone.
+
+**Migration:**
+
+```tsx
+// Before
+import { TOAST_BOTTOM_PADDING, toast } from '@metamask/design-system-react-native';
+
+toast({
+  hasNoTimeout: false,
+  title: 'Saved',
+  bottomOffset: 24,
+});
+
+const padding = TOAST_BOTTOM_PADDING;
+
+// After
+import { TOAST_TOP_PADDING, toast } from '@metamask/design-system-react-native';
+
+toast({
+  hasNoTimeout: false,
+  title: 'Saved',
+  topOffset: 24,
+});
+
+const padding = TOAST_TOP_PADDING;
+```
+
+**Impact:**
+
+- Any **`toast({ bottomOffset: ... })`**, **`toast({ customTopOffset: ... })`**, or **`showToast({ bottomOffset: ... })`** call site must rename the prop to **`topOffset`**. Re-evaluate the numeric value if it was tuned for bottom placement.
+- Any import of **`TOAST_BOTTOM_PADDING`** must switch to **`TOAST_TOP_PADDING`**.
+
+See [Toast Component](#toast-component) for the full mobile → design system mapping.
 
 ### From version 0.35.0 to 0.36.0
 
@@ -4688,7 +4745,7 @@ type ToastOptions = {
   startAccessory?: React.ReactNode;
   severity?: ToastSeverity;
   iconAlertProps?: ToastIconProps;
-  bottomOffset?: number;
+  topOffset?: number;
 };
 ```
 
@@ -4722,9 +4779,19 @@ toast({
 });
 ```
 
-##### `customBottomOffset` → `bottomOffset`
+##### `customBottomOffset` / `customTopOffset` / `bottomOffset` → `topOffset`
 
-The per-toast offset prop is renamed from `customBottomOffset` to `bottomOffset`.
+Toasts appear from the **top** of the screen. The per-toast offset prop maps as follows:
+
+| Source API | Design System |
+| ---------- | ------------- |
+| Mobile `customBottomOffset` | `topOffset` |
+| Mobile `customTopOffset` | `topOffset` |
+| Design system `bottomOffset` (0.23.0–0.36.0) | `topOffset` |
+
+`topOffset` is extra offset from the top (in addition to the safe-area inset and default top padding). The exported padding constant is **`TOAST_TOP_PADDING`** (replacing **`TOAST_BOTTOM_PADDING`**).
+
+See [Toast: top placement and `bottomOffset` / `TOAST_BOTTOM_PADDING` renames](#toast-bottomoffset-to-topoffset) for the version-to-version migration.
 
 #### Error Behavior
 


### PR DESCRIPTION
## **Description**

### **What issues does this PR address?**

* **Missing migration guidance for Toast renames**: The iOS-style top toast animation work ([#1304](https://github.com/MetaMask/metamask-design-system/pull/1304)) renames offset and padding APIs for top placement. Those breaking renames need to be documented in `MIGRATION.md` before the next release cut.

### **Key improvements**

* Adds a placeholder version section (`From version 0.x.0 to 0.x.0`) documenting the Toast top-placement renames:
  * `bottomOffset` → `topOffset`
  * `customTopOffset` → `topOffset`
  * `TOAST_BOTTOM_PADDING` → `TOAST_TOP_PADDING`
* Updates the Toast Component (mobile → design system) mapping so `customBottomOffset`, `customTopOffset`, and legacy `bottomOffset` all resolve to `topOffset`, and documents `TOAST_TOP_PADDING`.

### **Notes for reviewers**

- Version numbers are intentionally left as `0.x.0` placeholders until the release cut fills them in.
- Docs-only change; no runtime code in this PR.

## **Related issues**

Follow-up to: https://github.com/MetaMask/metamask-design-system/pull/1304

## **Manual testing steps**

1. Open `packages/design-system-react-native/MIGRATION.md`.
2. Confirm the TOC links to `From version 0.x.0 to 0.x.0`.
3. Confirm the new Toast rename section lists `bottomOffset`, `customTopOffset`, and `TOAST_BOTTOM_PADDING`.
4. Confirm the Toast Component offset mapping includes `customTopOffset` → `topOffset`.

## **Screenshots/Recordings**

### **Before**

N/A — docs only

### **After**

N/A — docs only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)