### PR TITLE
fix: Align swipe dismiss constants and finalize handling

### DIFF
--- a/packages/design-system-react-native/src/components/Toast/Toast.constants.ts
+++ b/packages/design-system-react-native/src/components/Toast/Toast.constants.ts
@@ -26,6 +26,12 @@ export const TOAST_SPRING_CONFIG: WithSpringConfig = {
 export const TOAST_DISMISS_DISTANCE_THRESHOLD = 0.35;
 
 /**
+ * Minimum upward drag distance (px) required to dismiss, used as a floor
+ * when the height-based threshold would otherwise be too small.
+ */
+export const TOAST_DISMISS_MIN_DISTANCE = 24;
+
+/**
  * Upward velocity (px/s) required to dismiss via a quick swipe.
  */
 export const TOAST_DISMISS_VELOCITY_THRESHOLD = 800;

--- a/packages/design-system-react-native/src/components/Toast/Toaster.test.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toaster.test.tsx
@@ -33,6 +33,7 @@ const mockPanGestureHandlers: {
   onStart?: () => void;
   onUpdate?: (event: { translationY: number }) => void;
   onEnd?: (event: { translationY: number; velocityY: number }) => void;
+  onFinalize?: () => void;
 } = {};
 
 jest.mock('react-native-gesture-handler', () => ({
@@ -57,6 +58,10 @@ jest.mock('react-native-gesture-handler', () => ({
         handler: (event: { translationY: number; velocityY: number }) => void,
       ) {
         mockPanGestureHandlers.onEnd = handler;
+        return this;
+      },
+      onFinalize(handler: () => void) {
+        mockPanGestureHandlers.onFinalize = handler;
         return this;
       },
     }),
@@ -105,6 +110,7 @@ const swipeToast = async ({
     mockPanGestureHandlers.onStart?.();
     mockPanGestureHandlers.onUpdate?.({ translationY });
     mockPanGestureHandlers.onEnd?.({ translationY, velocityY });
+    mockPanGestureHandlers.onFinalize?.();
     jest.runAllTimers();
   });
 };
@@ -118,6 +124,7 @@ describe('Toaster', () => {
     mockPanGestureHandlers.onStart = undefined;
     mockPanGestureHandlers.onUpdate = undefined;
     mockPanGestureHandlers.onEnd = undefined;
+    mockPanGestureHandlers.onFinalize = undefined;
     jest.useFakeTimers();
   });
 
@@ -560,6 +567,30 @@ describe('Toaster', () => {
       await swipeToast({ translationY: -10, velocityY: -100 });
 
       expect(screen.getByText('Incomplete swipe toast')).toBeOnTheScreen();
+    });
+
+    it('springs back when pan fails after activation (e.g. failOffsetX)', async () => {
+      render(<Toaster ref={toasterRef} testID="toast-root" />);
+
+      await showToastAndWait(toasterRef, {
+        hasNoTimeout: true,
+        title: 'Failed pan toast',
+      });
+
+      await act(async () => {
+        triggerToastLayout(screen.getByTestId('toast-root'));
+        jest.runAllTimers();
+      });
+
+      // Simulate failOffsetX: onEnd is skipped, only onFinalize runs.
+      await act(async () => {
+        mockPanGestureHandlers.onStart?.();
+        mockPanGestureHandlers.onUpdate?.({ translationY: -10 });
+        mockPanGestureHandlers.onFinalize?.();
+        jest.runAllTimers();
+      });
+
+      expect(screen.getByText('Failed pan toast')).toBeOnTheScreen();
     });
 
     it('still auto-dismisses after an incomplete swipe during entrance', async () => {

--- a/packages/design-system-react-native/src/components/Toast/Toaster.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toaster.tsx
@@ -25,6 +25,7 @@ import { scheduleOnRN } from 'react-native-worklets';
 import { Toast } from './Toast';
 import {
   TOAST_DISMISS_DISTANCE_THRESHOLD,
+  TOAST_DISMISS_MIN_DISTANCE,
   TOAST_DISMISS_VELOCITY_THRESHOLD,
   TOAST_SPRING_CONFIG,
   TOAST_SWIPE_ACTIVE_OFFSET_Y,
@@ -89,6 +90,9 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
     const gestureStartY = useSharedValue(0);
     const translateYProgress = useSharedValue(-screenHeight);
     const isDismissing = useSharedValue(false);
+    // True after onStart until onEnd/onFinalize recovers. Used so a failed pan
+    // (e.g. failOffsetX after activation) still springs back and resumes dismiss.
+    const isSwipeActive = useSharedValue(false);
     const toastGeneration = useSharedValue(0);
     const topOffset = toastOptions?.topOffset ?? 0;
     hasNoTimeoutRef.current = Boolean(toastOptions?.hasNoTimeout);
@@ -234,84 +238,106 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
       clearScheduledAutoDismissRef.current();
     };
 
-    const swipeGesture = useMemo(
-      () =>
-        // These gesture callbacks need explicit 'worklet' directives because this
-        // package ships a pre-built dist compiled by ts-bridge (tsc), which emits the
-        // gesture chain as a namespaced call (react_native_gesture_handler_1.Gesture).
-        // The consumer's Reanimated/Worklets Babel plugin does run over dist, but its
-        // gesture auto-detection doesn't recognize that compiled namespaced form.
-        Gesture.Pan()
-          .activeOffsetY(TOAST_SWIPE_ACTIVE_OFFSET_Y)
-          .failOffsetX([-TOAST_SWIPE_FAIL_OFFSET_X, TOAST_SWIPE_FAIL_OFFSET_X])
-          .onStart(() => {
-            'worklet';
+    const swipeGesture = useMemo(() => {
+      // These gesture callbacks need explicit 'worklet' directives because this
+      // package ships a pre-built dist compiled by ts-bridge (tsc), which emits the
+      // gesture chain as a namespaced call (react_native_gesture_handler_1.Gesture).
+      // The consumer's Reanimated/Worklets Babel plugin does run over dist, but its
+      // gesture auto-detection doesn't recognize that compiled namespaced form.
+      const springBackAfterSwipe = () => {
+        'worklet';
 
-            // Don't interrupt an in-progress dismiss animation.
-            if (isDismissing.value) {
-              return;
+        const generationAtSpringStart = toastGeneration.value;
+        translateYProgress.value = withSpring(
+          visibleTranslateY.value,
+          TOAST_SPRING_CONFIG,
+          (finished) => {
+            // A new pan cancels this spring via cancelAnimation; only resume
+            // auto-dismiss when the spring-back completed naturally.
+            if (finished) {
+              scheduleOnRN(
+                resumeAutoDismissFromSwipe,
+                generationAtSpringStart,
+              );
             }
-            scheduleOnRN(clearScheduledAutoDismissFromSwipe);
-            cancelAnimation(translateYProgress);
-            gestureStartY.value = translateYProgress.value;
-          })
-          .onUpdate((event) => {
-            'worklet';
+          },
+        );
+      };
 
-            if (isDismissing.value) {
-              return;
-            }
-            const nextTranslateY = gestureStartY.value + event.translationY;
-            // Toast sits at the top; only allow dragging upward (more negative).
-            translateYProgress.value = Math.min(
-              nextTranslateY,
-              visibleTranslateY.value,
-            );
-          })
-          .onEnd((event) => {
-            'worklet';
+      return Gesture.Pan()
+        .activeOffsetY(TOAST_SWIPE_ACTIVE_OFFSET_Y)
+        .failOffsetX([-TOAST_SWIPE_FAIL_OFFSET_X, TOAST_SWIPE_FAIL_OFFSET_X])
+        .onStart(() => {
+          'worklet';
 
-            if (isDismissing.value) {
-              return;
-            }
-            const { translationY, velocityY } = event;
-            const dismissDistance = Math.max(
-              toastHeight.value * TOAST_DISMISS_DISTANCE_THRESHOLD,
-              24,
-            );
-            const hasReachedDismissOffset = translationY <= -dismissDistance;
-            const hasReachedSwipeThreshold =
-              Math.abs(velocityY) > TOAST_DISMISS_VELOCITY_THRESHOLD;
-            const isQuickDismissing = velocityY < 0;
+          // Don't interrupt an in-progress dismiss animation.
+          if (isDismissing.value) {
+            return;
+          }
+          isSwipeActive.value = true;
+          scheduleOnRN(clearScheduledAutoDismissFromSwipe);
+          cancelAnimation(translateYProgress);
+          gestureStartY.value = translateYProgress.value;
+        })
+        .onUpdate((event) => {
+          'worklet';
 
-            const shouldDismiss =
-              hasReachedDismissOffset ||
-              (hasReachedSwipeThreshold && isQuickDismissing);
+          if (isDismissing.value || !isSwipeActive.value) {
+            return;
+          }
+          const nextTranslateY = gestureStartY.value + event.translationY;
+          // Toast sits at the top; only allow dragging upward (more negative).
+          translateYProgress.value = Math.min(
+            nextTranslateY,
+            visibleTranslateY.value,
+          );
+        })
+        .onEnd((event) => {
+          'worklet';
 
-            if (shouldDismiss) {
-              scheduleOnRN(dismissToastFromSwipe);
-              return;
-            }
+          if (!isSwipeActive.value) {
+            return;
+          }
+          isSwipeActive.value = false;
 
-            const generationAtSpringStart = toastGeneration.value;
-            translateYProgress.value = withSpring(
-              visibleTranslateY.value,
-              TOAST_SPRING_CONFIG,
-              (finished) => {
-                // A new pan cancels this spring via cancelAnimation; only resume
-                // auto-dismiss when the spring-back completed naturally.
-                if (finished) {
-                  scheduleOnRN(
-                    resumeAutoDismissFromSwipe,
-                    generationAtSpringStart,
-                  );
-                }
-              },
-            );
-          }),
+          if (isDismissing.value) {
+            return;
+          }
+          const { translationY, velocityY } = event;
+          const dismissDistance = Math.max(
+            toastHeight.value * TOAST_DISMISS_DISTANCE_THRESHOLD,
+            TOAST_DISMISS_MIN_DISTANCE,
+          );
+          const hasReachedDismissOffset = translationY <= -dismissDistance;
+          const hasReachedSwipeThreshold =
+            Math.abs(velocityY) > TOAST_DISMISS_VELOCITY_THRESHOLD;
+          const isQuickDismissing = velocityY < 0;
+
+          const shouldDismiss =
+            hasReachedDismissOffset ||
+            (hasReachedSwipeThreshold && isQuickDismissing);
+
+          if (shouldDismiss) {
+            scheduleOnRN(dismissToastFromSwipe);
+            return;
+          }
+
+          springBackAfterSwipe();
+        })
+        .onFinalize(() => {
+          'worklet';
+
+          // onEnd is skipped when the pan fails/cancels after activation
+          // (e.g. horizontal travel past failOffsetX). Recover position and
+          // auto-dismiss so the toast is not left stuck mid-offset.
+          if (!isSwipeActive.value || isDismissing.value) {
+            return;
+          }
+          isSwipeActive.value = false;
+          springBackAfterSwipe();
+        });
       // Shared values and swipe JS wrappers are stable for the component lifetime.
-      [],
-    );
+    }, []);
 
     innerRef.current = {
       closeToast,

--- a/packages/design-system-react-native/src/components/Toast/Toaster.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toaster.tsx
@@ -125,6 +125,7 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
       animationStartedRef.current = false;
       visibleAtRef.current = null;
       isDismissing.value = false;
+      isSwipeActive.value = false;
       clearScheduledAutoDismiss();
       setToastOptions(undefined);
     };
@@ -195,6 +196,7 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
         animationStartedRef.current = false;
         visibleAtRef.current = null;
         isDismissing.value = false;
+        isSwipeActive.value = false;
         setToastOptions(undefined);
       }
       if (replacementTimerRef.current !== null) {
@@ -327,10 +329,17 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
           // onEnd is skipped when the pan fails/cancels after activation
           // (e.g. horizontal travel past failOffsetX). Recover position and
           // auto-dismiss so the toast is not left stuck mid-offset.
-          if (!isSwipeActive.value || isDismissing.value) {
+          if (!isSwipeActive.value) {
             return;
           }
+          // Clear before the dismiss check — same order as onEnd — so a pan
+          // cancelled mid-dismiss cannot leave isSwipeActive stuck true for a
+          // later toast (resetState alone is not enough if finalize races it).
           isSwipeActive.value = false;
+
+          if (isDismissing.value) {
+            return;
+          }
           springBackAfterSwipe();
         });
       // Shared values and swipe JS wrappers are stable for the component lifetime.

--- a/packages/design-system-react-native/src/components/Toast/Toaster.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toaster.tsx
@@ -255,10 +255,7 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
             // A new pan cancels this spring via cancelAnimation; only resume
             // auto-dismiss when the spring-back completed naturally.
             if (finished) {
-              scheduleOnRN(
-                resumeAutoDismissFromSwipe,
-                generationAtSpringStart,
-              );
+              scheduleOnRN(resumeAutoDismissFromSwipe, generationAtSpringStart);
             }
           },
         );


### PR DESCRIPTION
## **Description**

Follow-up to [#1415](https://github.com/MetaMask/metamask-design-system/pull/1415) addressing post-merge review feedback on React Native Toast swipe-to-dismiss, aligned with BaseNotification ([metamask-mobile#33600](https://github.com/MetaMask/metamask-mobile/pull/33600)).

1. **What is the reason for the change?**
   - The minimum dismiss distance (`24`) was a magic number; BaseNotification already exposes this as a named constant.
   - A pan that activates on Y but then exceeds `failOffsetX` skips `onEnd`, which could leave the toast stuck mid-offset.
2. **What is the improvement/solution?**
   - Add `TOAST_DISMISS_MIN_DISTANCE` in `Toast.constants.ts` and use it as the dismiss-distance floor.
   - Track `isSwipeActive` and spring back in `onFinalize` when the pan fails/cancels after activation (same pattern as BaseNotification), then resume auto-dismiss.

## **Related issues**

Related:
- https://github.com/MetaMask/metamask-design-system/pull/1415
- https://github.com/MetaMask/metamask-mobile/pull/33600

## **Manual testing steps**

1. Run `yarn storybook:ios` (or `yarn storybook:android`)
2. Open `Components/Toast` and show a timed toast
3. Swipe up past the dismiss threshold — toast should dismiss
4. Start an upward swipe, then drag sideways past the fail offset — toast should spring back to its visible position (not stay mid-offset) and still auto-dismiss on schedule
5. Confirm incomplete upward swipes still spring back and resume auto-dismiss as before

## **Screenshots/Recordings**

### **Before**

<!-- Optional: toast stuck mid-offset after a pan that fails via failOffsetX -->

### **After**

<!-- Optional: failed pan springs back to the visible position -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)