### PR TITLE
fix(TextFieldSearch): align component with Figma designs

### DIFF
--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -3603,7 +3603,11 @@ import { TextFieldSearch } from '@metamask/design-system-react';
 // After (0.35.0) — now Lg by default; pass Md to preserve prior height
 import { TextFieldSearch, TextFieldSize } from '@metamask/design-system-react';
 
-<TextFieldSearch size={TextFieldSize.Md} value={query} onChange={handleChange} />;
+<TextFieldSearch
+  size={TextFieldSize.Md}
+  value={query}
+  onChange={handleChange}
+/>;
 ```
 
 **Impact:**

--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -48,6 +48,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TextFieldSearch Component](#textfieldsearch-component)
   - [FormTextField Component](#formtextfield-component)
 - [Version Updates](#version-updates)
+  - [From version 0.x.0 to 0.x.0](#from-version-0x0-to-0x0)
   - [From version 0.27.x to 0.28.0](#from-version-027x-to-0280)
   - [From version 0.25.0 to 0.26.0](#from-version-0250-to-0260)
   - [From version 0.22.0 to 0.23.0](#from-version-0220-to-0230)
@@ -3580,6 +3581,36 @@ The new `TextFieldSearch` reuses `TextField`'s Tailwind chrome instead of the `m
 `FormTextField` uses Tailwind utilities (`flex flex-col`) on the root and design-token classes on the composed `Label`/`TextField`/`HelpText` instead of the `mm-form-text-field` SCSS module. Custom container styles should be passed via `className`; legacy `mm-form-text-field--*` classes are no longer applied.
 
 ## Version Updates
+
+### From version 0.x.0 to 0.x.0
+
+#### TextFieldSearch: default `size` changed from `TextFieldSize.Md` to `TextFieldSize.Lg`
+
+**What changed:**
+
+`TextFieldSearch` now hardcodes `size={TextFieldSize.Lg}` to align with the Figma design spec. Previously the component inherited `TextField`'s default of `TextFieldSize.Md`. Any consumer that relied on the implicit `Md` height will now render a taller field, which can cause layout shifts.
+
+**Migration:**
+
+If you need the previous `Md` height, pass `size` explicitly:
+
+```tsx
+// Before (0.34.x) — implicitly Md
+import { TextFieldSearch } from '@metamask/design-system-react';
+
+<TextFieldSearch value={query} onChange={handleChange} />;
+
+// After (0.35.0) — now Lg by default; pass Md to preserve prior height
+import { TextFieldSearch, TextFieldSize } from '@metamask/design-system-react';
+
+<TextFieldSearch size={TextFieldSize.Md} value={query} onChange={handleChange} />;
+```
+
+**Impact:**
+
+- Any `TextFieldSearch` without an explicit `size` prop will now render at the `Lg` height (48px) instead of `Md` (40px).
+- Layouts that depend on the field's height (fixed containers, grid rows, inline forms) may shift and should be reviewed.
+- Pass `size={TextFieldSize.Md}` to opt back into the previous height.
 
 ### From version 0.27.x to 0.28.0
 

