### PR TITLE
ci: add check-release action to validate release PR titles

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -1,0 +1,265 @@
+name: Check release
+description: Check for conflicts in packages being released in this PR.
+
+inputs:
+  commit-starts-with:
+    description: "Validate that the release commit starts with a string in this comma-separated list. Use '[version]' to refer to the current release version."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout and setup environment
+      uses: MetaMask/action-checkout-and-setup@v3
+      with:
+        is-high-risk-environment: false
+        skip-install: true
+        persist-credentials: false
+
+    - name: Get merge base
+      id: merge-base
+      shell: bash
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+      run: |
+        set -euo pipefail
+
+        # Strip invalid prefix from `github.event.merge_group.base_ref`
+        # It comes prefixed with `refs/heads/`, but the branch is not checked out in this context
+        # We need to express it as a remote branch
+        PREFIXED_REF_REGEX='refs/heads/(.+)'
+        if [[ "$BASE_REF" =~ $PREFIXED_REF_REGEX ]]; then
+          BASE_REF="${BASH_REMATCH[1]}"
+        fi
+
+        MERGE_BASE=$(git merge-base HEAD "refs/remotes/origin/$BASE_REF")
+        echo "MERGE_BASE=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+
+    - name: Check that root package.json is bumped for release PRs
+      shell: bash
+      id: check-root-package
+      env:
+        MERGE_BASE: ${{ steps.merge-base.outputs.MERGE_BASE }}
+      run: |
+        set -euo pipefail
+
+        mapfile -t PACKAGES < <(yarn workspaces list --json --no-private | jq --raw-output '.location + "/package.json"')
+        ANY_PACKAGE_BUMPED=false
+
+        for package in "${PACKAGES[@]}"; do
+          if ! PACKAGE_JSON_AT_BASE=$(git show "$MERGE_BASE:$package" 2>/dev/null); then
+            # Package didn't exist at the merge base; it's newly added, not a
+            # version bump.
+            continue
+          fi
+          CURRENT_VERSION=$(echo "$PACKAGE_JSON_AT_BASE" | jq -r .version)
+          NEW_VERSION=$(jq -r .version "$package")
+
+          if [[ "$NEW_VERSION" != "0.0.0" && "$NEW_VERSION" != "$CURRENT_VERSION" ]]; then
+            ANY_PACKAGE_BUMPED=true
+            package_name=$(jq -r ".name" "$package")
+            echo "📦 Package \`$package_name\` has a version bump (\`$CURRENT_VERSION\` -> \`$NEW_VERSION\`)"
+          fi
+        done
+
+        if [ "$ANY_PACKAGE_BUMPED" = "true" ]; then
+          CURRENT_ROOT_VERSION=$(git show "$MERGE_BASE:package.json" | jq -r .version)
+          NEW_ROOT_VERSION=$(jq -r .version package.json)
+
+          if [ "$NEW_ROOT_VERSION" = "$CURRENT_ROOT_VERSION" ]; then
+            echo "::error::This pull request is a release (one or more packages have a version bump), but the root package.json version was not bumped. Please bump the root package.json version."
+            exit 1
+          else
+            echo "✅ Root package.json is bumped (\`$CURRENT_ROOT_VERSION\` -> \`$NEW_ROOT_VERSION\`)"
+            echo "root-package-bumped=true" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          echo "✅ No package version bumps detected; skipping root package.json check."
+        fi
+
+    - name: Check if the commit or pull request is a release
+      id: is-release
+      uses: MetaMask/action-is-release@v2
+      with:
+        commit-starts-with: ${{ inputs.commit-starts-with }}
+        commit-message: ${{ github.event.pull_request.title }}
+        before: ${{ steps.merge-base.outputs.MERGE_BASE }}
+        skip-checkout: true
+
+    - name: Fail if root package is bumped but not detected as release
+      if: github.event_name == 'pull_request' && steps.is-release.outputs.IS_RELEASE != 'true' && steps.check-root-package.outputs.root-package-bumped == 'true'
+      shell: bash
+      env:
+        COMMIT_STARTS_WITH: ${{ inputs.commit-starts-with }}
+      run: |
+        echo "::error::This pull request is a release, but the release check did not detect it as such. Please ensure that the commit message starts with one of the following prefixes: $COMMIT_STARTS_WITH."
+        exit 1
+
+    - name: Get pull request number
+      id: pr-number
+      if: steps.is-release.outputs.IS_RELEASE == 'true'
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+      run: |
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          echo "PR_NUMBER=$PULL_REQUEST_NUMBER" >> "$GITHUB_OUTPUT"
+        elif [ "$EVENT_NAME" = "merge_group" ]; then
+          PR_NUMBER_REGEX='/pr-([0-9]+)-'
+          if [[ "$MERGE_GROUP_HEAD_REF" =~ $PR_NUMBER_REGEX ]]; then
+            echo "PR_NUMBER=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not extract PR number from merge group head ref: $MERGE_GROUP_HEAD_REF."
+            exit 1
+          fi
+        fi
+
+    - name: Get target reference
+      id: get-target
+      if: steps.is-release.outputs.IS_RELEASE == 'true'
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          echo "TARGET=$(git merge-base HEAD refs/remotes/origin/main)" >> "$GITHUB_OUTPUT"
+        elif [ "$EVENT_NAME" = "merge_group" ]; then
+          echo "TARGET=$(git rev-parse HEAD^)" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::This action only supports \`pull_request\` and \`merge_group\` events."
+          exit 1
+        fi
+
+    - name: Check commits for changes in released packages
+      id: check-release
+      if: steps.is-release.outputs.IS_RELEASE == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PULL_REQUEST: ${{ steps.pr-number.outputs.PR_NUMBER }}
+        TARGET: ${{ steps.get-target.outputs.TARGET }}
+      run: |
+        set -euo pipefail
+
+        mapfile -t PACKAGES < <(find packages -maxdepth 2 -name "package.json" -not -path "*/node_modules/*")
+        RELEASED_PACKAGES=()
+
+        # Get all packages being released in this PR
+        MERGE_BASE=$(git merge-base HEAD refs/remotes/origin/main)
+        for package in "${PACKAGES[@]}"; do
+          MAIN_VERSION=$(git show "$MERGE_BASE:$package" | jq -r .version)
+          HEAD_VERSION=$(jq -r .version "$package")
+
+          if [ "$HEAD_VERSION" != "$MAIN_VERSION" ]; then
+            package_name=$(jq -r ".name" "$package")
+            echo "📦 Package \`$package_name\` is being released (version \`$MAIN_VERSION\` -> \`$HEAD_VERSION\`)"
+            RELEASED_PACKAGES+=("$package")
+          fi
+        done
+
+        # Fetch the pull request branch to compare changes.
+        PULL_REQUEST_BRANCH=$(gh pr view "$PULL_REQUEST" --json headRefName --template "{{ .headRefName }}")
+        echo "🔍 Checking for release conflicts with files changed ahead of PR branch \`$PULL_REQUEST_BRANCH\`..."
+        git fetch origin "$PULL_REQUEST_BRANCH"
+
+        # Get all files changed ahead of this PR.
+        BEFORE=$(git merge-base "refs/remotes/origin/main" "refs/remotes/origin/$PULL_REQUEST_BRANCH")
+        git diff --name-only "$BEFORE..$TARGET" > changed-files.txt
+
+        CONFLICTS=()
+        for package in "${RELEASED_PACKAGES[@]}"; do
+          package_directory=$(dirname "$package")
+          if grep -q "^$package_directory/" changed-files.txt; then
+            CONFLICTS+=("$package_directory")
+          fi
+        done
+
+        if [ ${#CONFLICTS[@]} -ne 0 ]; then
+          mapfile -t CONFLICTS < <(printf "%s\n" "${CONFLICTS[@]}" | sort -u)
+        fi
+
+        if [ ${#CONFLICTS[@]} -ne 0 ]; then
+          PACKAGE_NAMES=()
+
+          for conflict in "${CONFLICTS[@]}"; do
+            package_name=$(jq -r ".name" "$conflict/package.json")
+            PACKAGE_NAMES+=("$package_name")
+            echo "::error::Release conflict detected in \`$package_name\`. This package is being released in this PR, but files in the package were also modified ahead of this PR. Please ensure that all changes are included in the release."
+          done
+
+          PACKAGE_NAMES_JSON=$(printf '%s\n' "${PACKAGE_NAMES[@]}" | jq -R . | jq -s -c .)
+          echo "package-names=$PACKAGE_NAMES_JSON" >> "$GITHUB_OUTPUT"
+          echo "has-conflicts=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "✅ No release conflicts detected."
+        fi
+
+    - name: Hide previous comments
+      if: steps.is-release.outputs.IS_RELEASE == 'true'
+      uses: actions/github-script@v8
+      env:
+        PR_NUMBER: ${{ steps.pr-number.outputs.PR_NUMBER }}
+      with:
+        script: |
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: process.env.PR_NUMBER,
+          });
+
+          for (const comment of comments) {
+            if (comment.body.includes('<!-- Pull request release conflict comment -->')) {
+              await github.graphql(`
+                mutation($commentId: ID!, $classifier: ReportedContentClassifiers!) {
+                  minimizeComment(input: {subjectId: $commentId, classifier: $classifier}) {
+                    minimizedComment {
+                      isMinimized
+                    }
+                  }
+                }
+              `, {
+                commentId: comment.node_id,
+                classifier: 'OUTDATED',
+              });
+            }
+          }
+
+    - name: Reply on pull request
+      if: steps.check-release.outputs.has-conflicts == 'true'
+      uses: actions/github-script@v8
+      env:
+        PACKAGE_NAMES: ${{ steps.check-release.outputs.package-names }}
+        PR_NUMBER: ${{ steps.pr-number.outputs.PR_NUMBER }}
+      with:
+        script: |
+          const packageNames = JSON.parse(process.env.PACKAGE_NAMES);
+          const packageList = packageNames.map(name => `- \`${name}\``).join('\n');
+
+          const mergeQueueNote = context.eventName === 'merge_group' ? ' while this pull request was in the merge queue' : '';
+
+          const body = `
+            ## Release conflict detected
+
+            The following packages are being released in this pull request, but files in these packages were also modified ahead of this pull request${mergeQueueNote}:
+
+            ${packageList}
+
+            Please ensure that all changes are included in the release by updating this pull request, and adjusting the changelogs and version bumps as necessary.
+
+            <!-- Pull request release conflict comment -->
+          `;
+
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: process.env.PR_NUMBER,
+            body: body.split('\n').map(line => line.trim()).join('\n'),
+          });
+
+    - name: Fail if conflicts found
+      if: steps.check-release.outputs.has-conflicts == 'true'
+      shell: bash
+      run: |
+        exit 1

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -92,7 +92,7 @@ runs:
       env:
         COMMIT_STARTS_WITH: ${{ inputs.commit-starts-with }}
       run: |
