### PR TITLE
Release 57.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "56.0.0",
+  "version": "57.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.38.1]
 
-### Uncategorized
+### Changed
 
-- feat(dsrn): remove bottom border from BottomSheet ([#1413](https://github.com/MetaMask/metamask-design-system/pull/1413))
+- Removed bottom border from `BottomSheet` to align with updated Figma designs ([#1413](https://github.com/MetaMask/metamask-design-system/pull/1413))
 
 ## [0.38.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(dsrn): remove bottom border from BottomSheet ([#1413](https://github.com/MetaMask/metamask-design-system/pull/1413))
+
 ## [0.38.0]
 
 ### Added

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1]
+
 ### Uncategorized
 
 - feat(dsrn): remove bottom border from BottomSheet ([#1413](https://github.com/MetaMask/metamask-design-system/pull/1413))
@@ -647,7 +649,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.1...HEAD
+[0.38.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.0...@metamask/design-system-react-native@0.38.1
 [0.38.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.37.0...@metamask/design-system-react-native@0.38.0
 [0.37.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.36.0...@metamask/design-system-react-native@0.37.0
 [0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.35.0...@metamask/design-system-react-native@0.36.0

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.0]
 
+### Changed
+
+- **BREAKING:** `TextFieldSearch` default `size` changed from `TextFieldSize.Md` to `TextFieldSize.Lg` to match Figma designs ([#1418](https://github.com/MetaMask/metamask-design-system/pull/1418))
+  - Consumers relying on the implicit `Md` height will now render a taller field; pass `size={TextFieldSize.Md}` to preserve the prior height
+  - See [Migration Guide](./MIGRATION.md#from-version-0340-to-0350)
+
 ### Fixed
 
-- Fixed `TextFieldSearch` layout to match Figma designs ([#1418](https://github.com/MetaMask/metamask-design-system/pull/1418))
 - Fixed `ModalContent` to apply `border-muted` correctly in pure-black mode ([#1419](https://github.com/MetaMask/metamask-design-system/pull/1419))
 
 ## [0.34.0]

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.0]
 
-### Uncategorized
+### Fixed
 
-- fix(TextFieldSearch): align component with Figma designs ([#1418](https://github.com/MetaMask/metamask-design-system/pull/1418))
-- fix(ModalContent): apply border-muted in pure black mode ([#1419](https://github.com/MetaMask/metamask-design-system/pull/1419))
+- Fixed `TextFieldSearch` layout to match Figma designs ([#1418](https://github.com/MetaMask/metamask-design-system/pull/1418))
+- Fixed `ModalContent` to apply `border-muted` correctly in pure-black mode ([#1419](https://github.com/MetaMask/metamask-design-system/pull/1419))
 
 ## [0.34.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix(TextFieldSearch): align component with Figma designs ([#1418](https://github.com/MetaMask/metamask-design-system/pull/1418))
+- fix(ModalContent): apply border-muted in pure black mode ([#1419](https://github.com/MetaMask/metamask-design-system/pull/1419))
+
 ## [0.34.0]
 
 ### Added

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0]
+
 ### Uncategorized
 
 - fix(TextFieldSearch): align component with Figma designs ([#1418](https://github.com/MetaMask/metamask-design-system/pull/1418))
@@ -442,7 +444,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.34.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.0...HEAD
+[0.35.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.34.0...@metamask/design-system-react@0.35.0
 [0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.33.0...@metamask/design-system-react@0.34.0
 [0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.32.0...@metamask/design-system-react@0.33.0
 [0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.31.0...@metamask/design-system-react@0.32.0

--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -48,7 +48,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TextFieldSearch Component](#textfieldsearch-component)
   - [FormTextField Component](#formtextfield-component)
 - [Version Updates](#version-updates)
-  - [From version 0.x.0 to 0.x.0](#from-version-0x0-to-0x0)
+  - [From version 0.34.0 to 0.35.0](#from-version-0340-to-0350)
   - [From version 0.27.x to 0.28.0](#from-version-027x-to-0280)
   - [From version 0.25.0 to 0.26.0](#from-version-0250-to-0260)
   - [From version 0.22.0 to 0.23.0](#from-version-0220-to-0230)
@@ -3582,7 +3582,7 @@ The new `TextFieldSearch` reuses `TextField`'s Tailwind chrome instead of the `m
 
 ## Version Updates
 
-### From version 0.x.0 to 0.x.0
+### From version 0.34.0 to 0.35.0
 
 #### TextFieldSearch: default `size` changed from `TextFieldSize.Md` to `TextFieldSize.Lg`
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Release 57.0.0

Bug fixes and a Figma-alignment update for `TextFieldSearch` default size, plus a visual tweak to `BottomSheet` on React Native.

### 📦 Package Versions

- `@metamask/design-system-react`: **0.35.0**
- `@metamask/design-system-react-native`: **0.38.1**

### 🌐 React Web Updates (0.35.0)

#### Changed

- **BREAKING:** `TextFieldSearch` default `size` changed from `TextFieldSize.Md` to `TextFieldSize.Lg` to match Figma designs ([#1418](https://github.com/MetaMask/metamask-design-system/pull/1418))
  - Consumers relying on the implicit `Md` height will now render a taller field; pass `size={TextFieldSize.Md}` to preserve the prior height
  - See [Migration Guide](./packages/design-system-react/MIGRATION.md#from-version-0340-to-0350)

#### Fixed

- Fixed `ModalContent` to apply `border-muted` correctly in pure-black mode ([#1419](https://github.com/MetaMask/metamask-design-system/pull/1419))

### 📱 React Native Updates (0.38.1)

#### Changed

- Removed bottom border from `BottomSheet` to align with updated Figma designs ([#1413](https://github.com/MetaMask/metamask-design-system/pull/1413))

### ⚠️ Breaking Changes

#### TextFieldSearch: default size changed from Md to Lg (React Web Only)

**What Changed:**

- `TextFieldSearch` previously inherited `TextField`'s default of `TextFieldSize.Md`
- Now hardcodes `size={TextFieldSize.Lg}` to match the Figma design spec

**Migration:**

```tsx
// Before (0.34.x) — implicitly Md
import { TextFieldSearch } from '@metamask/design-system-react';

<TextFieldSearch value={query} onChange={handleChange} />;

// After (0.35.0) — now Lg by default; pass Md to preserve prior height
import { TextFieldSearch, TextFieldSize } from '@metamask/design-system-react';

<TextFieldSearch
  size={TextFieldSize.Md}
  value={query}
  onChange={handleChange}
/>;
```

**Impact:**

- Any `TextFieldSearch` without an explicit `size` prop will render at the `Lg` height (48px) instead of `Md` (40px)
- Fixed containers, grid rows, and inline forms that depend on field height may shift

See migration guide for complete instructions:

- [React Migration Guide](./packages/design-system-react/MIGRATION.md#from-version-0340-to-0350)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-react: minor (0.34.0 → 0.35.0) - breaking default size change
  - [x] design-system-react-native: patch (0.38.0 → 0.38.1) - visual-only BottomSheet change
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [ ] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The documented breaking `TextFieldSearch` default size can cause layout shifts for web consumers who omit `size`; the PR itself is low-risk metadata, but upgrading carries that consumer impact.
> 
> **Overview**
> **Release 57.0.0** cuts published versions and consumer-facing release notes; it does not change component source in this diff.
> 
> **`@metamask/design-system-react` 0.34.0 → 0.35.0:** Changelog and **MIGRATION.md** document a **breaking** default for **`TextFieldSearch`**: implicit size moves from **`TextFieldSize.Md`** to **`TextFieldSize.Lg`** (Figma alignment). Apps that depended on the old height should pass **`size={TextFieldSize.Md}`**. **`ModalContent`** **`border-muted`** in pure-black mode is listed as fixed.
> 
> **`@metamask/design-system-react-native` 0.38.0 → 0.38.1:** Changelog records removal of the **`BottomSheet`** bottom border (Figma).
> 
> Root **`package.json`** goes **56.0.0 → 57.0.0**; package **`CHANGELOG.md`** links and **`[Unreleased]`** sections are updated for the new tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de386e98d456ef713d94789e3b359267430d3fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->