### PR TITLE
fix(ModalContent): apply border-muted in pure black mode

### DIFF
--- a/packages/design-system-react/src/components/ModalContent/ModalContent.test.tsx
+++ b/packages/design-system-react/src/components/ModalContent/ModalContent.test.tsx
@@ -129,6 +129,36 @@ describe('ModalContent', () => {
     );
   });
 
+  it('applies border-muted to the dialog when pure black is enabled', () => {
+    render(
+      <PureBlackProvider isPureBlack>
+        <Modal isOpen onClose={onClose}>
+          <ModalContent modalDialogProps={{ 'data-testid': 'dialog' }}>
+            content
+          </ModalContent>
+        </Modal>
+      </PureBlackProvider>,
+    );
+
+    const dialog = screen.getByTestId('dialog');
+    expect(dialog).toHaveClass('border');
+    expect(dialog).toHaveClass('border-muted');
+  });
+
+  it('does not apply border-muted to the dialog when pure black is disabled', () => {
+    render(
+      <PureBlackProvider isPureBlack={false}>
+        <Modal isOpen onClose={onClose}>
+          <ModalContent modalDialogProps={{ 'data-testid': 'dialog' }}>
+            content
+          </ModalContent>
+        </Modal>
+      </PureBlackProvider>,
+    );
+
+    expect(screen.getByTestId('dialog')).not.toHaveClass('border-muted');
+  });
+
   it('forwards ref to the outer positioning element', () => {
     const ref = createRef<HTMLDivElement>();
     render(

--- a/packages/design-system-react/src/components/ModalContent/ModalContent.tsx
+++ b/packages/design-system-react/src/components/ModalContent/ModalContent.tsx
@@ -110,6 +110,7 @@ export const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
             className={twMerge(
               'flex max-h-full w-full rounded-lg shadow-lg motion-safe:animate-slide-up',
               TWCLASSMAP_MODAL_CONTENT_SIZE[size],
+              isPureBlack && 'border border-muted',
               modalDialogProps?.className,
             )}
           >


### PR DESCRIPTION
## Description

When pure black (OLED) dark mode is active, `ModalContent` now automatically applies a `border border-muted` class to the modal dialog box. This provides visual separation from the pure black background without requiring consumers to pass it manually via `modalDialogProps.className`.

The component already used `usePureBlack()` to switch the background color — this change extends that logic to also add the border.

## Related issues

Fixes workaround in MetaMask/metamask-extension#44877

## Changes

- `ModalContent.tsx`: add `isPureBlack && 'border border-muted'` to the dialog `twMerge` call
- `ModalContent.test.tsx`: two new tests covering border presence/absence based on pure black state

### Before

<img width="456" height="521" alt="Screenshot 2026-07-24 at 3 54 28 PM" src="https://github.com/user-attachments/assets/c1411c70-3e40-4d79-bd14-2c51d5c551c4" />

### After

<img width="440" height="808" alt="Screenshot 2026-07-24 at 3 54 17 PM" src="https://github.com/user-attachments/assets/74831608-dbcf-44ca-97c0-e898c54e5fc0" />


## Pre-merge author checklist

- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, conditional styling change in the design system with unit test coverage and no auth or data impact.
> 
> **Overview**
> **`ModalContent`** now adds **`border border-muted`** on the modal dialog when pure black (OLED) mode is on, alongside the existing alternative background, so modals stay visually distinct from a pure black backdrop without consumers passing border classes through **`modalDialogProps`**.
> 
> Tests assert the border classes apply with **`PureBlackProvider isPureBlack`** and are absent when pure black is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b0d23506815ee9bc9f98de0dae3a73bf0b12ff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->