### PR TITLE
chore(deps): bump @figma/code-connect from 1.4.8 to 1.4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@babel/core": "^7.25.2",
     "@babel/plugin-transform-modules-commonjs": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
-    "@figma/code-connect": "^1.4.8",
+    "@figma/code-connect": "^1.4.9",
     "@lavamoat/allow-scripts": "^3.2.1",
     "@metamask/create-release-branch": "^4.2.1",
     "@metamask/eslint-config": "^15.0.1",

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -55,7 +55,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.23.3",
-    "@figma/code-connect": "^1.4.8",
+    "@figma/code-connect": "^1.4.9",
     "@gorhom/bottom-sheet": "^5.1.3",
     "@metamask/auto-changelog": "^6.1.1",
     "@metamask/design-system-twrnc-preset": "workspace:^",

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -56,7 +56,7 @@
     "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {
-    "@figma/code-connect": "^1.4.8",
+    "@figma/code-connect": "^1.4.9",
     "@jest/globals": "^29.7.0",
     "@metamask/auto-changelog": "^6.1.1",
     "@metamask/design-system-tailwind-preset": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2717,9 +2717,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@figma/code-connect@npm:^1.4.8":
-  version: 1.4.8
-  resolution: "@figma/code-connect@npm:1.4.8"
+"@figma/code-connect@npm:^1.4.9":
+  version: 1.4.9
+  resolution: "@figma/code-connect@npm:1.4.9"
   dependencies:
     boxen: "npm:5.1.1"
     chalk: "npm:^4.1.2"
@@ -2745,7 +2745,7 @@ __metadata:
     zod-validation-error: "npm:^3.2.0"
   bin:
     figma: bin/figma
-  checksum: 10/2395f2beb60222b676c5d6660125f0d5f772d7ed9336c88b5910f3cabe58f74dfc341a6fce662771aa1608ffcb13c4500e06c4d85057356a852c87380542c038
+  checksum: 10/539793ad6c83335f87ade9d3f275f816f65c8891bdef98aed6ba71e30ba6b468bb87f733ebce9372ed0e93c332e808857610e65f9b42d92568d9396bcdce69e2
   languageName: node
   linkType: hard
 
@@ -3375,7 +3375,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/preset-react": "npm:^7.25.9"
     "@babel/preset-typescript": "npm:^7.23.3"
-    "@figma/code-connect": "npm:^1.4.8"
+    "@figma/code-connect": "npm:^1.4.9"
     "@gorhom/bottom-sheet": "npm:^5.1.3"
     "@metamask/auto-changelog": "npm:^6.1.1"
     "@metamask/design-system-shared": "workspace:^"
@@ -3427,7 +3427,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/design-system-react@workspace:packages/design-system-react"
   dependencies:
-    "@figma/code-connect": "npm:^1.4.8"
+    "@figma/code-connect": "npm:^1.4.9"
     "@floating-ui/react-dom": "npm:^2.1.2"
     "@jest/globals": "npm:^29.7.0"
     "@metamask/auto-changelog": "npm:^6.1.1"
@@ -3645,7 +3645,7 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/plugin-transform-modules-commonjs": "npm:^7.23.3"
     "@babel/preset-typescript": "npm:^7.23.3"
-    "@figma/code-connect": "npm:^1.4.8"
+    "@figma/code-connect": "npm:^1.4.9"
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@metamask/create-release-branch": "npm:^4.2.1"
     "@metamask/eslint-config": "npm:^15.0.1"


### PR DESCRIPTION
## **Description**

Bump `@figma/code-connect` from `1.4.8` to `1.4.9` in the root workspace and both `@metamask/design-system-react` and `@metamask/design-system-react-native`.


1.4.9 improves how slot contents are rendered by adopting the augmented getSlot API from [Code Connect v1.4.9](https://github.com/figma/code-connect/releases/tag/v1.4.9).

getSlot('SlotName') still renders as before, and the return value now also exposes connectedInstances — the connected instances directly in the slot. That lets us render a slot’s connected children inline.

This may resolve the review comment on [PR #1359](https://github.com/MetaMask/metamask-design-system/pull/1359#discussion_r3625796705) about mapping `startAccessory` / `endAccessory` via slots vs connected instances.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Confirm `@figma/code-connect` resolves to `1.4.9` (`yarn why @figma/code-connect`).
2. Run a Code Connect parse/publish dry-run for React and React Native packages to confirm the CLI still works.
3. Spot-check that existing `.figma.tsx` mappings still load as expected.

## **Screenshots/Recordings**

N/A — dependency bump only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)