### PR TITLE
Release 58.0.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -149,6 +149,8 @@ See migration guides for complete instructions:
 
 - [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
 - [ ] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
+- [ ] PR title follows the pattern `Release <version>` (no `chore:` or other prefix)
+- [ ] Squash merge commit message will be exactly `Release <version>` (verify before merging)
 - [ ] All tests pass (`yarn build && yarn test && yarn lint`)
 - [ ] Changelog validation passes (`yarn changelog:validate`)
 


### PR DESCRIPTION
## Release 58.0.0

Re-triggers the release publish workflow for **58.0.0**. Version bumps and changelogs from [#1428](https://github.com/MetaMask/metamask-design-system/pull/1428) are already on `main`; this PR adds an empty commit only.

PR #1428 merged with squash commit title `chore: Release 58.0.0 (#1428)`, which did not match the `is-release` commit prefix check in `.github/workflows/main.yml`. The **Publish release** job was skipped, so no `v58.0.0` tag, GitHub release, or NPM publish ran.

This release includes Checkbox color fixes, Toast swipe-to-dismiss support for React Native, and continued design system alignment.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.32.0**
- `@metamask/design-system-react`: **0.35.1**
- `@metamask/design-system-react-native`: **0.39.0**
- `@metamask/design-tokens`: **8.7.0**

### 🌐 React Web Updates (0.35.1)

#### Fixed

- Fixed Checkbox selected state to use monochromatic icon colors instead of primary blue ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))

### 📱 React Native Updates (0.39.0)

#### Added

- Added swipe-to-dismiss gesture support to Toast component with configurable distance and velocity thresholds ([#1415](https://github.com/MetaMask/metamask-design-system/pull/1415))

#### Fixed

- Fixed Checkbox selected state to use monochromatic icon colors instead of primary blue ([#1426](https://github.com/MetaMask/metamask-design-system/pull/1426))

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions (in #1428)
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: No changes (0.32.0)
  - [x] design-system-react: Patch (0.35.0 → 0.35.1) - Bug fix
  - [x] design-system-react-native: Minor (0.38.1 → 0.39.0) - New feature + bug fix
  - [x] design-tokens: No changes (8.7.0)
- [x] No breaking changes in this release
- [x] All changes accounted for in changelogs

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

## Merge instructions

**Squash & merge** this PR and confirm the final commit message is exactly:

```
Release 58.0.0
```

Do **not** use `chore: Release 58.0.0` or any other prefix. The PR title is already set to `Release 58.0.0`; verify the squash commit message box before confirming merge.

## Expected CI behavior after merge

1. `is-release` → `IS_RELEASE=true`
2. `publish-release` runs → creates `v58.0.0` tag and GitHub release
3. `publish-npm-dry-run` runs
4. `publish-npm` runs (requires `npm-publishers` approval)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the release PR template; no runtime or publish workflow logic is modified.
> 
> **Overview**
> **Release PR template** now reminds authors to use the exact merge metadata CI expects for publish.
> 
> The pre-merge author checklist gains two items: the PR title must follow **`Release <version>`** (no `chore:` or other prefix), and the squash-merge commit message must be exactly **`Release <version>`** before merging. This matches the `is-release` job’s `commit-starts-with` rules in `.github/workflows/main.yml`, which skipped publish when a prior release landed as `chore: Release 58.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138064cdf3777fece08a91be41cf5b31167f71d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->