### PR TITLE
feat: add React IconAlert and HelpText showIcon

### DIFF
--- a/packages/design-system-react-native/src/components/HelpText/HelpText.stories.tsx
+++ b/packages/design-system-react-native/src/components/HelpText/HelpText.stories.tsx
@@ -21,6 +21,11 @@ const meta: Meta<HelpTextProps> = {
       mapping: HelpTextSeverity,
       description: 'Optional semantic severity. When set, overrides `color`.',
     },
+    showIcon: {
+      control: 'boolean',
+      description:
+        'When true and `severity` is set, shows a leading IconAlert.',
+    },
     color: {
       control: 'select',
       options: Object.keys(TextColor),
@@ -41,6 +46,7 @@ type Story = StoryObj<HelpTextProps>;
 export const Default: Story = {
   args: {
     children: 'Helper message',
+    showIcon: false,
   },
 };
 
@@ -49,6 +55,18 @@ export const Severity: Story = {
     <Box flexDirection={BoxFlexDirection.Column} gap={2}>
       {Object.values(HelpTextSeverity).map((severity) => (
         <HelpText key={severity} severity={severity}>
+          {severity} severity message
+        </HelpText>
+      ))}
+    </Box>
+  ),
+};
+
+export const ShowIcon: Story = {
+  render: () => (
+    <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+      {Object.values(HelpTextSeverity).map((severity) => (
+        <HelpText key={severity} severity={severity} showIcon>
           {severity} severity message
         </HelpText>
       ))}

--- a/packages/design-system-react-native/src/components/HelpText/HelpText.test.tsx
+++ b/packages/design-system-react-native/src/components/HelpText/HelpText.test.tsx
@@ -1,7 +1,14 @@
-import { HelpTextSeverity, TextColor } from '@metamask/design-system-shared';
+import {
+  HelpTextSeverity,
+  IconSize,
+  TextColor,
+} from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { render, renderHook } from '@testing-library/react-native';
 import React from 'react';
+
+import { TWCLASSMAP_ICON_SIZE_DIMENSION } from '../Icon/Icon.constants';
+import { ICON_ALERT_SEVERITY_MAP } from '../IconAlert/IconAlert.constants';
 
 import { HelpText } from './HelpText';
 import { MAP_HELPTEXT_SEVERITY_COLOR } from './HelpText.constants';
@@ -56,6 +63,49 @@ describe('HelpText', () => {
       const helpText = getByTestId('help-text');
       expect(helpText).toHaveStyle(tw.style(TextColor.ErrorDefault));
       expect(helpText).not.toHaveStyle(tw.style(TextColor.SuccessDefault));
+    });
+  });
+
+  describe('ShowIcon', () => {
+    it('omits the icon by default', () => {
+      const { queryByTestId } = render(
+        <HelpText severity={HelpTextSeverity.Danger} testID="help-text">
+          No icon
+        </HelpText>,
+      );
+
+      expect(queryByTestId('help-text-icon')).toBeNull();
+    });
+
+    it('omits the icon when showIcon is true but severity is omitted', () => {
+      const { queryByTestId } = render(
+        <HelpText showIcon testID="help-text">
+          No icon without severity
+        </HelpText>,
+      );
+
+      expect(queryByTestId('help-text-icon')).toBeNull();
+    });
+
+    Object.values(HelpTextSeverity).forEach((severity) => {
+      it(`shows the ${severity} icon when showIcon is true`, () => {
+        const { getByTestId, getByText } = render(
+          <HelpText severity={severity} showIcon testID="help-text">
+            With icon
+          </HelpText>,
+        );
+
+        const icon = getByTestId('help-text-icon');
+        const { color } = ICON_ALERT_SEVERITY_MAP[severity];
+
+        expect(icon).toBeOnTheScreen();
+        expect(icon).toHaveStyle(
+          tw.style(color, TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Sm]),
+        );
+        expect(getByText('With icon')).toHaveStyle(
+          tw.style(MAP_HELPTEXT_SEVERITY_COLOR[severity]),
+        );
+      });
     });
   });
 

