### PR TITLE
feat(dsrn): add HelpText component

### DIFF
--- a/packages/design-system-react-native/src/components/HelpText/HelpText.constants.ts
+++ b/packages/design-system-react-native/src/components/HelpText/HelpText.constants.ts
@@ -1,0 +1,9 @@
+import { HelpTextSeverity, TextColor } from '@metamask/design-system-shared';
+
+export const MAP_HELPTEXT_SEVERITY_COLOR: Record<HelpTextSeverity, TextColor> =
+  {
+    [HelpTextSeverity.Danger]: TextColor.ErrorDefault,
+    [HelpTextSeverity.Warning]: TextColor.WarningDefault,
+    [HelpTextSeverity.Success]: TextColor.SuccessDefault,
+    [HelpTextSeverity.Info]: TextColor.InfoDefault,
+  };

--- a/packages/design-system-react-native/src/components/HelpText/HelpText.stories.tsx
+++ b/packages/design-system-react-native/src/components/HelpText/HelpText.stories.tsx
@@ -1,0 +1,76 @@
+import {
+  BoxFlexDirection,
+  HelpTextSeverity,
+  TextColor,
+} from '@metamask/design-system-shared';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import React from 'react';
+
+import { Box } from '../Box';
+
+import { HelpText } from './HelpText';
+import type { HelpTextProps } from './HelpText.types';
+
+const meta: Meta<HelpTextProps> = {
+  title: 'Components/HelpText',
+  component: HelpText,
+  argTypes: {
+    severity: {
+      control: 'select',
+      options: Object.keys(HelpTextSeverity),
+      mapping: HelpTextSeverity,
+      description: 'Optional semantic severity. When set, overrides `color`.',
+    },
+    color: {
+      control: 'select',
+      options: Object.keys(TextColor),
+      mapping: TextColor,
+      description: 'Optional text color. Ignored when `severity` is provided.',
+    },
+    children: {
+      control: 'text',
+      description: 'The content of the help text.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Box twClassName="p-4">
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<HelpTextProps>;
+
+export const Default: Story = {
+  args: {
+    children: 'Helper message',
+  },
+};
+
+export const Severity: Story = {
+  render: () => (
+    <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+      {Object.values(HelpTextSeverity).map((severity) => (
+        <HelpText key={severity} severity={severity}>
+          {severity} severity message
+        </HelpText>
+      ))}
+    </Box>
+  ),
+};
+
+export const Color: Story = {
+  render: () => (
+    <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+      <HelpText color={TextColor.TextDefault}>Default text color</HelpText>
+      <HelpText color={TextColor.TextAlternative}>
+        Alternative text color
+      </HelpText>
+      <HelpText color={TextColor.PrimaryDefault}>Primary text color</HelpText>
+    </Box>
+  ),
+};

--- a/packages/design-system-react-native/src/components/HelpText/HelpText.stories.tsx
+++ b/packages/design-system-react-native/src/components/HelpText/HelpText.stories.tsx
@@ -32,13 +32,6 @@ const meta: Meta<HelpTextProps> = {
       description: 'The content of the help text.',
     },
   },
-  decorators: [
-    (Story) => (
-      <Box twClassName="p-4">
-        <Story />
-      </Box>
-    ),
-  ],
 };
 
 export default meta;

--- a/packages/design-system-react-native/src/components/HelpText/HelpText.test.tsx
+++ b/packages/design-system-react-native/src/components/HelpText/HelpText.test.tsx
@@ -1,0 +1,83 @@
+import { HelpTextSeverity, TextColor } from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { render, renderHook } from '@testing-library/react-native';
+import React from 'react';
+
+import { HelpText } from './HelpText';
+import { MAP_HELPTEXT_SEVERITY_COLOR } from './HelpText.constants';
+
+describe('HelpText', () => {
+  let tw: ReturnType<typeof useTailwind>;
+
+  beforeAll(() => {
+    const { result } = renderHook(() => useTailwind());
+    tw = result.current;
+  });
+
+  it('renders children with default body-sm variant and default text color', () => {
+    const { getByTestId } = render(
+      <HelpText testID="help-text">Helper message</HelpText>,
+    );
+
+    const helpText = getByTestId('help-text');
+    expect(helpText).toBeOnTheScreen();
+    expect(helpText).toHaveTextContent('Helper message');
+    expect(helpText).toHaveStyle(
+      tw.style('text-body-sm', TextColor.TextDefault),
+    );
+  });
+
+  describe('Severity', () => {
+    Object.values(HelpTextSeverity).forEach((severity) => {
+      it(`applies ${severity} severity color`, () => {
+        const { getByTestId } = render(
+          <HelpText severity={severity} testID="help-text">
+            Severity message
+          </HelpText>,
+        );
+
+        expect(getByTestId('help-text')).toHaveStyle(
+          tw.style(MAP_HELPTEXT_SEVERITY_COLOR[severity]),
+        );
+      });
+    });
+
+    it('overrides explicit color when severity is provided', () => {
+      const { getByTestId } = render(
+        <HelpText
+          severity={HelpTextSeverity.Danger}
+          color={TextColor.SuccessDefault}
+          testID="help-text"
+        >
+          Severity wins
+        </HelpText>,
+      );
+
+      const helpText = getByTestId('help-text');
+      expect(helpText).toHaveStyle(tw.style(TextColor.ErrorDefault));
+      expect(helpText).not.toHaveStyle(tw.style(TextColor.SuccessDefault));
+    });
+  });
+
+  it('applies a custom color when no severity is provided', () => {
+    const { getByTestId } = render(
+      <HelpText color={TextColor.PrimaryDefault} testID="help-text">
+        Custom color
+      </HelpText>,
+    );
+
+    expect(getByTestId('help-text')).toHaveStyle(
+      tw.style(TextColor.PrimaryDefault),
+    );
+  });
+
+  it('merges custom twClassName', () => {
+    const { getByTestId } = render(
+      <HelpText twClassName="mt-2" testID="help-text">
+        With class
+      </HelpText>,
+    );
+
+    expect(getByTestId('help-text')).toHaveStyle(tw`mt-2`);
+  });
+});

--- a/packages/design-system-react-native/src/components/HelpText/HelpText.tsx
+++ b/packages/design-system-react-native/src/components/HelpText/HelpText.tsx
@@ -1,0 +1,24 @@
+import { TextColor, TextVariant } from '@metamask/design-system-shared';
+import React from 'react';
+
+import { Text } from '../Text';
+
+import { MAP_HELPTEXT_SEVERITY_COLOR } from './HelpText.constants';
+import type { HelpTextProps } from './HelpText.types';
+
+export const HelpText: React.FC<HelpTextProps> = ({
+  severity,
+  color = TextColor.TextDefault,
+  twClassName,
+  children,
+  ...props
+}) => (
+  <Text
+    variant={TextVariant.BodySm}
+    color={severity ? MAP_HELPTEXT_SEVERITY_COLOR[severity] : color}
+    twClassName={twClassName}
+    {...props}
+  >
+    {children}
+  </Text>
+);

--- a/packages/design-system-react-native/src/components/HelpText/HelpText.types.ts
+++ b/packages/design-system-react-native/src/components/HelpText/HelpText.types.ts
@@ -1,0 +1,5 @@
+import type { HelpTextPropsShared } from '@metamask/design-system-shared';
+
+import type { TextProps } from '../Text';
+
+export type HelpTextProps = HelpTextPropsShared & Omit<TextProps, 'variant'>;

--- a/packages/design-system-react-native/src/components/HelpText/README.md
+++ b/packages/design-system-react-native/src/components/HelpText/README.md
@@ -1,0 +1,112 @@
+# HelpText
+
+HelpText displays a helper or validation message below a form field. Use it to give the user guidance ("Must be at least 8 characters") or to surface field-level feedback ("Address is invalid"). Reach for a higher-level component such as `BannerAlert` when the message applies to a whole form or page rather than a single field.
+
+```tsx
+import { HelpText } from '@metamask/design-system-react-native';
+
+<HelpText>Default Example</HelpText>;
+```
+
+## Props
+
+### `severity`
+
+Use the `severity` prop to convey the semantic meaning of the message. When set, `severity` overrides any value passed to `color`.
+
+Available severities:
+
+- `HelpTextSeverity.Info`
+- `HelpTextSeverity.Success`
+- `HelpTextSeverity.Warning`
+- `HelpTextSeverity.Danger`
+
+| TYPE               | REQUIRED | DEFAULT     |
+| ------------------ | -------- | ----------- |
+| `HelpTextSeverity` | No       | `undefined` |
+
+```tsx
+<HelpText severity={HelpTextSeverity.Info}>Informational message</HelpText>
+<HelpText severity={HelpTextSeverity.Success}>Success message</HelpText>
+<HelpText severity={HelpTextSeverity.Warning}>Warning message</HelpText>
+<HelpText severity={HelpTextSeverity.Danger}>Danger message</HelpText>
+```
+
+### `color`
+
+Use `color` to set a custom text color when no `severity` applies. Ignored when `severity` is provided.
+
+| TYPE        | REQUIRED | DEFAULT                 |
+| ----------- | -------- | ----------------------- |
+| `TextColor` | No       | `TextColor.TextDefault` |
+
+```tsx
+<HelpText color={TextColor.TextDefault}>Default text color</HelpText>
+<HelpText color={TextColor.TextAlternative}>Alternative text color</HelpText>
+<HelpText color={TextColor.PrimaryDefault}>Primary text color</HelpText>
+```
+
+### `children`
+
+The content of the `HelpText` component.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | Yes      | `undefined` |
+
+```tsx
+import { HelpText } from '@metamask/design-system-react-native';
+
+<HelpText>Must be at least 8 characters</HelpText>;
+```
+
+### `twClassName`
+
+Use the `twClassName` prop to add Tailwind CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+| TYPE     | REQUIRED | DEFAULT     |
+| -------- | -------- | ----------- |
+| `string` | No       | `undefined` |
+
+```tsx
+import { HelpText } from '@metamask/design-system-react-native';
+
+// Add additional styles
+<HelpText twClassName="mt-4">
+  Helper with margin
+</HelpText>
+
+// Override default styles
+<HelpText twClassName="text-error-default">
+  Override color
+</HelpText>
+```
+
+### `style`
+
+Use the `style` prop to customize the component's appearance with React Native styles. For consistent styling, prefer using `twClassName` with Tailwind classes when possible. Use `style` with `tw.style()` for conditionals or dynamic values.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `StyleProp<TextStyle>` | No       | `undefined` |
+
+```tsx
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+
+export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
+  const tw = useTailwind();
+
+  return (
+    <HelpText style={tw.style('mt-2', isActive && 'text-success-default')}>
+      Conditional styling
+    </HelpText>
+  );
+};
+```
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react-native/src/components/HelpText/README.md
+++ b/packages/design-system-react-native/src/components/HelpText/README.md
@@ -5,7 +5,7 @@ HelpText displays a helper or validation message below a form field. Use it to g
 ```tsx
 import { HelpText } from '@metamask/design-system-react-native';
 
-<HelpText>Default Example</HelpText>;
+<HelpText>Helper message</HelpText>;
 ```
 
 ## Props

--- a/packages/design-system-react-native/src/components/HelpText/index.ts
+++ b/packages/design-system-react-native/src/components/HelpText/index.ts
@@ -1,0 +1,3 @@
+export { HelpTextSeverity } from '@metamask/design-system-shared';
+export { HelpText } from './HelpText';
+export type { HelpTextProps } from './HelpText.types';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -162,6 +162,9 @@ export type {
   HeaderStandardCenterColumnProps,
 } from './temp-components/HeaderStandardCenterColumn';
 
+export { HelpText, HelpTextSeverity } from './HelpText';
+export type { HelpTextProps } from './HelpText';
+
 export { Icon, IconColor, IconName, IconSize } from './Icon';
 export type { IconProps } from './Icon';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

HelpText already exists on web (`@metamask/design-system-react`) with shared types in `@metamask/design-system-shared`, but React Native did not have a matching component for field-level helper/validation messages.

This PR ports HelpText to `@metamask/design-system-react-native` as a `Text` wrapper fixed to `TextVariant.BodySm`, using the existing `HelpTextSeverity` / `HelpTextPropsShared` API so mobile and web stay aligned.

**What changed:**
- Added `HelpText` with optional `severity` (Info / Success / Warning / Danger) that maps to semantic `TextColor` values and overrides `color` when set
- Extended shared props with RN `TextProps` (`Omit<..., 'variant'>`), including `twClassName` / `style`
- Exported `HelpText`, `HelpTextSeverity`, and `HelpTextProps` from the package barrel
- Added Storybook stories (`Components/HelpText`: Default, Severity, Color), unit tests, and a consumer README

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-935

## **Manual testing steps**

1. Run unit tests: `yarn workspace @metamask/design-system-react-native run jest src/components/HelpText`
2. Start RN Storybook (`yarn storybook:ios` or `yarn storybook:android`) and open **Components/HelpText**
3. On **Default**, confirm BodySm styling and default text color; toggle `severity` and `color` in controls and confirm severity overrides color
4. Open **Severity** and **Color** stories and confirm Info / Success / Warning / Danger colors and the custom color examples

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/7d73ebd1-0ebe-4fba-b62b-c38ee7c46069

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New presentational design-system component with no auth, data, or business-logic changes; risk is limited to adoption in form UIs.
> 
> **Overview**
> Adds **HelpText** to `@metamask/design-system-react-native` so mobile can show field-level helper and validation copy with the same **`HelpTextSeverity`** / shared props API as web.
> 
> The component is a thin **`Text`** wrapper fixed to **`TextVariant.BodySm`**. Optional **`severity`** maps Info / Success / Warning / Danger to semantic **`TextColor`** values and **overrides** **`color`** when set; otherwise **`color`** defaults to **`TextColor.TextDefault`**. Props combine **`HelpTextPropsShared`** with RN **`Text`** props (minus **`variant`**), including **`twClassName`** and **`style`**.
> 
> **`HelpText`**, **`HelpTextSeverity`**, and **`HelpTextProps`** are exported from the package barrel. Storybook (**Default**, **Severity**, **Color**), unit tests, and a consumer README are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f0e23b7fc2b29b3560565da0f7da5812ad83070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->