### PR TITLE
Release/55.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "54.0.0",
+  "version": "55.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- docs: Add Toast topOffset migration notes for next release ([#1395](https://github.com/MetaMask/metamask-design-system/pull/1395))
+- fix: Merge Toast descriptionProps defaults in JSX ([#1396](https://github.com/MetaMask/metamask-design-system/pull/1396))
+- feat: Add iOS-style top toast animation for React Native ([#1304](https://github.com/MetaMask/metamask-design-system/pull/1304))
+- fix: Polish React Native Toast background, description color and border radius ([#1391](https://github.com/MetaMask/metamask-design-system/pull/1391))
+
 ## [0.36.0]
 
 ### Added

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,12 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.37.0]
 
-### Uncategorized
+### Changed
 
-- docs: Add Toast topOffset migration notes for next release ([#1395](https://github.com/MetaMask/metamask-design-system/pull/1395))
-- fix: Merge Toast descriptionProps defaults in JSX ([#1396](https://github.com/MetaMask/metamask-design-system/pull/1396))
-- feat: Add iOS-style top toast animation for React Native ([#1304](https://github.com/MetaMask/metamask-design-system/pull/1304))
-- fix: Polish React Native Toast background, description color and border radius ([#1391](https://github.com/MetaMask/metamask-design-system/pull/1391))
+- **BREAKING:** Updated `Toast` / `Toaster` to slide in from the top of the screen (below the safe area) with spring-based enter/exit motion ([#1304](https://github.com/MetaMask/metamask-design-system/pull/1304))
+  - Renamed `bottomOffset` and `customTopOffset` to `topOffset` (extra offset from the top, in addition to the safe-area inset and default top padding)
+  - Renamed exported `TOAST_BOTTOM_PADDING` to `TOAST_TOP_PADDING` and changed the default padding value from 36 to 8
+  - See [Migration Guide](./MIGRATION.md#toast-bottomoffset-to-topoffset)
+- Updated `Toast` surface styling for light/dark themes: light uses `background.default` with medium shadow; dark uses `background.section` with no shadow; border radius updated from 12px to 16px; description defaults to `TextColor.TextAlternative` ([#1391](https://github.com/MetaMask/metamask-design-system/pull/1391))
+
+### Fixed
+
+- Fixed `Toast` `descriptionProps` so partial consumer props merge with the default `TextAlternative` color instead of replacing it ([#1396](https://github.com/MetaMask/metamask-design-system/pull/1396))
 
 ## [0.36.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0]
+
 ### Uncategorized
 
 - docs: Add Toast topOffset migration notes for next release ([#1395](https://github.com/MetaMask/metamask-design-system/pull/1395))
@@ -614,7 +616,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.36.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.37.0...HEAD
+[0.37.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.36.0...@metamask/design-system-react-native@0.37.0
 [0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.35.0...@metamask/design-system-react-native@0.36.0
 [0.35.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.34.0...@metamask/design-system-react-native@0.35.0
 [0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.33.0...@metamask/design-system-react-native@0.34.0

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -4,7 +4,7 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Table of Contents
 
-- [From version 0.x.0 to 0.x.0](#from-version-0x0-to-0x0)
+- [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
 - [From version 0.35.0 to 0.36.0](#from-version-0350-to-0360)
 - [From version 0.33.0 to 0.34.0](#from-version-0330-to-0340)
 - [From version 0.29.0 to 0.30.0](#from-version-0290-to-0300)
@@ -48,7 +48,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TabEmptyState Component](#tabemptystate-component)
   - [Toast Component](#toast-component)
 - [Version Updates](#version-updates)
-  - [From version 0.x.0 to 0.x.0](#from-version-0x0-to-0x0)
+  - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
   - [From version 0.35.0 to 0.36.0](#from-version-0350-to-0360)
   - [From version 0.30.0 to 0.31.0](#from-version-0300-to-0310)
   - [From version 0.26.0 to 0.27.0](#from-version-0260-to-0270)
@@ -68,9 +68,9 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Version Updates
 
-### From version 0.x.0 to 0.x.0
+### From version 0.36.0 to 0.37.0
 
-<a id="from-version-0x0-to-0x0"></a>
+<a id="from-version-0360-to-0370"></a>
 
 <a id="toast-bottomoffset-to-topoffset"></a>
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
<!--
Release PR Template

Use this template for release PRs by creating your PR with:
https://github.com/MetaMask/metamask-design-system/compare/main...release/VERSION?template=release.md

Or use the default PR template and manually copy this structure.
-->

## Release 55.0.0

React Native Toast moves to iOS-style top placement with spring motion, related offset/padding renames, and surface polish (theme background, description color, border radius).

### 📦 Package Versions

- `@metamask/design-system-react-native`: **0.37.0**

### 📱 React Native Updates (0.37.0)

#### Changed

- **BREAKING:** Updated `Toast` / `Toaster` to slide in from the top of the screen (below the safe area) with spring-based enter/exit motion ([#1304](https://github.com/MetaMask/metamask-design-system/pull/1304))
  - Renamed `bottomOffset` and `customTopOffset` to `topOffset`
  - Renamed exported `TOAST_BOTTOM_PADDING` to `TOAST_TOP_PADDING` (default padding 36 → 8)
  - Migration: [Toast topOffset renames](./packages/design-system-react-native/MIGRATION.md#toast-bottomoffset-to-topoffset)
- Updated `Toast` surface styling for light/dark themes: light uses `background.default` with medium shadow; dark uses `background.section` with no shadow; border radius 12px → 16px; description defaults to `TextColor.TextAlternative` ([#1391](https://github.com/MetaMask/metamask-design-system/pull/1391))

#### Fixed

- Fixed `Toast` `descriptionProps` so partial consumer props merge with the default `TextAlternative` color instead of replacing it ([#1396](https://github.com/MetaMask/metamask-design-system/pull/1396))

### ⚠️ Breaking Changes

#### Toast top placement and offset renames (React Native Only)

**What Changed:**

- Toasts now appear from the **top** of the screen (below the safe area) instead of the bottom
- `bottomOffset` / `customTopOffset` → `topOffset`
- `TOAST_BOTTOM_PADDING` → `TOAST_TOP_PADDING` (default 36 → 8)

**Migration:**

```tsx
// Before (0.36.0)
import {
  TOAST_BOTTOM_PADDING,
  toast,
} from '@metamask/design-system-react-native';

toast({
  hasNoTimeout: false,
  title: 'Saved',
  bottomOffset: 24,
});

const padding = TOAST_BOTTOM_PADDING;

// After (0.37.0)
import { TOAST_TOP_PADDING, toast } from '@metamask/design-system-react-native';

toast({
  hasNoTimeout: false,
  title: 'Saved',
  topOffset: 24,
});

const padding = TOAST_TOP_PADDING;
```

**Impact:**

- Call sites using `bottomOffset`, `customTopOffset`, or `TOAST_BOTTOM_PADDING` must rename and re-evaluate numeric offsets tuned for bottom placement

See [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0360-to-0370)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-react-native: minor (0.36.0 → 0.37.0) - Toast top placement feature + breaking offset/padding renames
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples (if breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking Toast API renames and placement change require consumer updates; release-only diff is low risk, but adopters must follow MIGRATION.md for offset/padding call sites.
> 
> **Overview**
> **Release 55.0.0** cuts **`@metamask/design-system-react-native` 0.37.0** (monorepo root **55.0.0**). The diff is version bumps plus finalized **CHANGELOG** and **MIGRATION** entries for work already merged—not new component code in this PR.
> 
> Shipped in **0.37.0**: **Toast** / **Toaster** now enter from the **top** (below the safe area) with spring motion. **Breaking** renames: `bottomOffset` / `customTopOffset` → **`topOffset`**, **`TOAST_BOTTOM_PADDING`** → **`TOAST_TOP_PADDING`** (default padding **36 → 8**). Surface updates include theme-specific backgrounds/shadows, **16px** radius, and default description **`TextAlternative`**. **`descriptionProps`** now merge with defaults instead of replacing the default text color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e593d280bbf0882ffeb05042e73765a5f94def02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->