### PR TITLE
fix: Merge Toast descriptionProps defaults in JSX

### DIFF
--- a/packages/design-system-react-native/src/components/Toast/Toast.test.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toast.test.tsx
@@ -229,4 +229,21 @@ describe('Toast', () => {
       tw.style(TextColor.TextAlternative),
     );
   });
+
+  it('merges descriptionProps without dropping the default color', () => {
+    const tw = renderHook(() => useTailwind()).result.current;
+
+    render(
+      <Toast
+        description="Description of toast"
+        descriptionProps={{ testID: 'toast-description' }}
+        onClose={() => undefined}
+        title="Toast message"
+      />,
+    );
+
+    const description = screen.getByTestId('toast-description');
+    expect(description).toHaveStyle(tw.style(TextColor.TextAlternative));
+    expect(description).toHaveTextContent('Description of toast');
+  });
 });

--- a/packages/design-system-react-native/src/components/Toast/Toast.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toast.tsx
@@ -52,7 +52,7 @@ export const Toast: React.FC<ToastProps> = ({
   childrenWrapperProps,
   closeButtonProps,
   description,
-  descriptionProps = { color: TextColor.TextAlternative },
+  descriptionProps,
   onClose,
   iconAlertProps,
   severity = ToastSeverity.Default,
@@ -101,7 +101,10 @@ export const Toast: React.FC<ToastProps> = ({
       childrenWrapperProps={childrenWrapperProps}
       closeButtonProps={resolvedCloseButtonProps}
       description={description}
-      descriptionProps={descriptionProps}
+      descriptionProps={{
+        color: TextColor.TextAlternative,
+        ...descriptionProps,
+      }}
       onClose={onClose}
       startAccessory={renderSeverityAccessory({
         iconAlertProps,


### PR DESCRIPTION
## **Description**

Follow-up to [#1391](https://github.com/MetaMask/metamask-design-system/pull/1391) (Toast polish: background, description color, border radius).

### **What issues does this PR address?**

* **`descriptionProps` defaults replace instead of merge**: In [#1391](https://github.com/MetaMask/metamask-design-system/pull/1391), Toast defaulted `descriptionProps` in the destructure (`descriptionProps = { color: TextColor.TextAlternative }`). Passing any consumer object (e.g. `{ numberOfLines: 2 }` or `{ testID: '...' }`) replaced the whole default, so `TextAlternative` was silently dropped.

### **Key improvements**

* Merge the default description color inline in JSX: `descriptionProps={{ color: TextColor.TextAlternative, ...descriptionProps }}`, matching the team convention for props objects.
* Add a regression test that passes partial `descriptionProps` and asserts the default color is still applied.

### **Notes for reviewers**

- Addresses George’s post-merge follow-up on [#1391](https://github.com/MetaMask/metamask-design-system/pull/1391): merge `descriptionProps` in JSX instead of defaulting in the destructure.

## **Related issues**

Follow-up to: https://github.com/MetaMask/metamask-design-system/pull/1391

## **Manual testing steps**

1. Open React Native Storybook (`yarn storybook:ios` or `yarn storybook:android`) and navigate to Toast stories.
2. Confirm description text still uses the alternative text color by default.
3. Optionally verify a toast with `descriptionProps={{ testID: '...' }}` (or `numberOfLines`) keeps the alternative color.

## **Screenshots/Recordings**

### **Before**

N/A — behavior fix; visual default is unchanged when `descriptionProps` is omitted

### **After**

N/A — behavior fix; visual default is unchanged when `descriptionProps` is omitted

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)