### PR TITLE
chore: Release 58.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "57.0.0",
+  "version": "58.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0]
+
 ### Uncategorized
 
 - fix: Checkbox monochromatic selected colors (React + React Native) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
@@ -659,7 +661,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.0...HEAD
+[0.39.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.1...@metamask/design-system-react-native@0.39.0
 [0.38.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.0...@metamask/design-system-react-native@0.38.1
 [0.38.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.37.0...@metamask/design-system-react-native@0.38.0
 [0.37.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.36.0...@metamask/design-system-react-native@0.37.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: Checkbox monochromatic selected colors (React + React Native) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
+- chore: Add Code Connect for BadgeWrapper and BadgeIcon ([#1424](https://github.com/MetaMask/metamask-design-system/pull/1424))
+- chore: Update Code Connect for BadgeCount, BadgeNetwork, and BadgeStatus ([#1425](https://github.com/MetaMask/metamask-design-system/pull/1425))
+- chore: Add Code Connect for AvatarGroup ([#1423](https://github.com/MetaMask/metamask-design-system/pull/1423))
+- chore: Add Code Connect for Avatar components ([#1422](https://github.com/MetaMask/metamask-design-system/pull/1422))
+- fix: Add swipe to dismiss for React Native Toast ([#1415](https://github.com/MetaMask/metamask-design-system/pull/1415))
+- chore: Add Code Connect for BottomSheet ([#1364](https://github.com/MetaMask/metamask-design-system/pull/1364))
+
 ## [0.38.1]
 
 ### Changed

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,15 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.39.0]
 
-### Uncategorized
+### Added
 
-- fix: Checkbox monochromatic selected colors (React + React Native) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
-- chore: Add Code Connect for BadgeWrapper and BadgeIcon ([#1424](https://github.com/MetaMask/metamask-design-system/pull/1424))
-- chore: Update Code Connect for BadgeCount, BadgeNetwork, and BadgeStatus ([#1425](https://github.com/MetaMask/metamask-design-system/pull/1425))
-- chore: Add Code Connect for AvatarGroup ([#1423](https://github.com/MetaMask/metamask-design-system/pull/1423))
-- chore: Add Code Connect for Avatar components ([#1422](https://github.com/MetaMask/metamask-design-system/pull/1422))
-- fix: Add swipe to dismiss for React Native Toast ([#1415](https://github.com/MetaMask/metamask-design-system/pull/1415))
-- chore: Add Code Connect for BottomSheet ([#1364](https://github.com/MetaMask/metamask-design-system/pull/1364))
+- Added swipe-to-dismiss gesture support to Toast component with configurable distance and velocity thresholds ([#1415](https://github.com/MetaMask/metamask-design-system/pull/1415))
+
+### Fixed
+
+- Fixed Checkbox selected state to use monochromatic icon colors instead of primary blue ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
 
 ## [0.38.1]
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1]
+
 ### Uncategorized
 
 - fix: Checkbox monochromatic selected colors (React + React Native) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
@@ -457,7 +459,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.1...HEAD
+[0.35.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.0...@metamask/design-system-react@0.35.1
 [0.35.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.34.0...@metamask/design-system-react@0.35.0
 [0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.33.0...@metamask/design-system-react@0.34.0
 [0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.32.0...@metamask/design-system-react@0.33.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: Checkbox monochromatic selected colors (React + React Native) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
+- chore: Add Code Connect for BadgeWrapper and BadgeIcon ([#1424](https://github.com/MetaMask/metamask-design-system/pull/1424))
+- chore: Update Code Connect for BadgeCount, BadgeNetwork, and BadgeStatus ([#1425](https://github.com/MetaMask/metamask-design-system/pull/1425))
+- chore: Add Code Connect for AvatarGroup ([#1423](https://github.com/MetaMask/metamask-design-system/pull/1423))
+- chore: Add Code Connect for Avatar components ([#1422](https://github.com/MetaMask/metamask-design-system/pull/1422))
+
 ## [0.35.0]
 
 ### Changed

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,13 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.1]
 
-### Uncategorized
+### Fixed
 
-- fix: Checkbox monochromatic selected colors (React + React Native) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
-- chore: Add Code Connect for BadgeWrapper and BadgeIcon ([#1424](https://github.com/MetaMask/metamask-design-system/pull/1424))
-- chore: Update Code Connect for BadgeCount, BadgeNetwork, and BadgeStatus ([#1425](https://github.com/MetaMask/metamask-design-system/pull/1425))
-- chore: Add Code Connect for AvatarGroup ([#1423](https://github.com/MetaMask/metamask-design-system/pull/1423))
-- chore: Add Code Connect for Avatar components ([#1422](https://github.com/MetaMask/metamask-design-system/pull/1422))
+- Fixed Checkbox selected state to use monochromatic icon colors instead of primary blue ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
 
 ## [0.35.0]
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.32.0]
 
-### Fixed
+### Added
 
-- Fixed Checkbox component icon colors to use monochromatic theme (added `IconColor.IconInverse` for selected state) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
+- Added `IconColor.IconInverse` design token for monochromatic icon rendering in selected/active states ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
 
 ## [0.31.0]
 

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0]
+
 ### Uncategorized
 
 - fix: Checkbox monochromatic selected colors (React + React Native) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
@@ -319,7 +321,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.31.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.32.0...HEAD
+[0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.31.0...@metamask/design-system-shared@0.32.0
 [0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.30.0...@metamask/design-system-shared@0.31.0
 [0.30.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.29.0...@metamask/design-system-shared@0.30.0
 [0.29.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.28.0...@metamask/design-system-shared@0.29.0

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: Checkbox monochromatic selected colors (React + React Native) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
+
 ## [0.31.0]
 
 ### Added

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.32.0]
 
-### Uncategorized
+### Fixed
 
-- fix: Checkbox monochromatic selected colors (React + React Native) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
+- Fixed Checkbox component icon colors to use monochromatic theme (added `IconColor.IconInverse` for selected state) ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))
 
 ## [0.31.0]
 

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Release 58.0.0

This release includes Checkbox color fixes, Toast swipe-to-dismiss support for React Native, and continued design system alignment.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.32.0**
- `@metamask/design-system-react`: **0.35.1**
- `@metamask/design-system-react-native`: **0.39.0**
- `@metamask/design-tokens`: **8.7.0**

### 🌐 React Web Updates (0.35.1)

#### Fixed

- Fixed Checkbox selected state to use monochromatic icon colors instead of primary blue ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))

### 📱 React Native Updates (0.39.0)

#### Added

- Added swipe-to-dismiss gesture support to Toast component with configurable distance and velocity thresholds ([#1415](https://github.com/MetaMask/metamask-design-system/pull/1415))

#### Fixed

- Fixed Checkbox selected state to use monochromatic icon colors instead of primary blue ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: No changes (0.32.0)
  - [x] design-system-react: Patch (0.35.0 → 0.35.1) - Bug fix
  - [x] design-system-react-native: Minor (0.38.1 → 0.39.0) - New feature + bug fix
  - [x] design-tokens: No changes (8.7.0)
- [x] No breaking changes in this release
- [x] All changes accounted for in changelogs

## Pre-merge author checklist

- [x] All tests pass
- [x] Changelog validation passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and version bumps only; consumer-facing behavior was introduced in earlier PRs referenced by the changelogs.
> 
> **Overview**
> **Release 58.0.0** — version and changelog updates only; it cuts published versions of the design-system packages that bundle work already merged on `main`.
> 
> The monorepo root goes to **58.0.0**. **`@metamask/design-system-shared`** is **0.32.0** (documents new `IconColor.IconInverse` for monochromatic selected/active icons). **`@metamask/design-system-react`** is **0.35.1** (patch: Checkbox selected checkmark uses `IconInverse` instead of primary blue). **`@metamask/design-system-react-native`** is **0.39.0** (minor: Toast swipe-to-dismiss with configurable thresholds, plus the same Checkbox icon fix).
> 
> Each package’s `CHANGELOG.md` gains the **0.32.0 / 0.35.1 / 0.39.0** sections and compare links; there are no additional source changes in this diff beyond `package.json` versions and those changelog entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff338a9a94cb409b3394f0754bd405be5ac52cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->