--- a/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.test.tsx
+++ b/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.test.tsx
@@ -107,21 +107,6 @@ describe('TextFieldSearch', () => {
   });
 
   describe('clear button', () => {
-    it('uses the default icon color', () => {
-      render(
-        <TextFieldSearch
-          onChange={noop}
-          value="hello"
-          clearButtonOnClick={noop}
-        />,
-      );
-
-      // ButtonIcon sets text-icon-default on the button; the SVG inherits via text-inherit.
-      expect(screen.getByTestId(CLEAR_BUTTON_TEST_ID)).toHaveClass(
-        'text-icon-default',
-      );
-    });
-
     it('is hidden when value is empty', () => {
       render(
         <TextFieldSearch onChange={noop} value="" clearButtonOnClick={noop} />,

--- a/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.test.tsx
+++ b/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.test.tsx
@@ -9,6 +9,51 @@ const noop = () => undefined;
 
 describe('TextFieldSearch', () => {
   describe('rendering', () => {
+    it('applies hover border class when enabled', () => {
+      render(
+        <TextFieldSearch
+          data-testid={ROOT_TEST_ID}
+          onChange={noop}
+          value=""
+          clearButtonOnClick={noop}
+        />,
+      );
+
+      expect(screen.getByTestId(ROOT_TEST_ID)).toHaveClass(
+        'hover:border-default',
+      );
+    });
+
+    it('does not apply hover border class when disabled', () => {
+      render(
+        <TextFieldSearch
+          data-testid={ROOT_TEST_ID}
+          onChange={noop}
+          value=""
+          clearButtonOnClick={noop}
+          isDisabled
+        />,
+      );
+
+      expect(screen.getByTestId(ROOT_TEST_ID)).not.toHaveClass(
+        'hover:border-default',
+      );
+    });
+
+    it('hides native webkit search decorations on the input', () => {
+      render(
+        <TextFieldSearch onChange={noop} value="" clearButtonOnClick={noop} />,
+      );
+
+      const input = screen.getByRole('searchbox');
+      expect(input).toHaveClass(
+        '[&::-webkit-search-cancel-button]:hidden',
+        '[&::-webkit-search-decoration]:hidden',
+        '[&::-webkit-search-results-button]:hidden',
+        '[&::-webkit-search-results-decoration]:hidden',
+      );
+    });
+
     it('renders root container and inner search input', () => {
       render(
         <TextFieldSearch
@@ -62,6 +107,21 @@ describe('TextFieldSearch', () => {
   });
 
   describe('clear button', () => {
+    it('uses the default icon color', () => {
+      render(
+        <TextFieldSearch
+          onChange={noop}
+          value="hello"
+          clearButtonOnClick={noop}
+        />,
+      );
+
+      // ButtonIcon sets text-icon-default on the button; the SVG inherits via text-inherit.
+      expect(screen.getByTestId(CLEAR_BUTTON_TEST_ID)).toHaveClass(
+        'text-icon-default',
+      );
+    });
+
     it('is hidden when value is empty', () => {
       render(
         <TextFieldSearch onChange={noop} value="" clearButtonOnClick={noop} />,

--- a/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.test.tsx
+++ b/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.test.tsx
@@ -9,7 +9,7 @@ const noop = () => undefined;
 
 describe('TextFieldSearch', () => {
   describe('rendering', () => {
-    it('applies hover border class when enabled', () => {
+    it('applies muted background and hover background when enabled', () => {
       render(
         <TextFieldSearch
           data-testid={ROOT_TEST_ID}
@@ -20,11 +20,12 @@ describe('TextFieldSearch', () => {
       );
 
       expect(screen.getByTestId(ROOT_TEST_ID)).toHaveClass(
-        'hover:border-default',
+        'bg-muted',
+        'hover:bg-muted-hover',
       );
     });
 
-    it('does not apply hover border class when disabled', () => {
+    it('does not apply hover background class when disabled', () => {
       render(
         <TextFieldSearch
           data-testid={ROOT_TEST_ID}
@@ -36,7 +37,23 @@ describe('TextFieldSearch', () => {
       );
 
       expect(screen.getByTestId(ROOT_TEST_ID)).not.toHaveClass(
-        'hover:border-default',
+        'hover:bg-muted-hover',
+      );
+    });
+
+    it('does not apply hover background class when in error state', () => {
+      render(
+        <TextFieldSearch
+          data-testid={ROOT_TEST_ID}
+          onChange={noop}
+          value=""
+          clearButtonOnClick={noop}
+          isError
+        />,
+      );
+
+      expect(screen.getByTestId(ROOT_TEST_ID)).not.toHaveClass(
+        'hover:bg-muted-hover',
       );
     });
 

--- a/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.tsx
+++ b/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.tsx
@@ -51,7 +51,7 @@ export const TextFieldSearch = forwardRef<HTMLDivElement, TextFieldSearchProps>(
         type={TextFieldType.Search}
         className={twMerge(
           'rounded-full',
-          !isDisabled && 'hover:border-default',
+          !isDisabled && !props.isError && 'hover:border-default',
           className,
         )}
         inputProps={{

--- a/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.tsx
+++ b/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.tsx
@@ -17,6 +17,7 @@ export const TextFieldSearch = forwardRef<HTMLDivElement, TextFieldSearchProps>(
       startAccessory,
       isDisabled = false,
       className,
+      inputProps,
       ...props
     },
     ref,
@@ -27,7 +28,7 @@ export const TextFieldSearch = forwardRef<HTMLDivElement, TextFieldSearchProps>(
         ariaLabel="Clear"
         iconName={IconName.CircleX}
         size={ButtonIconSize.Md}
-        iconProps={{ color: IconColor.IconAlternative }}
+        iconProps={{ color: IconColor.IconDefault }}
         {...clearButtonProps}
         isDisabled={isDisabled || clearButtonProps?.isDisabled}
         onClick={clearButtonOnClick}
@@ -48,7 +49,18 @@ export const TextFieldSearch = forwardRef<HTMLDivElement, TextFieldSearchProps>(
         value={value}
         isDisabled={isDisabled}
         type={TextFieldType.Search}
-        className={twMerge('rounded-full', className)}
+        className={twMerge(
+          'rounded-full',
+          !isDisabled && 'hover:border-default',
+          className,
+        )}
+        inputProps={{
+          ...inputProps,
+          className: twMerge(
+            '[&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden [&::-webkit-search-results-button]:hidden [&::-webkit-search-results-decoration]:hidden',
+            inputProps?.className,
+          ),
+        }}
         startAccessory={
           startAccessory ?? (
             <Icon

--- a/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.tsx
+++ b/packages/design-system-react/src/components/TextFieldSearch/TextFieldSearch.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef } from 'react';
 import { twMerge } from '../../utils/tw-merge';
 import { ButtonIcon, ButtonIconSize } from '../ButtonIcon';
 import { Icon, IconColor, IconName, IconSize } from '../Icon';
-import { TextField, TextFieldType } from '../TextField';
+import { TextField, TextFieldSize, TextFieldType } from '../TextField';
 
 import type { TextFieldSearchProps } from './TextFieldSearch.types';
 
@@ -49,9 +49,10 @@ export const TextFieldSearch = forwardRef<HTMLDivElement, TextFieldSearchProps>(
         value={value}
         isDisabled={isDisabled}
         type={TextFieldType.Search}
+        size={TextFieldSize.Lg}
         className={twMerge(
-          'rounded-full',
-          !isDisabled && !props.isError && 'hover:border-default',
+          'rounded-full bg-muted',
+          !isDisabled && !props.isError && 'hover:bg-muted-hover',
           className,
         )}
         inputProps={{


### PR DESCRIPTION
## **Description**

Aligns `TextFieldSearch` (React web) with the Figma design ([node 4847-18012](https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?m=dev&node-id=4847-18012)).

Three visual properties were diverging from Figma:

- **Background**: was `bg-default` (TextField base default); now overrides to `bg-muted` to match Figma's translucent dark surface. Brings web in line with React Native, which already used `bg-muted`.
- **Hover state**: was applying `hover:border-default` (border change); Figma keeps the border at `border-muted` on hover and changes only the background. Now applies `hover:bg-muted-hover` instead — suppressed when `isDisabled` or `isError`.
- **Height**: was defaulting to `TextFieldSize.Md` (40 px); Figma specifies 48 px. Now passes `size={TextFieldSize.Lg}` (48 px / `h-12`), matching React Native's hardcoded `h-12`.

## **Related issues**

Fixes: [DSYS-968](https://consensyssoftware.atlassian.net/browse/DSYS-968)

## **Manual testing steps**

1. Render a `TextFieldSearch` in Storybook (`yarn storybook`).
2. Confirm the field has a muted/translucent background (not plain white/default).
3. Hover over the field — background should darken slightly (`bg-muted-hover`); border should stay muted (no border color change).
4. Focus the field — border should shift to `border-default`.
5. Confirm the field height is 48 px (matching the Lg size).
6. Type a value — clear button (×) should appear; clicking it should call `clearButtonOnClick`.

## **Screenshots/Recordings**

### **Before**

- Background: `bg-default`
- Hover: border changes to `border-default`
- Height: 40 px (`TextFieldSize.Md`)

https://github.com/user-attachments/assets/c5911610-6a78-4418-b2cb-aa7ddd322422

### **After**

- Background: `bg-muted`
- Hover: background darkens to `bg-muted-hover`, border stays muted
- Height: 48 px (`TextFieldSize.Lg`)

https://github.com/user-attachments/assets/c2b36e05-4637-4c55-ac33-f7c622bfa105

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default height and visual styling change for all consumers without an explicit `size`, which can shift layouts; behavior is documented but still a breaking visual default.
> 
> **Overview**
> Updates **`TextFieldSearch`** so its default look matches Figma and React Native: **muted background**, **background-only hover** (no border hover), and **large (48px) height** instead of inheriting **`TextField`**’s medium default.
> 
> The component now sets **`size={TextFieldSize.Lg}`**, applies **`bg-muted`** / **`hover:bg-muted-hover`** (skipped when disabled or in error), switches the clear icon to **`IconDefault`**, forwards **`inputProps`** with WebKit search-decoration hiding, and documents the default size change in **`MIGRATION.md`**. Tests cover the new classes and input styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b922c2ac18509bfbd6e94e96935ab424f8bc49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->