### PR TITLE
ci: reduce workflow overhead with low-risk cleanups (pt 1)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,9 +10,6 @@ jobs:
   chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/ensure-blocking-pr-labels-absent.yml
+++ b/.github/workflows/ensure-blocking-pr-labels-absent.yml
@@ -13,10 +13,6 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
-        with:
-          is-high-risk-environment: false
       - name: Run command
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -7,9 +7,6 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.x]
     outputs:
       child-workspace-package-names: ${{ steps.workspace-package-names.outputs.child-workspace-package-names }}
     steps:
@@ -17,7 +14,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
-          cache-node-modules: ${{ matrix.node-version == '24.x' }}
+          cache-node-modules: true
       - name: Fetch workspace package names
         id: workspace-package-names
         run: |
@@ -28,9 +25,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     needs: prepare
-    strategy:
-      matrix:
-        node-version: [24.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -54,7 +48,6 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        node-version: [24.x]
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
@@ -74,9 +67,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: prepare
-    strategy:
-      matrix:
-        node-version: [24.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -91,14 +81,10 @@ jobs:
             exit 1
           fi
 
-  test:
-    name: Test
+  test-scripts:
+    name: Test scripts
     runs-on: ubuntu-latest
     needs: prepare
-    strategy:
-      matrix:
-        node-version: [24.x]
-        package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -106,6 +92,27 @@ jobs:
           is-high-risk-environment: false
       - run: yarn build
       - run: yarn test:scripts
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      matrix:
+        package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
+        with:
+          is-high-risk-environment: false
+      - run: yarn build
       - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Require clean working directory
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
 
   analyse-code:
     name: Code scanner
-    needs: check-workflows
     uses: ./.github/workflows/security-code-scanner.yml
     permissions:
       actions: read


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

A set of low-risk, no-behavior-change cleanups to the GitHub Actions workflows. These were identified as part of a broader workflow optimization audit; a follow-up PR (pt 2) will tackle the more structural changes (artifact sharing, Storybook workflow consolidation).

Changes:

- **Remove single-value `node-version` matrices** from `lint-build-test.yml` and `chromatic.yml`. A matrix with one entry still pays the scheduling/fanout overhead with zero parallelism benefit. `cache-node-modules` in the `prepare` job was updated from the now-removed `matrix.node-version == '24.x'` condition to a plain `true`.
- **Extract `yarn test:scripts` into its own job** (`test-scripts`) so it runs once instead of once per workspace package in the `test` matrix.
- **Remove `action-checkout-and-setup` from the label-check workflow.** The `github-script` action reads labels directly from `context.payload.pull_request.labels`, which is always present in `pull_request` events — no local checkout is needed.
- **Run `analyse-code` in parallel with `check-workflows`** by removing the `needs: check-workflows` dependency. The security scanner has no dependency on workflow file validation and was being blocked unnecessarily.

## **Expected CI impact**

This PR delivers real efficiency gains, but **don't expect a dramatic drop in overall Main workflow wall-clock time**. Comparing recent runs on this branch vs main, total time was within normal variance (~217s vs ~221s).

### What we gain

- **Less duplicate work:** `yarn test:scripts` previously ran 6× (once per package matrix job); it now runs once in a dedicated `test-scripts` job (~40–50s of redundant runner time removed per PR).
- **Faster package test jobs:** Removing `test:scripts` from each matrix leg trimmed the slowest jobs by ~9–18s (e.g. react-native ~104s → ~95s, react ~93s → ~75s).
- **Parallel security scan:** `analyse-code` no longer waits for `check-workflows` (~7s earlier start on a ~3 min job).
- **Minor trims:** Single-entry matrix removal and dropping checkout from the label-check workflow reduce scheduling/checkout overhead (seconds, not minutes).

### Why total time barely changes (for now)

The Main workflow critical path is still dominated by jobs this PR doesn't shorten:

- Code scanner (~3 min)
- Slowest package test (~1.5 min + prepare), still running a full `yarn build` per matrix job
- Chromatic and Storybook accessibility tests

Pt 1 removes wasted repetition and starts the scanner slightly sooner, but **does not** address the structural cost drivers (duplicate builds across jobs, lack of artifact sharing, no changed-path package filtering).

### Pt 2 (follow-up)

The next workflow cleanup PR will tackle those structural changes — artifact sharing between jobs, Storybook workflow consolidation, and related optimizations — where the meaningful wall-clock improvements should show up.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Verify CI passes on this PR — all jobs in the `Main` workflow should complete successfully.
2. Confirm the `test-scripts` job appears as a distinct job in the workflow run (not grouped inside the `test` matrix).
3. Confirm `ensure-blocking-pr-labels-absent` still correctly fails when the `DO-NOT-MERGE` label is applied.
4. Confirm `analyse-code` and `check-workflows` now start simultaneously in the workflow graph.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions orchestration with no application or security logic changes; the main risk is mis-wiring jobs so a check is skipped or duplicated, which the PR author describes as behavior-preserving.
> 
> **Overview**
> Trims GitHub Actions scheduling overhead without changing what gets validated.
> 
> **`lint-build-test.yml` and `chromatic.yml`:** Drops single-entry `node-version` matrices from jobs that never parallelized. The `prepare` job now always passes `cache-node-modules: true` instead of tying caching to the removed matrix.
> 
> **Script tests:** Adds a dedicated **`test-scripts`** job that runs `yarn build` and `yarn test:scripts` once after `prepare`, and removes that step from each **`test`** matrix leg so script tests are not repeated per workspace package.
> 
> **Label gate:** **`ensure-blocking-pr-labels-absent`** no longer runs `action-checkout-and-setup`; it only uses `github-script` against `context.payload.pull_request.labels`.
> 
> **`main.yml`:** **`analyse-code`** no longer `needs: check-workflows`, so the security scanner can start alongside workflow linting instead of waiting on it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 237458f6a8913c84a0f970351c863a58fc4846cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->