### PR TITLE
Release/56.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "55.0.0",
+  "version": "56.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0]
+
 ### Uncategorized
 
 - chore: Add Code Connect for BannerAlert ([#1362](https://github.com/MetaMask/metamask-design-system/pull/1362))
@@ -635,7 +637,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.37.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.0...HEAD
+[0.38.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.37.0...@metamask/design-system-react-native@0.38.0
 [0.37.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.36.0...@metamask/design-system-react-native@0.37.0
 [0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.35.0...@metamask/design-system-react-native@0.36.0
 [0.35.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.34.0...@metamask/design-system-react-native@0.35.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: Add Code Connect for BannerAlert ([#1362](https://github.com/MetaMask/metamask-design-system/pull/1362))
+- fix: update AvatarAccount Code Connect to correct node and add variant mapping ([#1412](https://github.com/MetaMask/metamask-design-system/pull/1412))
+- chore: Add Code Connect for BannerBase ([#1363](https://github.com/MetaMask/metamask-design-system/pull/1363))
+- feat(dsrn): add KeyValueSelect pressable row with SelectButton value ([#1410](https://github.com/MetaMask/metamask-design-system/pull/1410))
+- feat: add React IconAlert and HelpText showIcon ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
+- fix(dsrn): stop Slider thumb rewind on rapid taps and fast pans ([#1397](https://github.com/MetaMask/metamask-design-system/pull/1397))
+- feat: Add isHidden support to RN Content, TitleHub, and KeyValueRow ([#1406](https://github.com/MetaMask/metamask-design-system/pull/1406))
+- chore(deps): bump @figma/code-connect from 1.4.8 to 1.4.9 ([#1407](https://github.com/MetaMask/metamask-design-system/pull/1407))
+- feat(dsrn): add HelpText component ([#1405](https://github.com/MetaMask/metamask-design-system/pull/1405))
+- fix(dsrn): stop Content description from stretching end accessory ([#1404](https://github.com/MetaMask/metamask-design-system/pull/1404))
+- fix: Polish RN BannerBase spacing for consistency ([#1393](https://github.com/MetaMask/metamask-design-system/pull/1393))
+
 ## [0.37.0]
 
 ### Changed

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,19 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.38.0]
 
-### Uncategorized
+### Added
 
-- chore: Add Code Connect for BannerAlert ([#1362](https://github.com/MetaMask/metamask-design-system/pull/1362))
-- fix: update AvatarAccount Code Connect to correct node and add variant mapping ([#1412](https://github.com/MetaMask/metamask-design-system/pull/1412))
-- chore: Add Code Connect for BannerBase ([#1363](https://github.com/MetaMask/metamask-design-system/pull/1363))
-- feat(dsrn): add KeyValueSelect pressable row with SelectButton value ([#1410](https://github.com/MetaMask/metamask-design-system/pull/1410))
-- feat: add React IconAlert and HelpText showIcon ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
-- fix(dsrn): stop Slider thumb rewind on rapid taps and fast pans ([#1397](https://github.com/MetaMask/metamask-design-system/pull/1397))
-- feat: Add isHidden support to RN Content, TitleHub, and KeyValueRow ([#1406](https://github.com/MetaMask/metamask-design-system/pull/1406))
-- chore(deps): bump @figma/code-connect from 1.4.8 to 1.4.9 ([#1407](https://github.com/MetaMask/metamask-design-system/pull/1407))
-- feat(dsrn): add HelpText component ([#1405](https://github.com/MetaMask/metamask-design-system/pull/1405))
-- fix(dsrn): stop Content description from stretching end accessory ([#1404](https://github.com/MetaMask/metamask-design-system/pull/1404))
-- fix: Polish RN BannerBase spacing for consistency ([#1393](https://github.com/MetaMask/metamask-design-system/pull/1393))
+- Added `KeyValueSelect` for pressable key/value rows with a non-interactive `SelectButton` value (opens a picker or bottom sheet via `onPress`) ([#1410](https://github.com/MetaMask/metamask-design-system/pull/1410))
+- Added `HelpText` for field-level helper and validation copy with optional `HelpTextSeverity` coloring ([#1405](https://github.com/MetaMask/metamask-design-system/pull/1405))
+- Added `showIcon` to `HelpText` (default `false`) to render a leading `IconAlert` when `severity` is set ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
+- Added `isHidden` / `length` support on string slots for `Content`, `ListItem`, `TitleHub`, and `KeyValueRow` via `SensitiveText` (e.g. `valueProps`, `amountProps`, `valueTextProps`) ([#1406](https://github.com/MetaMask/metamask-design-system/pull/1406))
+
+### Changed
+
+- **BREAKING:** `KeyValueRow` now defaults to `px-4` (16px) horizontal padding so rows align with other full-width list surfaces without a parent padding wrapper ([#1410](https://github.com/MetaMask/metamask-design-system/pull/1410))
+  - Call sites that already wrap rows in `px-4` / `paddingHorizontal={4}` will double-pad unless that wrapper padding is removed
+  - Flush rows can override with `twClassName="px-0"`
+  - See [Migration Guide](./MIGRATION.md#from-version-0370-to-0380)
+- Updated `BannerBase` spacing (conditional bottom/right padding and title/description gap) to match Figma; inherited by `BannerAlert` and `Toast` ([#1393](https://github.com/MetaMask/metamask-design-system/pull/1393))
+
+### Fixed
+
+- Fixed `Slider` thumb rewind on rapid taps and fast pans ([#1397](https://github.com/MetaMask/metamask-design-system/pull/1397))
+- Fixed `Content` description stretching the end accessory when the description wraps ([#1404](https://github.com/MetaMask/metamask-design-system/pull/1404))
 
 ## [0.37.0]
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.34.0]
 
-### Uncategorized
+### Added
 
-- chore: Add Code Connect for BannerAlert ([#1362](https://github.com/MetaMask/metamask-design-system/pull/1362))
-- fix: update AvatarAccount Code Connect to correct node and add variant mapping ([#1412](https://github.com/MetaMask/metamask-design-system/pull/1412))
-- chore: Add Code Connect for BannerBase ([#1363](https://github.com/MetaMask/metamask-design-system/pull/1363))
-- feat: add React IconAlert and HelpText showIcon ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
-- chore(deps): bump @figma/code-connect from 1.4.8 to 1.4.9 ([#1407](https://github.com/MetaMask/metamask-design-system/pull/1407))
-- fix: Polish React BannerBase spacing for consistency ([#1394](https://github.com/MetaMask/metamask-design-system/pull/1394))
+- Added `IconAlert` for severity-mapped icon glyphs aligned with the React Native primitive ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
+- Added `showIcon` to `HelpText` (default `false`) to render a leading `IconAlert` when `severity` is set ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
+
+### Changed
+
+- Updated `BannerBase` spacing (padding, title/description gap, action button margin, and close button offset) to match Figma; inherited by `BannerAlert` and `Toast` ([#1394](https://github.com/MetaMask/metamask-design-system/pull/1394))
 
 ## [0.33.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: Add Code Connect for BannerAlert ([#1362](https://github.com/MetaMask/metamask-design-system/pull/1362))
+- fix: update AvatarAccount Code Connect to correct node and add variant mapping ([#1412](https://github.com/MetaMask/metamask-design-system/pull/1412))
+- chore: Add Code Connect for BannerBase ([#1363](https://github.com/MetaMask/metamask-design-system/pull/1363))
+- feat: add React IconAlert and HelpText showIcon ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
+- chore(deps): bump @figma/code-connect from 1.4.8 to 1.4.9 ([#1407](https://github.com/MetaMask/metamask-design-system/pull/1407))
+- fix: Polish React BannerBase spacing for consistency ([#1394](https://github.com/MetaMask/metamask-design-system/pull/1394))
+
 ## [0.33.0]
 
 ### Added

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0]
+
 ### Uncategorized
 
 - chore: Add Code Connect for BannerAlert ([#1362](https://github.com/MetaMask/metamask-design-system/pull/1362))
@@ -435,7 +437,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.33.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.34.0...HEAD
+[0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.33.0...@metamask/design-system-react@0.34.0
 [0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.32.0...@metamask/design-system-react@0.33.0
 [0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.31.0...@metamask/design-system-react@0.32.0
 [0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.30.0...@metamask/design-system-react@0.31.0

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0]
+
 ### Uncategorized
 
 - feat(dsrn): add KeyValueSelect pressable row with SelectButton value ([#1410](https://github.com/MetaMask/metamask-design-system/pull/1410))
@@ -313,7 +315,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.30.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.31.0...HEAD
+[0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.30.0...@metamask/design-system-shared@0.31.0
 [0.30.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.29.0...@metamask/design-system-shared@0.30.0
 [0.29.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.28.0...@metamask/design-system-shared@0.29.0
 [0.28.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.27.0...@metamask/design-system-shared@0.28.0

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(dsrn): add KeyValueSelect pressable row with SelectButton value ([#1410](https://github.com/MetaMask/metamask-design-system/pull/1410))
+- feat: add React IconAlert and HelpText showIcon ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
+
 ## [0.30.0]
 
 ### Added

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.31.0]
 
-### Uncategorized
+### Added
 
-- feat(dsrn): add KeyValueSelect pressable row with SelectButton value ([#1410](https://github.com/MetaMask/metamask-design-system/pull/1410))
-- feat: add React IconAlert and HelpText showIcon ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
+- Added `KeyValueSelectPropsShared`, `KeyValueSelectSelectButtonPropsShared`, and `KeyValueSelectVariant` for cross-platform `KeyValueSelect` support ([#1410](https://github.com/MetaMask/metamask-design-system/pull/1410))
+- Added `showIcon` to `HelpTextPropsShared` (default `false`) for an optional leading severity icon on `HelpText` ([#1409](https://github.com/MetaMask/metamask-design-system/pull/1409))
 
 ## [0.30.0]
 

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
<!--
Release PR Template

Use this template for release PRs by creating your PR with:
https://github.com/MetaMask/metamask-design-system/compare/main...release/VERSION?template=release.md

Or use the default PR template and manually copy this structure.
-->

## Release 56.0.0

This release ships React `IconAlert` + `HelpText` `showIcon`, React Native `KeyValueSelect` / `HelpText` / sensitive-text `isHidden` support, shared type additions for those APIs, BannerBase spacing polish on both platforms, and RN Slider/Content fixes. It includes one React Native breaking change: `KeyValueRow` now defaults to `px-4` horizontal padding.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.31.0**
- `@metamask/design-system-react`: **0.34.0**
- `@metamask/design-system-react-native`: **0.38.0**

### 🔄 Shared Type Updates (0.31.0)

#### Component Type Additions (#1410, #1409)

**What Changed:**

- Added `KeyValueSelectPropsShared`, `KeyValueSelectSelectButtonPropsShared`, and `KeyValueSelectVariant` for cross-platform `KeyValueSelect` support (#1410)
- Added `showIcon` to `HelpTextPropsShared` (default `false`) for an optional leading severity icon on `HelpText` (#1409)

**Impact:**

- Enables React Native `KeyValueSelect` and cross-platform `HelpText` `showIcon` without divergent prop shapes
- Continues ADR-0003/0004 const-object + string-union pattern adoption

### 🌐 React Web Updates (0.34.0)

#### Added

- Added `IconAlert` for severity-mapped icon glyphs aligned with the React Native primitive (#1409)
- Added `showIcon` to `HelpText` (default `false`) to render a leading `IconAlert` when `severity` is set (#1409)

#### Changed

- Updated `BannerBase` spacing (padding, title/description gap, action button margin, and close button offset) to match Figma; inherited by `BannerAlert` and `Toast` (#1394)

### 📱 React Native Updates (0.38.0)

#### Added

- Added `KeyValueSelect` for pressable key/value rows with a non-interactive `SelectButton` value (opens a picker or bottom sheet via `onPress`) (#1410)
- Added `HelpText` for field-level helper and validation copy with optional `HelpTextSeverity` coloring (#1405)
- Added `showIcon` to `HelpText` (default `false`) to render a leading `IconAlert` when `severity` is set (#1409)
- Added `isHidden` / `length` support on string slots for `Content`, `ListItem`, `TitleHub`, and `KeyValueRow` via `SensitiveText` (e.g. `valueProps`, `amountProps`, `valueTextProps`) (#1406)

#### Changed

- **BREAKING:** `KeyValueRow` now defaults to `px-4` (16px) horizontal padding so rows align with other full-width list surfaces without a parent padding wrapper (#1410)
  - Call sites that already wrap rows in `px-4` / `paddingHorizontal={4}` will double-pad unless that wrapper padding is removed
  - Flush rows can override with `twClassName="px-0"`
  - Migration: [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0370-to-0380)
- Updated `BannerBase` spacing (conditional bottom/right padding and title/description gap) to match Figma; inherited by `BannerAlert` and `Toast` (#1393)

#### Fixed

- Fixed `Slider` thumb rewind on rapid taps and fast pans (#1397)
- Fixed `Content` description stretching the end accessory when the description wraps (#1404)

### ⚠️ Breaking Changes

#### `KeyValueRow` default horizontal padding (React Native Only)

**What Changed:**

- `KeyValueRow` previously had no default horizontal padding (parents often supplied `px-4`)
- `KeyValueRow` now defaults to `px-4` (16px) on the outer row

**Migration:**

```tsx
// Before (0.37.0) — parent owned the horizontal inset
import { Box, KeyValueRow } from '@metamask/design-system-react-native';

<Box twClassName="px-4">
  <KeyValueRow keyLabel="Network" value="Ethereum Mainnet" />
</Box>;

// After (0.38.0) — KeyValueRow owns the inset
import { KeyValueRow } from '@metamask/design-system-react-native';

<KeyValueRow keyLabel="Network" value="Ethereum Mainnet" />;

// If you still need flush/edge content, override the default
<KeyValueRow keyLabel="Network" value="Ethereum Mainnet" twClassName="px-0" />;
```

**Impact:**

- Call sites that already wrap `KeyValueRow` in a `px-4` / `paddingHorizontal={4}` container will get double horizontal padding unless that wrapper padding is removed
- Call sites that intentionally used flush rows should set `twClassName="px-0"` after upgrading

See migration guide for complete instructions:

- [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0370-to-0380)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: minor (0.30.0 → 0.31.0) - additive shared types (`KeyValueSelect*`, `HelpText` `showIcon`)
  - [x] design-system-react: minor (0.33.0 → 0.34.0) - new `IconAlert` + `HelpText` `showIcon`; BannerBase spacing polish
  - [x] design-system-react-native: minor (0.37.0 → 0.38.0) - new components/APIs + breaking `KeyValueRow` default padding (pre-1.0 minor may include breaking changes)
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples (if breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive releases, but React Native consumers must migrate around the breaking `KeyValueRow` default padding and updated `BannerBase`/`Toast` layout.
> 
> **Overview**
> **Release 56.0.0** cuts published versions and finalizes changelogs for `@metamask/design-system-shared` **0.31.0**, `@metamask/design-system-react` **0.34.0**, and `@metamask/design-system-react-native` **0.38.0** (root monorepo **56.0.0**).
> 
> Shared **0.31.0** adds cross-platform types for `KeyValueSelect` and `showIcon` on `HelpText`. React **0.34.0** adds web `IconAlert`, optional severity icons on `HelpText`, and Figma-aligned `BannerBase` spacing (affects `BannerAlert` / `Toast`). React Native **0.38.0** adds `KeyValueSelect`, `HelpText`, `HelpText` `showIcon`, and `SensitiveText` masking props on several list/title components; polishes `BannerBase`; fixes `Slider` thumb behavior and `Content` end-accessory layout.
> 
> **Breaking (RN only):** `KeyValueRow` now defaults to `px-4`—remove duplicate parent horizontal padding or use `twClassName="px-0"` for flush rows (see RN `MIGRATION.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38854b0a9c3134e15be5a9dc8fa3a2e8203f0b13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->