### PR TITLE
feat(dsrn): add KeyValueSelect pressable row with SelectButton value

### DIFF
--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -4,6 +4,7 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Table of Contents
 
+- [From version 0.37.0 to 0.38.0](#from-version-0370-to-0380)
 - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
 - [From version 0.35.0 to 0.36.0](#from-version-0350-to-0360)
 - [From version 0.33.0 to 0.34.0](#from-version-0330-to-0340)
@@ -48,6 +49,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TabEmptyState Component](#tabemptystate-component)
   - [Toast Component](#toast-component)
 - [Version Updates](#version-updates)
+  - [From version 0.37.0 to 0.38.0](#from-version-0370-to-0380)
   - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
   - [From version 0.35.0 to 0.36.0](#from-version-0350-to-0360)
   - [From version 0.30.0 to 0.31.0](#from-version-0300-to-0310)
@@ -67,6 +69,48 @@ This guide provides detailed instructions for migrating your project from one ve
   - [From version 0.1.0 to 0.2.0](#from-version-010-to-020)
 
 ## Version Updates
+
+### From version 0.37.0 to 0.38.0
+
+<a id="from-version-0370-to-0380"></a>
+
+<a id="keyvaluerow-default-horizontal-padding"></a>
+
+#### `KeyValueRow`: default horizontal padding (`px-4`)
+
+`KeyValueRow` now applies **`px-4`** (16px) horizontal padding by default so rows align with other full-width list surfaces without requiring a parent padding wrapper.
+
+**What changed:**
+
+| Before (0.37.0)                                  | After (0.38.0)                                                     |
+| ------------------------------------------------ | ------------------------------------------------------------------ |
+| No default horizontal padding on the row         | Default `px-4` on the outer row                                    |
+| Parents often added `paddingHorizontal` / `px-4` | Prefer relying on the row default; remove duplicate parent padding |
+
+**Migration:**
+
+```tsx
+// Before (0.37.0) — parent owned the horizontal inset
+import { Box, KeyValueRow } from '@metamask/design-system-react-native';
+
+<Box twClassName="px-4">
+  <KeyValueRow keyLabel="Network" value="Ethereum Mainnet" />
+</Box>;
+
+// After (0.38.0) — KeyValueRow owns the inset
+import { KeyValueRow } from '@metamask/design-system-react-native';
+
+<KeyValueRow keyLabel="Network" value="Ethereum Mainnet" />;
+
+// If you still need flush/edge content, override the default
+<KeyValueRow keyLabel="Network" value="Ethereum Mainnet" twClassName="px-0" />;
+```
+
+**Impact:**
+
+- Call sites that already wrap `KeyValueRow` in a `px-4` / `paddingHorizontal={4}` container will get **double** horizontal padding unless that wrapper padding is removed.
+- Call sites that intentionally used flush rows should set `twClassName="px-0"` (or another override) after upgrading.
+- `KeyValueSelect` continues to keep a 16px trailing content inset by merging `pr-1` onto the inner `KeyValueRow` (SelectButton already contributes 12px).
 
 ### From version 0.36.0 to 0.37.0
 

--- a/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.stories.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.stories.tsx
@@ -30,7 +30,8 @@ const meta: Meta<KeyValueRowProps> = {
     value: { control: 'text' },
     variant: {
       control: 'select',
-      options: [KeyValueRowVariant.Summary, KeyValueRowVariant.Input],
+      options: Object.keys(KeyValueRowVariant),
+      mapping: KeyValueRowVariant,
     },
   },
 };
@@ -49,54 +50,22 @@ export const Default: Story = {
   render: (args) => <KeyValueRow {...args} />,
 };
 
-const selectRowChevron = <Icon name={IconName.ArrowDown} size={IconSize.Sm} />;
-
 export const Variant: Story = {
   render: () => (
-    <Box gap={6} twClassName="w-full">
-      <Box>
+    <Box gap={4} twClassName="w-full">
+      {(
+        Object.entries(KeyValueRowVariant) as [
+          keyof typeof KeyValueRowVariant,
+          (typeof KeyValueRowVariant)[keyof typeof KeyValueRowVariant],
+        ][]
+      ).map(([key, rowVariant]) => (
         <KeyValueRow
-          keyLabel="To"
-          value="Account 1"
-          variant={KeyValueRowVariant.Input}
-          valueStartAccessory={
-            <AvatarAccount
-              address={SAMPLE_ADDRESS}
-              size={AvatarAccountSize.Xs}
-            />
-          }
-          valueEndAccessory={selectRowChevron}
-          twClassName="border-b border-border-muted"
+          key={key}
+          keyLabel={key}
+          value={`Value (${key})`}
+          variant={rowVariant}
         />
-        <KeyValueRow
-          keyLabel="Pay with"
-          value="Debit or credit"
-          variant={KeyValueRowVariant.Input}
-          valueStartAccessory={<Icon name={IconName.Card} size={IconSize.Sm} />}
-          valueEndAccessory={selectRowChevron}
-        />
-      </Box>
-      <Box>
-        <KeyValueRow
-          keyLabel="Transaction fees"
-          value="$2.59"
-          variant={KeyValueRowVariant.Summary}
-          keyEndButtonIconProps={{
-            iconName: IconName.Info,
-            onPress: () => undefined,
-          }}
-        />
-        <KeyValueRow
-          keyLabel="Est. time"
-          value="5 min"
-          variant={KeyValueRowVariant.Summary}
-        />
-        <KeyValueRow
-          keyLabel="Total"
-          value="$102.59"
-          variant={KeyValueRowVariant.Summary}
-        />
-      </Box>
+      ))}
     </Box>
   ),
 };

--- a/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.stories.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<KeyValueRowProps> = {
   component: KeyValueRow,
   decorators: [
     (Story) => (
-      <Box twClassName="w-full" paddingHorizontal={4}>
+      <Box twClassName="w-full">
         <Story />
       </Box>
     ),

--- a/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.test.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.test.tsx
@@ -84,8 +84,14 @@ describe('KeyValueRow', () => {
       render(<KeyValueRow keyLabel="K" value="V" testID="key-value-row" />);
 
       expect(screen.getByTestId('key-value-row')).toHaveStyle(
-        tw`h-10 flex-row items-center gap-4`,
+        tw`h-10 px-4 flex-row items-center gap-4`,
       );
+    });
+
+    it('applies default horizontal padding', () => {
+      render(<KeyValueRow keyLabel="K" value="V" testID="key-value-row" />);
+
+      expect(screen.getByTestId('key-value-row')).toHaveStyle(tw`px-4`);
     });
 
     it('applies resolved h-12 when variant is Input', () => {

--- a/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.test.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.test.tsx
@@ -84,7 +84,7 @@ describe('KeyValueRow', () => {
       render(<KeyValueRow keyLabel="K" value="V" testID="key-value-row" />);
 
       expect(screen.getByTestId('key-value-row')).toHaveStyle(
-        tw`h-10 px-4 flex-row items-center gap-4`,
+        tw`h-10 flex-row items-center gap-4 px-4`,
       );
     });
 

--- a/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueRow/KeyValueRow.tsx
@@ -106,6 +106,7 @@ export const KeyValueRow = ({
       gap={4}
       style={[
         tw.style(
+          'px-4',
           variant === KeyValueRowVariant.Input ? 'h-12' : 'h-10',
           twClassName,
         ),

--- a/packages/design-system-react-native/src/components/KeyValueRow/README.md
+++ b/packages/design-system-react-native/src/components/KeyValueRow/README.md
@@ -242,7 +242,7 @@ Use the `twClassName` prop to add Tailwind CSS classes to the component. These c
 - Add new styles that don't exist in the default component
 - Override the component's default styles when needed
 
-The outer row always includes a height class from `variant` (`h-10` or `h-12`); your classes are merged with that base.
+The outer row always includes `px-4` (16px horizontal padding) and a height class from `variant` (`h-10` or `h-12`); your classes are merged with that base. Override horizontal padding with `twClassName` when needed (for example `px-0` or `pl-4 pr-1`).
 
 | TYPE     | REQUIRED | DEFAULT     |
 | -------- | -------- | ----------- |

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.stories.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.stories.tsx
@@ -1,5 +1,5 @@
 import {
-  KeyValueRowVariant,
+  KeyValueSelectVariant,
   SelectButtonEndArrow,
 } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
@@ -30,9 +30,9 @@ const meta: Meta<KeyValueSelectProps> = {
     },
     variant: {
       control: 'select',
-      options: Object.keys(KeyValueRowVariant),
-      mapping: KeyValueRowVariant,
-      description: 'KeyValueRow height variant.',
+      options: Object.keys(KeyValueSelectVariant),
+      mapping: KeyValueSelectVariant,
+      description: 'KeyValueSelect height variant.',
     },
     isDisabled: {
       control: 'boolean',
@@ -61,9 +61,9 @@ export const Variant: Story = {
   render: () => (
     <Box gap={4}>
       {(
-        Object.entries(KeyValueRowVariant) as [
-          keyof typeof KeyValueRowVariant,
-          (typeof KeyValueRowVariant)[keyof typeof KeyValueRowVariant],
+        Object.entries(KeyValueSelectVariant) as [
+          keyof typeof KeyValueSelectVariant,
+          (typeof KeyValueSelectVariant)[keyof typeof KeyValueSelectVariant],
         ][]
       ).map(([key, rowVariant]) => (
         <KeyValueSelect
@@ -203,6 +203,18 @@ export const KeyTextProps: Story = {
       value="Details"
       keyTextProps={{ variant: TextVariant.BodySm }}
       selectButtonProps={{ placeholder: 'Select' }}
+      onPress={noopPress}
+    />
+  ),
+};
+
+export const KeyValueRowProps: Story = {
+  render: () => (
+    <KeyValueSelect
+      keyLabel="Network"
+      value="Ethereum Mainnet"
+      selectButtonProps={{ placeholder: 'Select network' }}
+      keyValueRowProps={{ twClassName: 'border-b border-border-muted' }}
       onPress={noopPress}
     />
   ),

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.stories.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.stories.tsx
@@ -1,0 +1,229 @@
+import {
+  KeyValueRowVariant,
+  SelectButtonEndArrow,
+} from '@metamask/design-system-shared';
+import type { Meta, StoryObj } from '@storybook/react-native';
+import React from 'react';
+
+import { AvatarToken, AvatarTokenSize } from '../AvatarToken';
+import { SAMPLE_AVATARTOKEN_URIS } from '../AvatarToken/AvatarToken.dev';
+import { Box } from '../Box';
+import { Icon, IconName, IconSize } from '../Icon';
+import { TextVariant } from '../Text';
+
+import { KeyValueSelect } from './KeyValueSelect';
+import type { KeyValueSelectProps } from './KeyValueSelect.types';
+
+const noopPress = () => undefined;
+
+const meta: Meta<KeyValueSelectProps> = {
+  title: 'Components/KeyValueSelect',
+  component: KeyValueSelect,
+  argTypes: {
+    keyLabel: {
+      control: 'text',
+      description: 'Key content shown on the left.',
+    },
+    value: {
+      control: 'text',
+      description: 'Selected select label.',
+    },
+    variant: {
+      control: 'select',
+      options: Object.keys(KeyValueRowVariant),
+      mapping: KeyValueRowVariant,
+      description: 'KeyValueRow height variant.',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Disables the row press and SelectButton presentation.',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<KeyValueSelectProps>;
+
+export const Default: Story = {
+  args: {
+    keyLabel: 'Network',
+    value: 'Ethereum Mainnet',
+    selectButtonProps: {
+      placeholder: 'Select network',
+    },
+    onPress: noopPress,
+  },
+  render: (args) => <KeyValueSelect {...args} />,
+};
+
+export const Variant: Story = {
+  render: () => (
+    <Box gap={4}>
+      {(
+        Object.entries(KeyValueRowVariant) as [
+          keyof typeof KeyValueRowVariant,
+          (typeof KeyValueRowVariant)[keyof typeof KeyValueRowVariant],
+        ][]
+      ).map(([key, rowVariant]) => (
+        <KeyValueSelect
+          key={key}
+          keyLabel={key}
+          value={`Option ${key}`}
+          variant={rowVariant}
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+        />
+      ))}
+    </Box>
+  ),
+};
+
+export const ValueStartAccessory: Story = {
+  render: () => (
+    <KeyValueSelect
+      keyLabel="Pay with"
+      value="ETH"
+      valueStartAccessory={
+        <AvatarToken
+          name="ETH"
+          src={SAMPLE_AVATARTOKEN_URIS[1]}
+          size={AvatarTokenSize.Xs}
+        />
+      }
+      selectButtonProps={{ placeholder: 'Select asset' }}
+      onPress={noopPress}
+    />
+  ),
+};
+
+export const ValueEndAccessory: Story = {
+  render: () => (
+    <KeyValueSelect
+      keyLabel="Custom end"
+      value="Custom"
+      valueEndAccessory={<Icon name={IconName.ArrowRight} size={IconSize.Sm} />}
+      selectButtonProps={{
+        placeholder: 'Select',
+        hideEndArrow: true,
+      }}
+      onPress={noopPress}
+    />
+  ),
+};
+
+export const ValueTextProps: Story = {
+  render: () => (
+    <KeyValueSelect
+      keyLabel="Network"
+      value="Ethereum Mainnet"
+      valueTextProps={{ variant: TextVariant.BodySm }}
+      selectButtonProps={{ placeholder: 'Select network' }}
+      onPress={noopPress}
+    />
+  ),
+};
+
+export const SelectButtonProps: Story = {
+  render: () => (
+    <Box gap={4}>
+      {(
+        Object.entries(SelectButtonEndArrow) as [
+          keyof typeof SelectButtonEndArrow,
+          (typeof SelectButtonEndArrow)[keyof typeof SelectButtonEndArrow],
+        ][]
+      ).map(([key, endArrowDirection]) => (
+        <KeyValueSelect
+          key={key}
+          keyLabel={key}
+          value={`Arrow ${key}`}
+          selectButtonProps={{
+            placeholder: 'Select',
+            endArrowDirection,
+          }}
+          onPress={noopPress}
+        />
+      ))}
+      <KeyValueSelect
+        keyLabel="Hidden arrow"
+        value="Hidden"
+        selectButtonProps={{
+          placeholder: 'Select',
+          hideEndArrow: true,
+        }}
+        onPress={noopPress}
+      />
+    </Box>
+  ),
+};
+
+export const KeyStartAccessory: Story = {
+  render: () => (
+    <KeyValueSelect
+      keyLabel="Fee"
+      value="$2.59"
+      keyStartAccessory={<Icon name={IconName.Info} size={IconSize.Sm} />}
+      selectButtonProps={{ placeholder: 'Select' }}
+      onPress={noopPress}
+    />
+  ),
+};
+
+export const KeyEndAccessory: Story = {
+  render: () => (
+    <KeyValueSelect
+      keyLabel="Limit"
+      value="Unlimited"
+      keyEndAccessory={<Icon name={IconName.Info} size={IconSize.Sm} />}
+      selectButtonProps={{ placeholder: 'Select' }}
+      onPress={noopPress}
+    />
+  ),
+};
+
+export const KeyEndButtonIconProps: Story = {
+  render: () => (
+    <KeyValueSelect
+      keyLabel="Network"
+      value="Ethereum Mainnet"
+      keyEndButtonIconProps={{
+        iconName: IconName.Info,
+        onPress: noopPress,
+      }}
+      selectButtonProps={{ placeholder: 'Select network' }}
+      onPress={noopPress}
+    />
+  ),
+};
+
+export const KeyTextProps: Story = {
+  render: () => (
+    <KeyValueSelect
+      keyLabel="Note"
+      value="Details"
+      keyTextProps={{ variant: TextVariant.BodySm }}
+      selectButtonProps={{ placeholder: 'Select' }}
+      onPress={noopPress}
+    />
+  ),
+};
+
+export const IsDisabled: Story = {
+  render: () => (
+    <Box gap={4}>
+      <KeyValueSelect
+        keyLabel="Enabled"
+        value="Ethereum Mainnet"
+        selectButtonProps={{ placeholder: 'Select network' }}
+        onPress={noopPress}
+      />
+      <KeyValueSelect
+        keyLabel="Disabled"
+        value="Ethereum Mainnet"
+        isDisabled
+        selectButtonProps={{ placeholder: 'Select network' }}
+        onPress={noopPress}
+      />
+    </Box>
+  ),
+};

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
@@ -129,7 +129,23 @@ describe('KeyValueSelect', () => {
         />,
       );
 
-      expect(getByTestId('key-value-row')).toHaveStyle(tw.style('opacity-50'));
+      expect(getByTestId('key-value-row')).toHaveStyle(
+        tw.style('pl-4 pr-1', 'opacity-50'),
+      );
+    });
+
+    it('keeps SelectButton trailing inset via pr-1 on the inner KeyValueRow', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          keyValueRowProps={{ testID: 'key-value-row' }}
+          onPress={noopPress}
+        />,
+      );
+
+      // KeyValueRow default px-4 + KeyValueSelect pr-1 → pl-4 pr-1
+      expect(getByTestId('key-value-row')).toHaveStyle(tw.style('pl-4 pr-1'));
     });
   });
 
@@ -218,7 +234,7 @@ describe('KeyValueSelect', () => {
   });
 
   describe('when rendering the root', () => {
-    it('applies full-width edge padding (16px leading, 4px trailing)', () => {
+    it('applies full-width pressable without horizontal padding', () => {
       const { getByTestId } = render(
         <KeyValueSelect
           keyLabel="Network"
@@ -228,12 +244,10 @@ describe('KeyValueSelect', () => {
         />,
       );
 
-      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
-        tw.style('w-full pl-4 pr-1'),
-      );
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(tw.style('w-full'));
     });
 
-    it('merges twClassName with default root padding', () => {
+    it('merges twClassName with default root width', () => {
       const { getByTestId } = render(
         <KeyValueSelect
           keyLabel="Network"
@@ -245,7 +259,7 @@ describe('KeyValueSelect', () => {
       );
 
       expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
-        tw.style('w-full pl-4 pr-1', 'rounded-lg'),
+        tw.style('w-full', 'rounded-lg'),
       );
     });
 
@@ -261,7 +275,7 @@ describe('KeyValueSelect', () => {
       );
 
       expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
-        tw.style('w-full pl-4 pr-1', 'bg-pressed'),
+        tw.style('w-full', 'bg-pressed'),
       );
     });
 
@@ -277,7 +291,7 @@ describe('KeyValueSelect', () => {
       );
 
       expect(getByTestId(ROOT_TEST_ID)).toHaveStyle([
-        tw.style('w-full pl-4 pr-1'),
+        tw.style('w-full'),
         { marginTop: 8 },
       ]);
     });

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
@@ -1,0 +1,219 @@
+import {
+  SelectButtonEndArrow,
+  SelectButtonSize,
+  SelectButtonVariant,
+} from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { fireEvent, render, renderHook } from '@testing-library/react-native';
+import React from 'react';
+import { View } from 'react-native';
+
+import { KeyValueSelect } from './KeyValueSelect';
+
+const ROOT_TEST_ID = 'key-value-select';
+const noopPress = () => undefined;
+const defaultSelectButtonProps = { placeholder: 'Select network' };
+
+describe('KeyValueSelect', () => {
+  let tw: ReturnType<typeof useTailwind>;
+
+  beforeAll(() => {
+    tw = renderHook(() => useTailwind()).result.current;
+  });
+
+  describe('when rendering content', () => {
+    it('renders keyLabel and placeholder', () => {
+      const { getByText } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={defaultSelectButtonProps}
+          onPress={noopPress}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByText('Network')).toBeOnTheScreen();
+      expect(getByText('Select network')).toBeOnTheScreen();
+    });
+
+    it('renders value when set', () => {
+      const { getByText, queryByText } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          value="Ethereum Mainnet"
+          selectButtonProps={defaultSelectButtonProps}
+          onPress={noopPress}
+        />,
+      );
+
+      expect(getByText('Ethereum Mainnet')).toBeOnTheScreen();
+      expect(queryByText('Select network')).toBeNull();
+    });
+
+    it('maps valueStartAccessory to SelectButton startAccessory', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Asset"
+          valueStartAccessory={<View testID="start-accessory" />}
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+        />,
+      );
+
+      expect(getByTestId('start-accessory')).toBeOnTheScreen();
+    });
+
+    it('maps valueEndAccessory through selectButtonProps hideEndArrow', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Asset"
+          valueEndAccessory={<View testID="end-accessory" />}
+          selectButtonProps={{
+            placeholder: 'Select',
+            hideEndArrow: true,
+          }}
+          onPress={noopPress}
+        />,
+      );
+
+      expect(getByTestId('end-accessory')).toBeOnTheScreen();
+    });
+  });
+
+  describe('when pressed', () => {
+    it('calls onPress', () => {
+      const onPress = jest.fn();
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={onPress}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      fireEvent.press(getByTestId(ROOT_TEST_ID));
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when isDisabled is true', () => {
+    it('does not call onPress', () => {
+      const onPress = jest.fn();
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          value="Ethereum"
+          isDisabled
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={onPress}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      fireEvent.press(getByTestId(ROOT_TEST_ID));
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    it('disables the root Pressable', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          isDisabled
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toBeDisabled();
+    });
+  });
+
+  describe('when composing SelectButton', () => {
+    it('sets pointerEvents to none and accessible to false on SelectButton', () => {
+      const { root } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+        />,
+      );
+
+      const selectButton = root.findByProps({ pointerEvents: 'none' });
+
+      expect(selectButton).toBeDefined();
+      expect(selectButton.props.accessible).toBe(false);
+    });
+
+    it('uses SelectButtonSize.Md and Secondary variant on SelectButton', () => {
+      const { root } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          value="Ethereum"
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+        />,
+      );
+
+      const selectButton = root.findByProps({ pointerEvents: 'none' });
+
+      expect(selectButton.props.size).toBe(SelectButtonSize.Md);
+      expect(selectButton.props.variant).toBe(SelectButtonVariant.Secondary);
+    });
+
+    it('forwards selectButtonProps to SelectButton', () => {
+      const { root } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          value="Ethereum"
+          selectButtonProps={{
+            placeholder: 'Select',
+            endArrowDirection: SelectButtonEndArrow.Right,
+          }}
+          onPress={noopPress}
+        />,
+      );
+
+      const selectButton = root.findByProps({ pointerEvents: 'none' });
+
+      expect(selectButton.props.endArrowDirection).toBe(
+        SelectButtonEndArrow.Right,
+      );
+      expect(selectButton.props.placeholder).toBe('Select');
+    });
+  });
+
+  describe('when rendering the root', () => {
+    it('applies full-width edge padding (16px leading, 4px trailing)', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
+        tw.style('w-full pl-4 pr-1'),
+      );
+    });
+
+    it('merges twClassName with default root padding', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          twClassName="rounded-lg"
+          onPress={noopPress}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
+        tw.style('w-full pl-4 pr-1', 'rounded-lg'),
+      );
+    });
+  });
+});

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
@@ -215,5 +215,67 @@ describe('KeyValueSelect', () => {
         tw.style('w-full pl-4 pr-1', 'rounded-lg'),
       );
     });
+
+    it('applies bg-pressed when pressed', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+          testOnly_pressed
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle(
+        tw.style('w-full pl-4 pr-1', 'bg-pressed'),
+      );
+    });
+
+    it('merges user style with base pressable style', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+          style={{ marginTop: 8 }}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle([
+        tw.style('w-full pl-4 pr-1'),
+        { marginTop: 8 },
+      ]);
+    });
+
+    it('merges user function style for pressed state', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+          testOnly_pressed
+          style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle({ opacity: 0.5 });
+    });
+
+    it('merges user function style at rest', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={noopPress}
+          style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId(ROOT_TEST_ID)).toHaveStyle({ opacity: 1 });
+    });
   });
 });

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
@@ -100,6 +100,39 @@ describe('KeyValueSelect', () => {
     });
   });
 
+  describe('when keyValueRowProps is provided', () => {
+    it('forwards testID to the inner KeyValueRow', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          keyValueRowProps={{ testID: 'key-value-row' }}
+          onPress={noopPress}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      expect(getByTestId('key-value-row')).toBeOnTheScreen();
+      expect(getByTestId(ROOT_TEST_ID)).toBeOnTheScreen();
+    });
+
+    it('forwards twClassName to the inner KeyValueRow', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          selectButtonProps={{ placeholder: 'Select' }}
+          keyValueRowProps={{
+            testID: 'key-value-row',
+            twClassName: 'opacity-50',
+          }}
+          onPress={noopPress}
+        />,
+      );
+
+      expect(getByTestId('key-value-row')).toHaveStyle(tw.style('opacity-50'));
+    });
+  });
+
   describe('when pressed', () => {
     it('calls onPress from the root', () => {
       const onPress = jest.fn();

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.test.tsx
@@ -1,12 +1,10 @@
-import {
-  SelectButtonEndArrow,
-  SelectButtonSize,
-  SelectButtonVariant,
-} from '@metamask/design-system-shared';
+import { SelectButtonEndArrow } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { fireEvent, render, renderHook } from '@testing-library/react-native';
-import React from 'react';
+import React, { createRef } from 'react';
 import { View } from 'react-native';
+
+import { MAP_SELECTBUTTON_END_ARROW_DIRECTION_TO_ICON_NAME } from '../SelectButton/SelectButton.constants';
 
 import { KeyValueSelect } from './KeyValueSelect';
 
@@ -50,7 +48,7 @@ describe('KeyValueSelect', () => {
       expect(queryByText('Select network')).toBeNull();
     });
 
-    it('maps valueStartAccessory to SelectButton startAccessory', () => {
+    it('renders valueStartAccessory', () => {
       const { getByTestId } = render(
         <KeyValueSelect
           keyLabel="Asset"
@@ -63,7 +61,7 @@ describe('KeyValueSelect', () => {
       expect(getByTestId('start-accessory')).toBeOnTheScreen();
     });
 
-    it('maps valueEndAccessory through selectButtonProps hideEndArrow', () => {
+    it('renders valueEndAccessory when end arrow is hidden', () => {
       const { getByTestId } = render(
         <KeyValueSelect
           keyLabel="Asset"
@@ -78,10 +76,32 @@ describe('KeyValueSelect', () => {
 
       expect(getByTestId('end-accessory')).toBeOnTheScreen();
     });
+
+    it('renders trailing arrow from selectButtonProps endArrowDirection', () => {
+      const { getByTestId } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          value="Ethereum"
+          selectButtonProps={{
+            placeholder: 'Select',
+            endArrowDirection: SelectButtonEndArrow.Right,
+            endArrowDirectionIconProps: { testID: 'end-arrow' },
+          }}
+          onPress={noopPress}
+        />,
+      );
+
+      expect(getByTestId('end-arrow')).toHaveProp(
+        'name',
+        MAP_SELECTBUTTON_END_ARROW_DIRECTION_TO_ICON_NAME[
+          SelectButtonEndArrow.Right
+        ],
+      );
+    });
   });
 
   describe('when pressed', () => {
-    it('calls onPress', () => {
+    it('calls onPress from the root', () => {
       const onPress = jest.fn();
       const { getByTestId } = render(
         <KeyValueSelect
@@ -93,6 +113,22 @@ describe('KeyValueSelect', () => {
       );
 
       fireEvent.press(getByTestId(ROOT_TEST_ID));
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls outer onPress when pressing the select value label', () => {
+      const onPress = jest.fn();
+      const { getByText } = render(
+        <KeyValueSelect
+          keyLabel="Network"
+          value="Ethereum"
+          selectButtonProps={{ placeholder: 'Select' }}
+          onPress={onPress}
+          testID={ROOT_TEST_ID}
+        />,
+      );
+
+      fireEvent.press(getByText('Ethereum'));
       expect(onPress).toHaveBeenCalledTimes(1);
     });
   });
@@ -130,57 +166,21 @@ describe('KeyValueSelect', () => {
     });
   });
 
-  describe('when composing SelectButton', () => {
-    it('sets pointerEvents to none and accessible to false on SelectButton', () => {
-      const { root } = render(
+  describe('when forwarding a ref', () => {
+    it('exposes the root Pressable via forwardRef', () => {
+      const ref = createRef<View>();
+
+      render(
         <KeyValueSelect
+          ref={ref}
           keyLabel="Network"
           selectButtonProps={{ placeholder: 'Select' }}
           onPress={noopPress}
         />,
       );
 
-      const selectButton = root.findByProps({ pointerEvents: 'none' });
-
-      expect(selectButton).toBeDefined();
-      expect(selectButton.props.accessible).toBe(false);
-    });
-
-    it('uses SelectButtonSize.Md and Secondary variant on SelectButton', () => {
-      const { root } = render(
-        <KeyValueSelect
-          keyLabel="Network"
-          value="Ethereum"
-          selectButtonProps={{ placeholder: 'Select' }}
-          onPress={noopPress}
-        />,
-      );
-
-      const selectButton = root.findByProps({ pointerEvents: 'none' });
-
-      expect(selectButton.props.size).toBe(SelectButtonSize.Md);
-      expect(selectButton.props.variant).toBe(SelectButtonVariant.Secondary);
-    });
-
-    it('forwards selectButtonProps to SelectButton', () => {
-      const { root } = render(
-        <KeyValueSelect
-          keyLabel="Network"
-          value="Ethereum"
-          selectButtonProps={{
-            placeholder: 'Select',
-            endArrowDirection: SelectButtonEndArrow.Right,
-          }}
-          onPress={noopPress}
-        />,
-      );
-
-      const selectButton = root.findByProps({ pointerEvents: 'none' });
-
-      expect(selectButton.props.endArrowDirection).toBe(
-        SelectButtonEndArrow.Right,
-      );
-      expect(selectButton.props.placeholder).toBe('Select');
+      expect(ref.current).not.toBeNull();
+      expect(ref.current).toBeInstanceOf(View);
     });
   });
 

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.tsx
@@ -1,0 +1,92 @@
+import {
+  mergeTwClassName,
+  SelectButtonSize,
+  SelectButtonVariant,
+} from '@metamask/design-system-shared';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React from 'react';
+import { Pressable } from 'react-native';
+import type {
+  PressableStateCallbackType,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
+
+import { KeyValueRow } from '../KeyValueRow';
+import { SelectButton } from '../SelectButton';
+
+import type { KeyValueSelectProps } from './KeyValueSelect.types';
+
+const ROOT_TW_CLASS_NAME = 'w-full pl-4 pr-1';
+
+export const KeyValueSelect = ({
+  keyLabel,
+  keyStartAccessory,
+  keyEndAccessory,
+  keyTextProps,
+  keyEndButtonIconProps,
+  variant,
+  value,
+  valueStartAccessory,
+  valueEndAccessory,
+  valueTextProps,
+  selectButtonProps,
+  isDisabled = false,
+  twClassName,
+  style,
+  accessibilityRole,
+  ...pressableProps
+}: KeyValueSelectProps) => {
+  const tw = useTailwind();
+  const rootTwClassName = mergeTwClassName(ROOT_TW_CLASS_NAME, twClassName);
+
+  const getPressableStyle = ({
+    pressed,
+  }: PressableStateCallbackType): StyleProp<ViewStyle> => {
+    const baseStyle = tw.style(rootTwClassName, pressed && 'bg-pressed');
+
+    if (!style) {
+      return baseStyle;
+    }
+
+    const userStyle = typeof style === 'function' ? style({ pressed }) : style;
+
+    return [baseStyle, userStyle];
+  };
+
+  const renderSelectValue = () => (
+    <SelectButton
+      {...selectButtonProps}
+      value={value}
+      startAccessory={valueStartAccessory}
+      endAccessory={valueEndAccessory}
+      textProps={valueTextProps}
+      variant={SelectButtonVariant.Secondary}
+      isDisabled={isDisabled}
+      size={SelectButtonSize.Md}
+      pointerEvents="none"
+      accessible={false}
+    />
+  );
+
+  return (
+    <Pressable
+      accessibilityRole={accessibilityRole ?? 'button'}
+      disabled={isDisabled}
+      style={getPressableStyle}
+      {...pressableProps}
+    >
+      <KeyValueRow
+        keyLabel={keyLabel}
+        keyStartAccessory={keyStartAccessory}
+        keyEndAccessory={keyEndAccessory}
+        keyTextProps={keyTextProps}
+        keyEndButtonIconProps={keyEndButtonIconProps}
+        variant={variant}
+        value={renderSelectValue()}
+      />
+    </Pressable>
+  );
+};
+
+KeyValueSelect.displayName = 'KeyValueSelect';

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.tsx
@@ -4,11 +4,12 @@ import {
   SelectButtonVariant,
 } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { Pressable } from 'react-native';
 import type {
   PressableStateCallbackType,
   StyleProp,
+  View,
   ViewStyle,
 } from 'react-native';
 
@@ -19,74 +20,81 @@ import type { KeyValueSelectProps } from './KeyValueSelect.types';
 
 const ROOT_TW_CLASS_NAME = 'w-full pl-4 pr-1';
 
-export const KeyValueSelect = ({
-  keyLabel,
-  keyStartAccessory,
-  keyEndAccessory,
-  keyTextProps,
-  keyEndButtonIconProps,
-  variant,
-  value,
-  valueStartAccessory,
-  valueEndAccessory,
-  valueTextProps,
-  selectButtonProps,
-  isDisabled = false,
-  twClassName,
-  style,
-  accessibilityRole,
-  ...pressableProps
-}: KeyValueSelectProps) => {
-  const tw = useTailwind();
-  const rootTwClassName = mergeTwClassName(ROOT_TW_CLASS_NAME, twClassName);
+export const KeyValueSelect = forwardRef<View, KeyValueSelectProps>(
+  (
+    {
+      keyLabel,
+      keyStartAccessory,
+      keyEndAccessory,
+      keyTextProps,
+      keyEndButtonIconProps,
+      variant,
+      value,
+      valueStartAccessory,
+      valueEndAccessory,
+      valueTextProps,
+      selectButtonProps,
+      isDisabled = false,
+      twClassName,
+      style,
+      accessibilityRole,
+      ...pressableProps
+    },
+    ref,
+  ) => {
+    const tw = useTailwind();
+    const rootTwClassName = mergeTwClassName(ROOT_TW_CLASS_NAME, twClassName);
 
-  const getPressableStyle = ({
-    pressed,
-  }: PressableStateCallbackType): StyleProp<ViewStyle> => {
-    const baseStyle = tw.style(rootTwClassName, pressed && 'bg-pressed');
+    const getPressableStyle = ({
+      pressed,
+    }: PressableStateCallbackType): StyleProp<ViewStyle> => {
+      const baseStyle = tw.style(rootTwClassName, pressed && 'bg-pressed');
 
-    if (!style) {
-      return baseStyle;
-    }
+      if (!style) {
+        return baseStyle;
+      }
 
-    const userStyle = typeof style === 'function' ? style({ pressed }) : style;
+      const userStyle =
+        typeof style === 'function' ? style({ pressed }) : style;
 
-    return [baseStyle, userStyle];
-  };
+      return [baseStyle, userStyle];
+    };
 
-  const renderSelectValue = () => (
-    <SelectButton
-      {...selectButtonProps}
-      value={value}
-      startAccessory={valueStartAccessory}
-      endAccessory={valueEndAccessory}
-      textProps={valueTextProps}
-      variant={SelectButtonVariant.Secondary}
-      isDisabled={isDisabled}
-      size={SelectButtonSize.Md}
-      pointerEvents="none"
-      accessible={false}
-    />
-  );
-
-  return (
-    <Pressable
-      accessibilityRole={accessibilityRole ?? 'button'}
-      disabled={isDisabled}
-      style={getPressableStyle}
-      {...pressableProps}
-    >
-      <KeyValueRow
-        keyLabel={keyLabel}
-        keyStartAccessory={keyStartAccessory}
-        keyEndAccessory={keyEndAccessory}
-        keyTextProps={keyTextProps}
-        keyEndButtonIconProps={keyEndButtonIconProps}
-        variant={variant}
-        value={renderSelectValue()}
+    const renderSelectValue = () => (
+      <SelectButton
+        {...selectButtonProps}
+        value={value}
+        startAccessory={valueStartAccessory}
+        endAccessory={valueEndAccessory}
+        textProps={valueTextProps}
+        variant={SelectButtonVariant.Secondary}
+        isDisabled={isDisabled}
+        size={SelectButtonSize.Md}
+        pointerEvents="none"
+        accessible={false}
       />
-    </Pressable>
-  );
-};
+    );
+
+    return (
+      <Pressable
+        ref={ref}
+        accessibilityRole={accessibilityRole ?? 'button'}
+        disabled={isDisabled}
+        style={getPressableStyle}
+        {...pressableProps}
+      >
+        <KeyValueRow
+          keyLabel={keyLabel}
+          keyStartAccessory={keyStartAccessory}
+          keyEndAccessory={keyEndAccessory}
+          keyTextProps={keyTextProps}
+          keyEndButtonIconProps={keyEndButtonIconProps}
+          variant={variant}
+          value={renderSelectValue()}
+        />
+      </Pressable>
+    );
+  },
+);
 
 KeyValueSelect.displayName = 'KeyValueSelect';

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.tsx
@@ -34,6 +34,7 @@ export const KeyValueSelect = forwardRef<View, KeyValueSelectProps>(
       valueEndAccessory,
       valueTextProps,
       selectButtonProps,
+      keyValueRowProps,
       isDisabled = false,
       twClassName,
       style,
@@ -84,6 +85,7 @@ export const KeyValueSelect = forwardRef<View, KeyValueSelectProps>(
         {...pressableProps}
       >
         <KeyValueRow
+          {...keyValueRowProps}
           keyLabel={keyLabel}
           keyStartAccessory={keyStartAccessory}
           keyEndAccessory={keyEndAccessory}

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.tsx
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.tsx
@@ -18,7 +18,10 @@ import { SelectButton } from '../SelectButton';
 
 import type { KeyValueSelectProps } from './KeyValueSelect.types';
 
-const ROOT_TW_CLASS_NAME = 'w-full pl-4 pr-1';
+const ROOT_TW_CLASS_NAME = 'w-full';
+
+/** Overrides KeyValueRow `pr-4` so SelectButton's `px-3` keeps a 16px trailing inset. */
+const KEY_VALUE_ROW_TW_CLASS_NAME = 'pr-1';
 
 export const KeyValueSelect = forwardRef<View, KeyValueSelectProps>(
   (
@@ -45,6 +48,12 @@ export const KeyValueSelect = forwardRef<View, KeyValueSelectProps>(
   ) => {
     const tw = useTailwind();
     const rootTwClassName = mergeTwClassName(ROOT_TW_CLASS_NAME, twClassName);
+    const { twClassName: keyValueRowTwClassName, ...restKeyValueRowProps } =
+      keyValueRowProps ?? {};
+    const resolvedKeyValueRowTwClassName = mergeTwClassName(
+      KEY_VALUE_ROW_TW_CLASS_NAME,
+      keyValueRowTwClassName,
+    );
 
     const getPressableStyle = ({
       pressed,
@@ -85,7 +94,8 @@ export const KeyValueSelect = forwardRef<View, KeyValueSelectProps>(
         {...pressableProps}
       >
         <KeyValueRow
-          {...keyValueRowProps}
+          {...restKeyValueRowProps}
+          twClassName={resolvedKeyValueRowTwClassName}
           keyLabel={keyLabel}
           keyStartAccessory={keyStartAccessory}
           keyEndAccessory={keyEndAccessory}

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.types.ts
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.types.ts
@@ -6,6 +6,7 @@ import type { PressableProps } from 'react-native';
 
 import type { ButtonIconProps } from '../ButtonIcon/ButtonIcon.types';
 import type { IconProps } from '../Icon/Icon.types';
+import type { KeyValueRowProps } from '../KeyValueRow/KeyValueRow.types';
 import type { TextProps } from '../Text/Text.types';
 
 /**
@@ -22,10 +23,30 @@ export type KeyValueSelectSelectButtonProps =
   };
 
 /**
+ * KeyValueRow shell / ViewProps escape hatch.
+ * Owned KeyValueSelect content props are omitted so the public API stays the source of truth.
+ */
+export type KeyValueSelectKeyValueRowProps = Omit<
+  KeyValueRowProps,
+  | 'keyLabel'
+  | 'keyStartAccessory'
+  | 'keyEndAccessory'
+  | 'keyTextProps'
+  | 'keyEndButtonIconProps'
+  | 'value'
+  | 'valueStartAccessory'
+  | 'valueEndAccessory'
+  | 'valueTextProps'
+  | 'valueEndButtonIconProps'
+  | 'variant'
+>;
+
+/**
  * KeyValueSelect component props.
  *
  * Pressable KeyValueRow with a SelectButton value. Value-side KeyValueRow props
  * map onto SelectButton; SelectButton-only options use `selectButtonProps`.
+ * Use `keyValueRowProps` for inner KeyValueRow shell props (e.g. `testID`, `twClassName`).
  */
 export type KeyValueSelectProps = Omit<
   KeyValueSelectPropsShared,
@@ -40,6 +61,11 @@ export type KeyValueSelectProps = Omit<
     valueTextProps?: Partial<Omit<TextProps, 'children'>>;
     /** SelectButton-only props (placeholder and caret controls). */
     selectButtonProps: KeyValueSelectSelectButtonProps;
+    /**
+     * Optional props forwarded to the inner KeyValueRow (e.g. `testID`, `twClassName`, `style`,
+     * accessibility props). Owned content props are set by KeyValueSelect and are not available here.
+     */
+    keyValueRowProps?: KeyValueSelectKeyValueRowProps;
     /** Optional Tailwind class names applied to the outer Pressable. */
     twClassName?: string;
   };

--- a/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.types.ts
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/KeyValueSelect.types.ts
@@ -1,0 +1,45 @@
+import type {
+  KeyValueSelectPropsShared,
+  KeyValueSelectSelectButtonPropsShared,
+} from '@metamask/design-system-shared';
+import type { PressableProps } from 'react-native';
+
+import type { ButtonIconProps } from '../ButtonIcon/ButtonIcon.types';
+import type { IconProps } from '../Icon/Icon.types';
+import type { TextProps } from '../Text/Text.types';
+
+/**
+ * SelectButton-only props for KeyValueSelect (RN).
+ * Size is always Md and variant is always Secondary.
+ */
+export type KeyValueSelectSelectButtonProps =
+  KeyValueSelectSelectButtonPropsShared & {
+    /**
+     * Optional props passed to the SelectButton trailing arrow Icon when a trailing
+     * arrow is shown (excluding `name`, which is derived from the resolved direction).
+     */
+    endArrowDirectionIconProps?: Partial<Omit<IconProps, 'name'>>;
+  };
+
+/**
+ * KeyValueSelect component props.
+ *
+ * Pressable KeyValueRow with a SelectButton value. Value-side KeyValueRow props
+ * map onto SelectButton; SelectButton-only options use `selectButtonProps`.
+ */
+export type KeyValueSelectProps = Omit<
+  KeyValueSelectPropsShared,
+  'selectButtonProps'
+> &
+  Omit<PressableProps, 'children' | 'disabled'> & {
+    /** Optional props for the key Text when key is a string. */
+    keyTextProps?: Partial<Omit<TextProps, 'children'>>;
+    /** When set, renders a ButtonIcon as the key endAccessory (takes precedence over keyEndAccessory). */
+    keyEndButtonIconProps?: Partial<ButtonIconProps>;
+    /** Optional props for the SelectButton label Text. Mapped from KeyValueRow `valueTextProps`. */
+    valueTextProps?: Partial<Omit<TextProps, 'children'>>;
+    /** SelectButton-only props (placeholder and caret controls). */
+    selectButtonProps: KeyValueSelectSelectButtonProps;
+    /** Optional Tailwind class names applied to the outer Pressable. */
+    twClassName?: string;
+  };

--- a/packages/design-system-react-native/src/components/KeyValueSelect/README.md
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/README.md
@@ -345,7 +345,7 @@ Use the `twClassName` prop to add Tailwind CSS classes to the component. These c
 - Add new styles that don't exist in the default component
 - Override the component's default styles when needed
 
-Default root classes include `w-full pl-4 pr-1` so the pressable spans the full width with a 16px leading inset and a 4px trailing inset (SelectButton already contributes 12px of trailing padding).
+Default root classes include `w-full` so the pressable spans the full width for pressed feedback. Horizontal inset comes from the inner [KeyValueRow](../KeyValueRow/README.md) (`px-4`), with `pr-1` applied so SelectButton's trailing padding still totals 16px from the edge.
 
 | TYPE     | REQUIRED | DEFAULT     |
 | -------- | -------- | ----------- |

--- a/packages/design-system-react-native/src/components/KeyValueSelect/README.md
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/README.md
@@ -1,6 +1,6 @@
 # KeyValueSelect
 
-KeyValueSelect is used to show a key on the left and a select value on the right in a pressable row. Use it for form and summary rows that open a picker or bottom sheet. Value-side props follow [KeyValueRow](../KeyValueRow/README.md) naming and map onto a secondary [SelectButton](../SelectButton/README.md). SelectButton-only options (placeholder and caret) use `selectButtonProps`. For a static key/value row, use KeyValueRow. For a standalone select control, use SelectButton.
+KeyValueSelect is used to show a key on the left and a select value on the right in a pressable row. Use it for form and summary rows that open a picker or bottom sheet. Value-side props follow [KeyValueRow](../KeyValueRow/README.md) naming and map onto a secondary [SelectButton](../SelectButton/README.md). SelectButton-only options (placeholder and caret) use `selectButtonProps`. Use `keyValueRowProps` for inner KeyValueRow shell props such as `testID` or `twClassName`. For a static key/value row, use KeyValueRow. For a standalone select control, use SelectButton.
 
 ```tsx
 import { KeyValueSelect } from '@metamask/design-system-react-native';
@@ -156,6 +156,31 @@ import {
 />;
 ```
 
+### `keyValueRowProps`
+
+Optional props forwarded to the inner [KeyValueRow](../KeyValueRow/README.md). Use this for row shell concerns such as `testID`, `twClassName`, `style`, and accessibility `ViewProps` that should apply to the row content rather than the outer Pressable.
+
+Owned KeyValueSelect content props (`keyLabel`, value-side props, `variant`, etc.) are not available here — set those on `KeyValueSelect` directly.
+
+| TYPE                             | REQUIRED | DEFAULT     |
+| -------------------------------- | -------- | ----------- |
+| `KeyValueSelectKeyValueRowProps` | No       | `undefined` |
+
+```tsx
+import { KeyValueSelect } from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  value="Ethereum Mainnet"
+  selectButtonProps={{ placeholder: 'Select network' }}
+  keyValueRowProps={{
+    testID: 'network-row',
+    twClassName: 'border-b border-border-muted',
+  }}
+  onPress={() => {}}
+/>;
+```
+
 ### `onPress`
 
 Callback fired when the row is pressed. Use this to open a picker or sheet.
@@ -180,22 +205,22 @@ Row height: compact summary (40px) or taller input context (48px).
 
 Available values:
 
-- `KeyValueRowVariant.Summary` — outer row `h-10` (40px).
-- `KeyValueRowVariant.Input` — outer row `h-12` (48px).
+- `KeyValueSelectVariant.Summary` — outer row `h-10` (40px).
+- `KeyValueSelectVariant.Input` — outer row `h-12` (48px).
 
-| TYPE                 | REQUIRED | DEFAULT                      |
-| -------------------- | -------- | ---------------------------- |
-| `KeyValueRowVariant` | No       | `KeyValueRowVariant.Summary` |
+| TYPE                    | REQUIRED | DEFAULT                         |
+| ----------------------- | -------- | ------------------------------- |
+| `KeyValueSelectVariant` | No       | `KeyValueSelectVariant.Summary` |
 
 ```tsx
 import {
-  KeyValueRowVariant,
   KeyValueSelect,
+  KeyValueSelectVariant,
 } from '@metamask/design-system-react-native';
 
 <KeyValueSelect
   keyLabel="Network"
-  variant={KeyValueRowVariant.Input}
+  variant={KeyValueSelectVariant.Input}
   selectButtonProps={{ placeholder: 'Select' }}
   onPress={() => {}}
 />;

--- a/packages/design-system-react-native/src/components/KeyValueSelect/README.md
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/README.md
@@ -1,0 +1,377 @@
+# KeyValueSelect
+
+KeyValueSelect is used to show a key on the left and a select value on the right in a pressable row. Use it for form and summary rows that open a picker or bottom sheet. Value-side props follow [KeyValueRow](../KeyValueRow/README.md) naming and map onto a secondary [SelectButton](../SelectButton/README.md). SelectButton-only options (placeholder and caret) use `selectButtonProps`. For a static key/value row, use KeyValueRow. For a standalone select control, use SelectButton.
+
+```tsx
+import { KeyValueSelect } from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  value="Ethereum Mainnet"
+  selectButtonProps={{ placeholder: 'Select network' }}
+  onPress={() => {}}
+/>;
+```
+
+## Props
+
+### `keyLabel`
+
+The key content, as a string or custom `ReactNode`. Named `keyLabel` to avoid React's reserved `key` prop.
+
+| TYPE                  | REQUIRED | DEFAULT |
+| --------------------- | -------- | ------- |
+| `string \| ReactNode` | Yes      | —       |
+
+```tsx
+import { KeyValueSelect } from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  selectButtonProps={{ placeholder: 'Select network' }}
+  onPress={() => {}}
+/>;
+```
+
+### `value`
+
+Optional selected label for the select value. When `undefined` or `null`, `selectButtonProps.placeholder` is shown. An empty string `""` still counts as a selected label.
+
+| TYPE             | REQUIRED | DEFAULT     |
+| ---------------- | -------- | ----------- |
+| `string \| null` | No       | `undefined` |
+
+```tsx
+import { KeyValueSelect } from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  value="Ethereum Mainnet"
+  selectButtonProps={{ placeholder: 'Select network' }}
+  onPress={() => {}}
+/>;
+```
+
+### `valueStartAccessory`
+
+Optional node rendered before the select label (for example an avatar or icon). Mapped to SelectButton `startAccessory`.
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  KeyValueSelect,
+} from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Pay with"
+  value="ETH"
+  valueStartAccessory={<AvatarToken name="ETH" size={AvatarTokenSize.Xs} />}
+  selectButtonProps={{ placeholder: 'Select asset' }}
+  onPress={() => {}}
+/>;
+```
+
+### `valueEndAccessory`
+
+Optional node at the end of the select value when no trailing arrow is shown. Mapped to SelectButton `endAccessory`. Pair with `selectButtonProps.hideEndArrow` (or omit the default arrow via SelectButton rules).
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+import {
+  Icon,
+  IconName,
+  IconSize,
+  KeyValueSelect,
+} from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  value="Custom"
+  valueEndAccessory={<Icon name={IconName.ArrowRight} size={IconSize.Sm} />}
+  selectButtonProps={{ placeholder: 'Select', hideEndArrow: true }}
+  onPress={() => {}}
+/>;
+```
+
+### `valueTextProps`
+
+Optional props for the select label `Text`. Mapped to SelectButton `textProps`.
+
+| TYPE                                   | REQUIRED | DEFAULT     |
+| -------------------------------------- | -------- | ----------- |
+| `Omit<Partial<TextProps>, 'children'>` | No       | `undefined` |
+
+```tsx
+import {
+  KeyValueSelect,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  value="Ethereum Mainnet"
+  valueTextProps={{ variant: TextVariant.BodySm }}
+  selectButtonProps={{ placeholder: 'Select network' }}
+  onPress={() => {}}
+/>;
+```
+
+### `selectButtonProps`
+
+SelectButton-only options for the value. Size is always `Md` and variant is always `Secondary`.
+
+| TYPE                              | REQUIRED | DEFAULT |
+| --------------------------------- | -------- | ------- |
+| `KeyValueSelectSelectButtonProps` | Yes      | —       |
+
+Includes:
+
+- `placeholder` (required) — label when `value` is `undefined` or `null`
+- `endArrowDirection` — trailing arrow direction
+- `hideEndArrow` — hide the trailing arrow
+- `endArrowDirectionIconProps` — props for the trailing arrow `Icon`
+
+```tsx
+import {
+  KeyValueSelect,
+  SelectButtonEndArrow,
+} from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  value="Ethereum Mainnet"
+  selectButtonProps={{
+    placeholder: 'Select network',
+    endArrowDirection: SelectButtonEndArrow.Right,
+  }}
+  onPress={() => {}}
+/>;
+```
+
+### `onPress`
+
+Callback fired when the row is pressed. Use this to open a picker or sheet.
+
+| TYPE                        | REQUIRED | DEFAULT     |
+| --------------------------- | -------- | ----------- |
+| `PressableProps['onPress']` | No       | `undefined` |
+
+```tsx
+import { KeyValueSelect } from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  selectButtonProps={{ placeholder: 'Select network' }}
+  onPress={() => {}}
+/>;
+```
+
+### `variant`
+
+Row height: compact summary (40px) or taller input context (48px).
+
+Available values:
+
+- `KeyValueRowVariant.Summary` — outer row `h-10` (40px).
+- `KeyValueRowVariant.Input` — outer row `h-12` (48px).
+
+| TYPE                 | REQUIRED | DEFAULT                      |
+| -------------------- | -------- | ---------------------------- |
+| `KeyValueRowVariant` | No       | `KeyValueRowVariant.Summary` |
+
+```tsx
+import {
+  KeyValueRowVariant,
+  KeyValueSelect,
+} from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  variant={KeyValueRowVariant.Input}
+  selectButtonProps={{ placeholder: 'Select' }}
+  onPress={() => {}}
+/>;
+```
+
+### `keyStartAccessory`
+
+Optional node rendered before the key (for example an icon).
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+import {
+  Icon,
+  IconName,
+  IconSize,
+  KeyValueSelect,
+} from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Fee"
+  keyStartAccessory={<Icon name={IconName.Info} size={IconSize.Sm} />}
+  selectButtonProps={{ placeholder: 'Select' }}
+  onPress={() => {}}
+/>;
+```
+
+### `keyEndAccessory`
+
+Optional node rendered after the key (for example an icon or badge).
+
+| TYPE        | REQUIRED | DEFAULT     |
+| ----------- | -------- | ----------- |
+| `ReactNode` | No       | `undefined` |
+
+```tsx
+import {
+  Icon,
+  IconName,
+  IconSize,
+  KeyValueSelect,
+} from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Limit"
+  keyEndAccessory={<Icon name={IconName.Info} size={IconSize.Sm} />}
+  selectButtonProps={{ placeholder: 'Select' }}
+  onPress={() => {}}
+/>;
+```
+
+### `keyEndButtonIconProps`
+
+When set with `iconName`, renders a `ButtonIcon` as the key end accessory (takes precedence over `keyEndAccessory`).
+
+| TYPE                       | REQUIRED | DEFAULT     |
+| -------------------------- | -------- | ----------- |
+| `Partial<ButtonIconProps>` | No       | `undefined` |
+
+```tsx
+import { IconName, KeyValueSelect } from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  keyEndButtonIconProps={{
+    iconName: IconName.Info,
+    onPress: () => {},
+  }}
+  selectButtonProps={{ placeholder: 'Select network' }}
+  onPress={() => {}}
+/>;
+```
+
+### `keyTextProps`
+
+Optional props for the key `Text` when `keyLabel` is a string.
+
+| TYPE                                   | REQUIRED | DEFAULT     |
+| -------------------------------------- | -------- | ----------- |
+| `Omit<Partial<TextProps>, 'children'>` | No       | `undefined` |
+
+```tsx
+import {
+  KeyValueSelect,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Note"
+  keyTextProps={{ variant: TextVariant.BodySm }}
+  selectButtonProps={{ placeholder: 'Select' }}
+  onPress={() => {}}
+/>;
+```
+
+### `isDisabled`
+
+When `true`, disables the row press and applies disabled presentation on the select value.
+
+| TYPE      | REQUIRED | DEFAULT |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
+```tsx
+import { KeyValueSelect } from '@metamask/design-system-react-native';
+
+<KeyValueSelect
+  keyLabel="Network"
+  value="Ethereum Mainnet"
+  isDisabled
+  selectButtonProps={{ placeholder: 'Select network' }}
+  onPress={() => {}}
+/>;
+```
+
+### `twClassName`
+
+Use the `twClassName` prop to add Tailwind CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`, allowing you to:
+
+- Add new styles that don't exist in the default component
+- Override the component's default styles when needed
+
+Default root classes include `w-full pl-4 pr-1` so the pressable spans the full width with a 16px leading inset and a 4px trailing inset (SelectButton already contributes 12px of trailing padding).
+
+| TYPE     | REQUIRED | DEFAULT     |
+| -------- | -------- | ----------- |
+| `string` | No       | `undefined` |
+
+```tsx
+import { KeyValueSelect } from '@metamask/design-system-react-native';
+
+// Add additional styles
+<KeyValueSelect
+  keyLabel="Network"
+  selectButtonProps={{ placeholder: 'Select' }}
+  twClassName="mt-4"
+  onPress={() => {}}
+/>
+
+// Override default styles
+<KeyValueSelect
+  keyLabel="Network"
+  selectButtonProps={{ placeholder: 'Select' }}
+  twClassName="bg-background-alternative"
+  onPress={() => {}}
+/>
+```
+
+### `style`
+
+Use the `style` prop to customize the component's appearance with React Native styles. For consistent styling, prefer using `twClassName` with Tailwind classes when possible. Use `style` with `tw.style()` for conditionals or dynamic values.
+
+| TYPE                   | REQUIRED | DEFAULT     |
+| ---------------------- | -------- | ----------- |
+| `StyleProp<ViewStyle>` | No       | `undefined` |
+
+```tsx
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { KeyValueSelect } from '@metamask/design-system-react-native';
+
+export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
+  const tw = useTailwind();
+
+  return (
+    <KeyValueSelect
+      keyLabel="Network"
+      selectButtonProps={{ placeholder: 'Select' }}
+      onPress={() => {}}
+      style={tw.style('opacity-100', !isActive && 'opacity-50')}
+    />
+  );
+};
+```
+
+## References
+
+[MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)

--- a/packages/design-system-react-native/src/components/KeyValueSelect/index.ts
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/index.ts
@@ -1,5 +1,7 @@
+export { KeyValueSelectVariant } from '@metamask/design-system-shared';
 export { KeyValueSelect } from './KeyValueSelect';
 export type {
+  KeyValueSelectKeyValueRowProps,
   KeyValueSelectProps,
   KeyValueSelectSelectButtonProps,
 } from './KeyValueSelect.types';

--- a/packages/design-system-react-native/src/components/KeyValueSelect/index.ts
+++ b/packages/design-system-react-native/src/components/KeyValueSelect/index.ts
@@ -1,0 +1,5 @@
+export { KeyValueSelect } from './KeyValueSelect';
+export type {
+  KeyValueSelectProps,
+  KeyValueSelectSelectButtonProps,
+} from './KeyValueSelect.types';

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -180,6 +180,12 @@ export type { KeyValueColumnProps } from './KeyValueColumn';
 export { KeyValueRow, KeyValueRowVariant } from './KeyValueRow';
 export type { KeyValueRowProps } from './KeyValueRow';
 
+export { KeyValueSelect } from './KeyValueSelect';
+export type {
+  KeyValueSelectProps,
+  KeyValueSelectSelectButtonProps,
+} from './KeyValueSelect';
+
 export { Label } from './Label';
 export type { LabelProps } from './Label';
 

--- a/packages/design-system-react-native/src/components/index.ts
+++ b/packages/design-system-react-native/src/components/index.ts
@@ -180,8 +180,9 @@ export type { KeyValueColumnProps } from './KeyValueColumn';
 export { KeyValueRow, KeyValueRowVariant } from './KeyValueRow';
 export type { KeyValueRowProps } from './KeyValueRow';
 
-export { KeyValueSelect } from './KeyValueSelect';
+export { KeyValueSelect, KeyValueSelectVariant } from './KeyValueSelect';
 export type {
+  KeyValueSelectKeyValueRowProps,
   KeyValueSelectProps,
   KeyValueSelectSelectButtonProps,
 } from './KeyValueSelect';

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -103,6 +103,12 @@ export {
   type KeyValueRowPropsShared,
 } from './types/KeyValueRow';
 
+// KeyValueSelect types (ADR-0004)
+export {
+  type KeyValueSelectPropsShared,
+  type KeyValueSelectSelectButtonPropsShared,
+} from './types/KeyValueSelect';
+
 // ButtonFilter types (ADR-0004)
 export { type ButtonFilterPropsShared } from './types/ButtonFilter';
 

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -103,8 +103,9 @@ export {
   type KeyValueRowPropsShared,
 } from './types/KeyValueRow';
 
-// KeyValueSelect types (ADR-0004)
+// KeyValueSelect types (ADR-0003 + ADR-0004)
 export {
+  KeyValueSelectVariant,
   type KeyValueSelectPropsShared,
   type KeyValueSelectSelectButtonPropsShared,
 } from './types/KeyValueSelect';

--- a/packages/design-system-shared/src/types/KeyValueSelect/KeyValueSelect.types.ts
+++ b/packages/design-system-shared/src/types/KeyValueSelect/KeyValueSelect.types.ts
@@ -1,7 +1,5 @@
-import {
-  KeyValueRowVariant,
-  type KeyValueRowPropsShared,
-} from '../KeyValueRow/KeyValueRow.types';
+import { KeyValueRowVariant } from '../KeyValueRow/KeyValueRow.types';
+import type { KeyValueRowPropsShared } from '../KeyValueRow/KeyValueRow.types';
 import type { SelectButtonPropsShared } from '../SelectButton/SelectButton.types';
 
 /**

--- a/packages/design-system-shared/src/types/KeyValueSelect/KeyValueSelect.types.ts
+++ b/packages/design-system-shared/src/types/KeyValueSelect/KeyValueSelect.types.ts
@@ -1,5 +1,15 @@
-import type { KeyValueRowPropsShared } from '../KeyValueRow/KeyValueRow.types';
+import {
+  KeyValueRowVariant,
+  type KeyValueRowPropsShared,
+} from '../KeyValueRow/KeyValueRow.types';
 import type { SelectButtonPropsShared } from '../SelectButton/SelectButton.types';
+
+/**
+ * KeyValueSelect row height variant (ADR-0003).
+ * Alias to KeyValueRowVariant to keep values in sync.
+ */
+export const KeyValueSelectVariant = KeyValueRowVariant;
+export type KeyValueSelectVariant = KeyValueRowVariant;
 
 /**
  * SelectButton-only props exposed on KeyValueSelect via `selectButtonProps`.
@@ -14,15 +24,22 @@ export type KeyValueSelectSelectButtonPropsShared = Pick<
  * KeyValueSelect shared props (ADR-0004).
  * Keeps KeyValueRow key/value naming; SelectButton-only options live on `selectButtonProps`.
  * `value` is narrowed to a select label (`string | null`) rather than KeyValueRow's ReactNode.
+ * `variant` uses the component-scoped `KeyValueSelectVariant` alias.
  */
 export type KeyValueSelectPropsShared = Omit<
   KeyValueRowPropsShared,
-  'value'
+  'value' | 'variant'
 > & {
   /**
    * Selected select label. When `undefined` or `null`, `selectButtonProps.placeholder` is shown.
    */
   value?: string | null;
+  /**
+   * Row height variant.
+   *
+   * @default KeyValueSelectVariant.Summary
+   */
+  variant?: KeyValueSelectVariant;
   /**
    * SelectButton-only props (placeholder and caret controls).
    */

--- a/packages/design-system-shared/src/types/KeyValueSelect/KeyValueSelect.types.ts
+++ b/packages/design-system-shared/src/types/KeyValueSelect/KeyValueSelect.types.ts
@@ -1,0 +1,36 @@
+import type { KeyValueRowPropsShared } from '../KeyValueRow/KeyValueRow.types';
+import type { SelectButtonPropsShared } from '../SelectButton/SelectButton.types';
+
+/**
+ * SelectButton-only props exposed on KeyValueSelect via `selectButtonProps`.
+ * Size is always Md and variant is always Secondary.
+ */
+export type KeyValueSelectSelectButtonPropsShared = Pick<
+  SelectButtonPropsShared,
+  'placeholder' | 'endArrowDirection' | 'hideEndArrow'
+>;
+
+/**
+ * KeyValueSelect shared props (ADR-0004).
+ * Keeps KeyValueRow key/value naming; SelectButton-only options live on `selectButtonProps`.
+ * `value` is narrowed to a select label (`string | null`) rather than KeyValueRow's ReactNode.
+ */
+export type KeyValueSelectPropsShared = Omit<
+  KeyValueRowPropsShared,
+  'value'
+> & {
+  /**
+   * Selected select label. When `undefined` or `null`, `selectButtonProps.placeholder` is shown.
+   */
+  value?: string | null;
+  /**
+   * SelectButton-only props (placeholder and caret controls).
+   */
+  selectButtonProps: KeyValueSelectSelectButtonPropsShared;
+  /**
+   * When true, disables the row press and SelectButton presentation.
+   *
+   * @default false
+   */
+  isDisabled?: boolean;
+};

--- a/packages/design-system-shared/src/types/KeyValueSelect/index.ts
+++ b/packages/design-system-shared/src/types/KeyValueSelect/index.ts
@@ -1,4 +1,5 @@
 export {
+  KeyValueSelectVariant,
   type KeyValueSelectPropsShared,
   type KeyValueSelectSelectButtonPropsShared,
 } from './KeyValueSelect.types';

--- a/packages/design-system-shared/src/types/KeyValueSelect/index.ts
+++ b/packages/design-system-shared/src/types/KeyValueSelect/index.ts
@@ -1,0 +1,4 @@
+export {
+  type KeyValueSelectPropsShared,
+  type KeyValueSelectSelectButtonPropsShared,
+} from './KeyValueSelect.types';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a React Native `KeyValueSelect` composer for pressable key/value rows that open a picker or bottom sheet, and aligns `KeyValueRow` horizontal inset with that full-width list layout.

**What changed:**
- New `@metamask/design-system-react-native` `KeyValueSelect`: outer `Pressable` (ListItem-style `bg-pressed`, `forwardRef`) wrapping `KeyValueRow`, with a non-interactive `SelectButton` value (`pointerEvents="none"`, fixed `Md` + `Secondary`)
- KeyValueRow-style value props (`value`, `valueStartAccessory`, `valueEndAccessory`, `valueTextProps`) map onto SelectButton; SelectButton-only options live on required `selectButtonProps` (`placeholder`, caret controls)
- Component-scoped `KeyValueSelectVariant` alias (instead of importing `KeyValueRowVariant`)
- `keyValueRowProps` escape hatch for inner row shell props (`testID`, `twClassName`, `style`, a11y `ViewProps`)
- Pressable is full-bleed (`w-full`); horizontal inset comes from `KeyValueRow`, with `pr-1` merged so SelectButton’s `px-3` still totals a 16px trailing content inset
- Shared types in `@metamask/design-system-shared`, plus README, Storybook stories, and unit tests

**Breaking change:**
- `KeyValueRow` now defaults to `px-4` (16px horizontal padding). Call sites that already wrap rows in `px-4` / `paddingHorizontal={4}` will double-pad unless that wrapper padding is removed. Flush rows can override with `twClassName="px-0"`.
- See [MIGRATION.md — From version 0.37.0 to 0.38.0](packages/design-system-react-native/MIGRATION.md#from-version-0370-to-0380)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-967

## **Manual testing steps**

1. From repo root: `yarn workspace @metamask/design-system-react-native run jest 'KeyValueRow|KeyValueSelect'`
2. Start RN Storybook (`yarn storybook:ios` or `yarn storybook:android`)
3. Open **Components → KeyValueRow** — confirm default 16px horizontal inset without a padded story wrapper; check flush override if needed (`twClassName="px-0"`)
4. Open **Components → KeyValueSelect** — **Default**: full-width pressable, 16px content inset, secondary SelectButton value, press shows `bg-pressed` (no SelectButton scale/press)
5. Spot-check **Variant**, **ValueStartAccessory**, **ValueEndAccessory**, **SelectButtonProps**, **KeyValueRowProps**, **KeyEndButtonIconProps**, and **IsDisabled** (disabled row does not fire `onPress`)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/4232bfaa-c86e-42f6-b575-2c3216582f40

https://github.com/user-attachments/assets/496f41c4-1a97-40d0-9e3e-1a13f5cc339e

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The KeyValueRow default padding change is a breaking visual/layout change for existing consumers; KeyValueSelect is new surface area but well-tested and documented.
> 
> **Overview**
> Introduces **`KeyValueSelect`**, a full-width pressable row for picker/sheet flows: outer `Pressable` with ListItem-style pressed feedback wraps **`KeyValueRow`** and a non-interactive **`SelectButton`** value (`Md` + `Secondary`). Key/value-side props mirror `KeyValueRow`; caret and placeholder live on required **`selectButtonProps`**. Shared types export **`KeyValueSelectVariant`**; **`keyValueRowProps`** forwards row shell props. Inner row merges **`pr-1`** so trailing inset stays 16px with SelectButton padding.
> 
> **Breaking:** **`KeyValueRow`** now defaults to **`px-4`** horizontal padding. Remove duplicate parent `px-4` wrappers to avoid double inset, or use **`twClassName="px-0"`** for flush rows. **0.37.0 → 0.38.0** migration notes added.
> 
> Docs, Storybook, and tests cover both components; `KeyValueRow` stories no longer pad the decorator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a005874b642456f90b4f40baf65f437bf55604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->