-        echo "::error::This pull request is a release, but the release check did not detect it as such. Please ensure that the commit message starts with one of the following prefixes: $COMMIT_STARTS_WITH."
+        echo "::error::This pull request is a release, but the release check did not detect it as such. Set the PR title (and squash merge commit message) to start with one of the following prefixes: $COMMIT_STARTS_WITH. Do not use a conventional-commit prefix such as chore:."
         exit 1
 
     - name: Get pull request number
@@ -149,6 +149,9 @@ runs:
         # Get all packages being released in this PR
         MERGE_BASE=$(git merge-base HEAD refs/remotes/origin/main)
         for package in "${PACKAGES[@]}"; do
+          if ! git show "$MERGE_BASE:$package" &>/dev/null; then
+            continue
+          fi
           MAIN_VERSION=$(git show "$MERGE_BASE:$package" | jq -r .version)
           HEAD_VERSION=$(jq -r .version "$package")
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,25 @@ jobs:
     secrets:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
+  check-release:
+    name: Check release
+    needs: check-workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check release
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/check-release
+        with:
+          commit-starts-with: 'Release [version],Release v[version],Release/[version],Release/v[version],Release `[version]`'
+
   is-release:
     name: Determine whether this is a release merge commit
     needs: lint-build-test
@@ -78,6 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - analyse-code
+      - check-release
       - lint-build-test
       - test-storybook
       - chromatic


### PR DESCRIPTION
## **Description**

Ports MetaMask/core's [`check-release`](https://github.com/MetaMask/core/blob/main/.github/actions/check-release/action.yml) composite action to prevent release PRs from merging with invalid titles (e.g. `chore: Release 58.0.0`), which caused the 58.0.0 publish workflow to be skipped.

On release PRs (detected when package versions are bumped), CI now validates that the **PR title** matches the same `is-release` commit prefix patterns used on merge. It also checks for release conflicts when packages being released were modified on `main` ahead of the PR branch.

Suggested by @metamask-npm-publishers after the 58.0.0 release incident.

## **Related issues**

Follow-up to release 58.0.0 publish workflow skip.

## **Manual testing steps**

1. Verify CI passes on this PR (non-release PR — check-release step should be skipped)
2. After merge, open a release PR with an invalid title (e.g. `chore: Release X.Y.Z`) and confirm **Check release** fails
3. Confirm a release PR titled `Release X.Y.Z` passes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability

## **Pre-merge reviewer checklist**

- [ ] Confirm `check-release` job wiring matches MetaMask/core pattern
- [ ] Confirm push-to-main workflows still pass when check-release step is skipped

Made with [Cursor](https://cursor.com)