--- a/packages/design-system-react-native/src/components/HelpText/HelpText.tsx
+++ b/packages/design-system-react-native/src/components/HelpText/HelpText.tsx
@@ -1,6 +1,14 @@
-import { TextColor, TextVariant } from '@metamask/design-system-shared';
+import {
+  BoxAlignItems,
+  BoxFlexDirection,
+  IconSize,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-shared';
 import React from 'react';
 
+import { Box } from '../Box';
+import { IconAlert } from '../IconAlert';
 import { Text } from '../Text';
 
 import { MAP_HELPTEXT_SEVERITY_COLOR } from './HelpText.constants';
@@ -8,17 +16,48 @@ import type { HelpTextProps } from './HelpText.types';
 
 export const HelpText: React.FC<HelpTextProps> = ({
   severity,
+  showIcon = false,
   color = TextColor.TextDefault,
   twClassName,
+  style,
+  testID,
   children,
   ...props
-}) => (
-  <Text
-    variant={TextVariant.BodySm}
-    color={severity ? MAP_HELPTEXT_SEVERITY_COLOR[severity] : color}
-    twClassName={twClassName}
-    {...props}
-  >
-    {children}
-  </Text>
-);
+}) => {
+  const textColor = severity ? MAP_HELPTEXT_SEVERITY_COLOR[severity] : color;
+
+  if (!(showIcon && severity)) {
+    return (
+      <Text
+        variant={TextVariant.BodySm}
+        color={textColor}
+        twClassName={twClassName}
+        style={style}
+        testID={testID}
+        {...props}
+      >
+        {children}
+      </Text>
+    );
+  }
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      gap={1}
+      twClassName={twClassName}
+      style={style}
+      testID={testID}
+    >
+      <IconAlert
+        severity={severity}
+        size={IconSize.Sm}
+        testID="help-text-icon"
+      />
+      <Text variant={TextVariant.BodySm} color={textColor} {...props}>
+        {children}
+      </Text>
+    </Box>
+  );
+};

