### PR TITLE
fix(dsrn): stop Content description from stretching end accessory

### DIFF
--- a/packages/design-system-react-native/src/components/Content/Content.tsx
+++ b/packages/design-system-react-native/src/components/Content/Content.tsx
@@ -76,7 +76,7 @@ export const Content: React.FC<ContentProps> = ({
               endAccessory={descriptionEndAccessory}
               gap={1}
             >
-              <BoxColumn twClassName="flex-1 min-w-0">
+              <BoxColumn twClassName="min-w-0">
                 <TextOrChildren
                   textProps={{
                     variant: TextVariant.BodySm,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In `Content`, the description slot was wrapped in a `BoxColumn` with `flex-1`, which made short descriptions expand and pinned `descriptionEndAccessory` to the trailing edge of the row (e.g. address + copy icon no longer hugging). This restores hugging layout while keeping the column wrapper needed for MultiLine stacked description nodes.

**What changed:**
- Removed `flex-1` from the description `BoxColumn` in React Native `Content` (`min-w-0` only, matching subvalue)
- No public API changes

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-934

## **Manual testing steps**

1. Run React Native Storybook (`yarn storybook:ios` or `yarn storybook:android`)
2. Open **Components/Content → Description End Accessory** and confirm the end icon sits immediately after the description text (not flush right)
3. Open **Components/Content → Variant** (MultiLine example) and confirm multiple description lines still stack vertically
4. Run unit tests:
   ```bash
   yarn workspace @metamask/design-system-react-native run jest --testPathPattern="Content/Content.test" --coverage=false
   ```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-21 at 19 56 15" src="https://github.com/user-attachments/assets/a027c2a6-90e9-4e08-b51b-dd053e11e547" />

### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-21 at 19 56 04" src="https://github.com/user-attachments/assets/8597bc96-6020-4812-a661-d4681f615402" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout class change in a presentational component with no API or logic changes.
> 
> **Overview**
> Fixes React Native **Content** layout so **description** text and **`descriptionEndAccessory`** (e.g. copy icon) sit next to each other instead of the accessory being pinned to the far right of the row.
> 
> The description wrapper **`BoxColumn`** no longer uses **`flex-1`**—only **`min-w-0`**, aligned with the subvalue column—so short descriptions don’t expand while the column wrapper still supports stacked MultiLine description nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 782f7b3ccdaeaed954234c63907e596a6549254a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->