### PR TITLE
fix(BadgeCount): increase Lg height by 2px to 22px

### DIFF
--- a/packages/design-system-react-native/src/components/BadgeCount/BadgeCount.constants.ts
+++ b/packages/design-system-react-native/src/components/BadgeCount/BadgeCount.constants.ts
@@ -16,5 +16,5 @@ export const TWCLASSMAP_BADGECOUNT_SIZE_CONTAINER: Record<
   string
 > = {
   [BadgeCountSize.Md]: 'min-w-4 h-4 px-1', // min-width 16px, height 14px, padding-horizontal 4
-  [BadgeCountSize.Lg]: 'min-w-6 h-5 px-1.5', // min-width 24px, height 20px, padding-horizontal 6
+  [BadgeCountSize.Lg]: 'min-w-6 h-[22px] px-1.5', // min-width 24px, height 22px, padding-horizontal 6
 };

--- a/packages/design-system-react-native/src/components/BadgeCount/README.md
+++ b/packages/design-system-react-native/src/components/BadgeCount/README.md
@@ -42,7 +42,7 @@ Available sizes:
 
 - `BadgeCountSize.Sm` (16px)
 - `BadgeCountSize.Md` (20px)
-- `BadgeCountSize.Lg` (24px)
+- `BadgeCountSize.Lg` (22px)
 
 | TYPE             | REQUIRED | DEFAULT             |
 | ---------------- | -------- | ------------------- |

--- a/packages/design-system-react/src/components/BadgeCount/BadgeCount.constants.ts
+++ b/packages/design-system-react/src/components/BadgeCount/BadgeCount.constants.ts
@@ -16,5 +16,5 @@ export const TWCLASSMAP_BADGECOUNT_SIZE_CONTAINER: Record<
   string
 > = {
   [BadgeCountSize.Md]: 'min-w-4 h-4 px-1', // min-width 16px, height 14px, padding-horizontal 4
-  [BadgeCountSize.Lg]: 'min-w-6 h- px-1.5', // min-width 24px, height 20px, padding-horizontal 6
+  [BadgeCountSize.Lg]: 'min-w-6 h-[22px] px-1.5', // min-width 24px, height 22px, padding-horizontal 6
 };

--- a/packages/design-system-react/src/components/BadgeCount/README.mdx
+++ b/packages/design-system-react/src/components/BadgeCount/README.mdx
@@ -48,7 +48,7 @@ BadgeCount supports two sizes.
 Available sizes:
 
 - `BadgeCountSize.Md` (14px height)
-- `BadgeCountSize.Lg` (20px height)
+- `BadgeCountSize.Lg` (22px height)
 
 <table>
   <thead>

--- a/packages/design-system-shared/src/types/BadgeCount/BadgeCount.types.ts
+++ b/packages/design-system-shared/src/types/BadgeCount/BadgeCount.types.ts
@@ -8,7 +8,7 @@ export const BadgeCountSize = {
    */
   Md: 'md',
   /**
-   * Represents a large badge count (20px height).
+   * Represents a large badge count (22px height).
    */
   Lg: 'lg',
 } as const;


### PR DESCRIPTION
## **Description**

Increases `BadgeCount` `Lg` height by 2px (20px → 22px) so large badges match Figma.

1. **What is the reason for the change?** Design parity with Figma BadgeCount `size=Lg` showed the code height needed a 2px bump.
2. **What is the improvement/solution?** Updated React and React Native container maps to `h-[22px]`, restored the broken React `Lg` height class (`h-` → `h-[22px]`), and synced docs/JSDoc.

## **Related issues**

Fixes: <!-- Add issue links -->

## **Manual testing steps**

1. Run `yarn storybook` and open `Components/BadgeCount`
2. Compare `Md` vs `Lg` — Lg should be 22px tall
3. Run `yarn storybook:ios` (or android) and open `Components/BadgeCount` Size story
4. Confirm `99+` Lg badge renders at the taller height without clipping text

## **Screenshots/Recordings**

### **Before**

<!-- Lg BadgeCount at 20px (React class was also broken as `h-`) -->

### **After**

<!-- Lg BadgeCount at 22px on React and React Native -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