--- a/packages/design-system-react-native/src/components/HelpText/README.md
+++ b/packages/design-system-react-native/src/components/HelpText/README.md
@@ -32,6 +32,23 @@ Available severities:
 <HelpText severity={HelpTextSeverity.Danger}>Danger message</HelpText>
 ```
 
+### `showIcon`
+
+When `true` and `severity` is set, shows a leading `IconAlert` at `IconSize.Sm`. If `severity` is omitted, the icon is not shown.
+
+| TYPE      | REQUIRED | DEFAULT |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
+```tsx
+<HelpText severity={HelpTextSeverity.Info} showIcon>
+  Informational message
+</HelpText>
+<HelpText severity={HelpTextSeverity.Danger} showIcon>
+  Danger message
+</HelpText>
+```
+
 ### `color`
 
 Use `color` to set a custom text color when no `severity` applies. Ignored when `severity` is provided.

--- a/packages/design-system-react/src/components/HelpText/HelpText.stories.tsx
+++ b/packages/design-system-react/src/components/HelpText/HelpText.stories.tsx
@@ -27,6 +27,11 @@ const meta: Meta<HelpTextProps> = {
       mapping: HelpTextSeverity,
       description: 'Optional semantic severity. When set, overrides `color`.',
     },
+    showIcon: {
+      control: 'boolean',
+      description:
+        'When true and `severity` is set, shows a leading IconAlert.',
+    },
     color: {
       control: 'select',
       options: Object.keys(TextColor),
@@ -52,6 +57,7 @@ type Story = StoryObj<HelpTextProps>;
 export const Default: Story = {
   args: {
     children: 'Helper message',
+    showIcon: false,
   },
 };
 
@@ -66,6 +72,18 @@ export const Severity: Story = {
           }
         >
           {severityKey} severity message
+        </HelpText>
+      ))}
+    </Box>
+  ),
+};
+
+export const ShowIcon: Story = {
+  render: () => (
+    <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+      {Object.values(HelpTextSeverity).map((severity) => (
+        <HelpText key={severity} severity={severity} showIcon>
+          {severity} severity message
         </HelpText>
       ))}
     </Box>

--- a/packages/design-system-react/src/components/HelpText/HelpText.test.tsx
+++ b/packages/design-system-react/src/components/HelpText/HelpText.test.tsx
@@ -1,6 +1,13 @@
-import { HelpTextSeverity, TextColor } from '@metamask/design-system-shared';
+import {
+  HelpTextSeverity,
+  IconSize,
+  TextColor,
+} from '@metamask/design-system-shared';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+
+import { TWCLASSMAP_ICON_SIZE_DIMENSION } from '../Icon/Icon.constants';
+import { ICON_ALERT_SEVERITY_MAP } from '../IconAlert/IconAlert.constants';
 
 import { HelpText } from './HelpText';
 import { MAP_HELPTEXT_SEVERITY_COLOR } from './HelpText.constants';
@@ -45,6 +52,50 @@ describe('HelpText', () => {
       const helpText = screen.getByTestId('help-text');
       expect(helpText).toHaveClass(TextColor.ErrorDefault);
       expect(helpText).not.toHaveClass(TextColor.SuccessDefault);
+    });
+  });
+
+  describe('ShowIcon', () => {
+    it('omits the icon by default', () => {
+      render(
+        <HelpText severity={HelpTextSeverity.Danger} data-testid="help-text">
+          No icon
+        </HelpText>,
+      );
+
+      expect(screen.queryByTestId('help-text-icon')).not.toBeInTheDocument();
+    });
+
+    it('omits the icon when showIcon is true but severity is omitted', () => {
+      render(
+        <HelpText showIcon data-testid="help-text">
+          No icon without severity
+        </HelpText>,
+      );
+
+      expect(screen.queryByTestId('help-text-icon')).not.toBeInTheDocument();
+    });
+
+    Object.values(HelpTextSeverity).forEach((severity) => {
+      it(`shows the ${severity} icon when showIcon is true`, () => {
+        render(
+          <HelpText severity={severity} showIcon data-testid="help-text">
+            With icon
+          </HelpText>,
+        );
+
+        const icon = screen.getByTestId('help-text-icon');
+        const { color } = ICON_ALERT_SEVERITY_MAP[severity];
+
+        expect(icon).toBeInTheDocument();
+        expect(icon).toHaveClass(
+          color,
+          TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Sm],
+        );
+        expect(screen.getByTestId('help-text')).toHaveClass(
+          MAP_HELPTEXT_SEVERITY_COLOR[severity],
+        );
+      });
     });
   });
 

--- a/packages/design-system-react/src/components/HelpText/HelpText.tsx
+++ b/packages/design-system-react/src/components/HelpText/HelpText.tsx
@@ -1,6 +1,14 @@
-import { TextColor, TextVariant } from '@metamask/design-system-shared';
+import {
+  BoxAlignItems,
+  BoxFlexDirection,
+  IconSize,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-shared';
 import React from 'react';
 
+import { Box } from '../Box';
+import { IconAlert } from '../IconAlert';
 import { Text } from '../Text';
 
 import { MAP_HELPTEXT_SEVERITY_COLOR } from './HelpText.constants';
@@ -8,17 +16,42 @@ import type { HelpTextProps } from './HelpText.types';
 
 export const HelpText: React.FC<HelpTextProps> = ({
   severity,
+  showIcon = false,
   color = TextColor.TextDefault,
   className,
   children,
   ...props
-}) => (
-  <Text
-    variant={TextVariant.BodySm}
-    color={severity ? MAP_HELPTEXT_SEVERITY_COLOR[severity] : color}
-    className={className}
-    {...props}
-  >
-    {children}
-  </Text>
-);
+}) => {
+  const textColor = severity ? MAP_HELPTEXT_SEVERITY_COLOR[severity] : color;
+
+  if (!(showIcon && severity)) {
+    return (
+      <Text
+        variant={TextVariant.BodySm}
+        color={textColor}
+        className={className}
+        {...props}
+      >
+        {children}
+      </Text>
+    );
+  }
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      gap={1}
+      className={className}
+    >
+      <IconAlert
+        severity={severity}
+        size={IconSize.Sm}
+        data-testid="help-text-icon"
+      />
+      <Text variant={TextVariant.BodySm} color={textColor} {...props}>
+        {children}
+      </Text>
+    </Box>
+  );
+};

--- a/packages/design-system-react/src/components/HelpText/README.mdx
+++ b/packages/design-system-react/src/components/HelpText/README.mdx
@@ -50,6 +50,33 @@ Available severities:
 
 <Canvas of={HelpTextStories.Severity} />
 
+### `showIcon`
+
+When `true` and `severity` is set, shows a leading [`IconAlert`](./../IconAlert/README.mdx) at `IconSize.Sm`. If `severity` is omitted, the icon is not shown.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>boolean</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>false</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HelpTextStories.ShowIcon} />
+
 ### `color`
 
 Use `color` to set a custom text color when no `severity` applies. Ignored when `severity` is provided.

--- a/packages/design-system-react/src/components/IconAlert/IconAlert.constants.ts
+++ b/packages/design-system-react/src/components/IconAlert/IconAlert.constants.ts
@@ -1,0 +1,27 @@
+import {
+  IconAlertSeverity,
+  IconColor,
+  IconName,
+} from '@metamask/design-system-shared';
+
+export const ICON_ALERT_SEVERITY_MAP: Record<
+  IconAlertSeverity,
+  { name: IconName; color: IconColor }
+> = {
+  [IconAlertSeverity.Info]: {
+    name: IconName.Info,
+    color: IconColor.PrimaryDefault,
+  },
+  [IconAlertSeverity.Success]: {
+    name: IconName.Confirmation,
+    color: IconColor.SuccessDefault,
+  },
+  [IconAlertSeverity.Warning]: {
+    name: IconName.Danger,
+    color: IconColor.WarningDefault,
+  },
+  [IconAlertSeverity.Danger]: {
+    name: IconName.Error,
+    color: IconColor.ErrorDefault,
+  },
+};

--- a/packages/design-system-react/src/components/IconAlert/IconAlert.stories.tsx
+++ b/packages/design-system-react/src/components/IconAlert/IconAlert.stories.tsx
@@ -1,0 +1,98 @@
+import {
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxFlexWrap,
+  IconAlertSeverity,
+  IconSize,
+} from '@metamask/design-system-shared';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+
+import { Box } from '../Box';
+import type { BoxProps } from '../Box';
+
+import { IconAlert } from './IconAlert';
+import type { IconAlertProps } from './IconAlert.types';
+import README from './README.mdx';
+
+const meta: Meta<IconAlertProps> = {
+  title: 'React Components/IconAlert',
+  component: IconAlert,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    severity: {
+      control: 'select',
+      options: Object.keys(IconAlertSeverity),
+      mapping: IconAlertSeverity,
+      description:
+        'Maps to a fixed icon and theme color for alerts and messaging.',
+    },
+    size: {
+      control: 'select',
+      options: Object.keys(IconSize),
+      mapping: IconSize,
+      description: 'Optional icon size.',
+    },
+    className: {
+      control: 'text',
+      description:
+        'Optional CSS class to merge with the component’s default classes.',
+    },
+  },
+};
+
+export default meta;
+
+const IconAlertStoryWrapper: React.FC<BoxProps> = ({ children, ...props }) => (
+  <Box
+    backgroundColor={BoxBackgroundColor.BackgroundDefault}
+    padding={4}
+    {...props}
+  >
+    {children}
+  </Box>
+);
+
+type Story = StoryObj<IconAlertProps>;
+
+export const Default: Story = {
+  args: {
+    severity: IconAlertSeverity.Info,
+  },
+  render: (args) => (
+    <IconAlertStoryWrapper>
+      <IconAlert {...args} />
+    </IconAlertStoryWrapper>
+  ),
+};
+
+export const Severity: Story = {
+  render: () => (
+    <IconAlertStoryWrapper
+      flexDirection={BoxFlexDirection.Row}
+      flexWrap={BoxFlexWrap.Wrap}
+      gap={4}
+    >
+      {Object.values(IconAlertSeverity).map((severity) => (
+        <Box key={severity} alignItems={BoxAlignItems.Center} gap={2}>
+          <IconAlert severity={severity} size={IconSize.Xl} />
+        </Box>
+      ))}
+    </IconAlertStoryWrapper>
+  ),
+};
+
+export const Size: Story = {
+  render: () => (
+    <IconAlertStoryWrapper gap={4}>
+      {Object.values(IconSize).map((size) => (
+        <IconAlert key={size} severity={IconAlertSeverity.Info} size={size} />
+      ))}
+    </IconAlertStoryWrapper>
+  ),
+};

--- a/packages/design-system-react/src/components/IconAlert/IconAlert.test.tsx
+++ b/packages/design-system-react/src/components/IconAlert/IconAlert.test.tsx
@@ -1,0 +1,64 @@
+import { IconAlertSeverity, IconSize } from '@metamask/design-system-shared';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { TWCLASSMAP_ICON_SIZE_DIMENSION } from '../Icon/Icon.constants';
+
+import { IconAlert } from './IconAlert';
+import { ICON_ALERT_SEVERITY_MAP } from './IconAlert.constants';
+
+type IconAlertSeverityUnion =
+  (typeof IconAlertSeverity)[keyof typeof IconAlertSeverity];
+
+describe('IconAlert', () => {
+  describe('when a severity is provided', () => {
+    it.each(Object.values(IconAlertSeverity) as IconAlertSeverityUnion[])(
+      'renders %s with the mapped color class',
+      (severity) => {
+        render(<IconAlert severity={severity} data-testid="icon-alert" />);
+
+        const icon = screen.getByTestId('icon-alert');
+        const { color } = ICON_ALERT_SEVERITY_MAP[severity];
+
+        expect(icon).toBeInTheDocument();
+        expect(icon).toHaveClass(
+          color,
+          TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Md],
+        );
+      },
+    );
+  });
+
+  describe('when size is Lg', () => {
+    it('applies large icon dimensions for Info severity', () => {
+      render(
+        <IconAlert
+          severity={IconAlertSeverity.Info}
+          size={IconSize.Lg}
+          data-testid="icon-alert"
+        />,
+      );
+
+      const icon = screen.getByTestId('icon-alert');
+      const { color } = ICON_ALERT_SEVERITY_MAP[IconAlertSeverity.Info];
+
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveClass(
+        color,
+        TWCLASSMAP_ICON_SIZE_DIMENSION[IconSize.Lg],
+      );
+    });
+  });
+
+  it('merges custom className', () => {
+    render(
+      <IconAlert
+        severity={IconAlertSeverity.Info}
+        className="opacity-70"
+        data-testid="icon-alert"
+      />,
+    );
+
+    expect(screen.getByTestId('icon-alert')).toHaveClass('opacity-70');
+  });
+});

--- a/packages/design-system-react/src/components/IconAlert/IconAlert.tsx
+++ b/packages/design-system-react/src/components/IconAlert/IconAlert.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Icon } from '../Icon';
+
+import { ICON_ALERT_SEVERITY_MAP } from './IconAlert.constants';
+import type { IconAlertProps } from './IconAlert.types';
+
+export const IconAlert = ({ severity, ...props }: IconAlertProps) => {
+  const { name, color } = ICON_ALERT_SEVERITY_MAP[severity];
+  return <Icon {...props} color={color} name={name} />;
+};
+
+IconAlert.displayName = 'IconAlert';

--- a/packages/design-system-react/src/components/IconAlert/IconAlert.types.ts
+++ b/packages/design-system-react/src/components/IconAlert/IconAlert.types.ts
@@ -1,0 +1,6 @@
+import type { IconAlertPropsShared } from '@metamask/design-system-shared';
+
+import type { IconProps } from '../Icon';
+
+export type IconAlertProps = IconAlertPropsShared &
+  Omit<IconProps, 'name' | 'color' | keyof IconAlertPropsShared>;

--- a/packages/design-system-react/src/components/IconAlert/README.mdx
+++ b/packages/design-system-react/src/components/IconAlert/README.mdx
@@ -1,0 +1,119 @@
+import { Controls, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as IconAlertStories from './IconAlert.stories';
+
+# IconAlert
+
+IconAlert maps a severity value to the correct alert [`Icon`](./../Icon/README.mdx) glyph and theme color for informational, success, warning, and error messaging.
+
+```tsx
+import { IconAlert, IconAlertSeverity } from '@metamask/design-system-react';
+
+<IconAlert severity={IconAlertSeverity.Info} />;
+```
+
+<Canvas of={IconAlertStories.Default} />
+
+## Props
+
+### `severity`
+
+The severity variant to display. Each value uses a fixed icon name and `IconColor` (callers cannot override `name` or `color` on the underlying `Icon`).
+
+Available severities:
+
+- `IconAlertSeverity.Info` — `IconName.Info`, `IconColor.PrimaryDefault`
+- `IconAlertSeverity.Success` — `IconName.Confirmation`, `IconColor.SuccessDefault`
+- `IconAlertSeverity.Warning` — `IconName.Danger`, `IconColor.WarningDefault`
+- `IconAlertSeverity.Danger` — `IconName.Error`, `IconColor.ErrorDefault`
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>IconAlertSeverity</code>
+      </td>
+      <td align="left">Yes</td>
+      <td align="left">
+        <code>-</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={IconAlertStories.Severity} />
+
+### `size`
+
+The size of the icon. Same behavior as [`Icon` `size`](./../Icon/README.mdx).
+
+Available sizes:
+
+- `IconSize.Xs` (12px)
+- `IconSize.Sm` (16px)
+- `IconSize.Md` (20px)
+- `IconSize.Lg` (24px)
+- `IconSize.Xl` (32px)
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>IconSize</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>IconSize.Md</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={IconAlertStories.Size} />
+
+### `className`
+
+Use the `className` prop to add custom CSS classes to the component. Classes merge with the component's defaults using `twMerge`.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Component API
+
+<Controls of={IconAlertStories.Default} />
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react/src/components/IconAlert/index.ts
+++ b/packages/design-system-react/src/components/IconAlert/index.ts
@@ -1,0 +1,3 @@
+export { IconAlertSeverity } from '@metamask/design-system-shared';
+export { IconAlert } from './IconAlert';
+export type { IconAlertProps } from './IconAlert.types';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -89,6 +89,9 @@ export { Icon } from './Icon';
 export { IconName, IconSize, IconColor } from './Icon';
 export type { IconProps } from './Icon';
 
+export { IconAlert, IconAlertSeverity } from './IconAlert';
+export type { IconAlertProps } from './IconAlert';
+
 export { Input } from './Input';
 export type { InputProps } from './Input';
 

--- a/packages/design-system-shared/src/types/HelpText/HelpText.types.ts
+++ b/packages/design-system-shared/src/types/HelpText/HelpText.types.ts
@@ -25,4 +25,10 @@ export type HelpTextPropsShared = {
    * Optional semantic severity. When set, overrides `color`.
    */
   severity?: HelpTextSeverity;
+  /**
+   * When true and `severity` is set, shows a leading IconAlert.
+   *
+   * @default false
+   */
+  showIcon?: boolean;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`IconAlert` already existed on React Native with shared types, but React web had no matching severity icon primitive. HelpText also needed an optional way to show a leading severity icon next to field-level helper/validation text on both platforms.

This PR ports `IconAlert` to `@metamask/design-system-react` and adds `showIcon` to HelpText so both React and React Native can render a leading `IconAlert` when severity is set.

**What changed:**
- Added React web `IconAlert` (severity → icon glyph/color map aligned with RN; stories, tests, README.mdx, package export)
- Added shared `showIcon?: boolean` (`@default false`) on `HelpTextPropsShared`
- Updated HelpText on React and React Native to render `IconAlert` at `IconSize.Sm` with `gap={1}` when `showIcon && severity`; icon is omitted if severity is missing
- Updated HelpText stories (`ShowIcon`), tests, and READMEs on both platforms

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-966

## **Manual testing steps**

1. Run unit tests:
   - `yarn workspace @metamask/design-system-react run jest src/components/IconAlert src/components/HelpText`
   - `yarn workspace @metamask/design-system-react-native run jest src/components/HelpText`
2. Web Storybook (`yarn storybook`):
   - Open **React Components/IconAlert** — check Default, Severity, Size
   - Open **React Components/HelpText** — toggle `showIcon` on Default; open **ShowIcon** and confirm each severity shows a leading icon + colored text; confirm icon is absent when severity is unset
3. RN Storybook (`yarn storybook:ios` or `yarn storybook:android`):
   - Open **Components/HelpText** — same Default / ShowIcon / severity checks as web

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="296" height="296" alt="Screenshot 2026-07-22 at 11 25 19 PM" src="https://github.com/user-attachments/assets/62f8dccd-fbbf-455d-8ec5-ab699b955891" />
<img width="253" height="203" alt="Screenshot 2026-07-22 at 11 25 28 PM" src="https://github.com/user-attachments/assets/56662f63-2ac7-4ef1-add5-f92918593dc8" />

https://github.com/user-attachments/assets/7f91cacd-782d-4619-bff4-0267db802001

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive design-system API with `showIcon` defaulting to false; no auth, data, or breaking changes to existing HelpText usage.
> 
> **Overview**
> Adds **`IconAlert`** to `@metamask/design-system-react` so web matches the existing React Native severity icon primitive: each `IconAlertSeverity` maps to a fixed glyph and theme color via `ICON_ALERT_SEVERITY_MAP`, with Storybook, tests, docs, and package exports.
> 
> Introduces shared **`showIcon`** on `HelpText` (default `false`). On React and React Native, when `showIcon` and `severity` are both set, **HelpText** renders a horizontal row with a small leading `IconAlert` and the same severity-colored body text; without severity or with `showIcon` off, behavior stays a single `Text` node. Stories, tests, and READMEs cover the new prop on both platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2739be11cbc5bf0c418e69e47a36189cb6e3bfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->