### PR TITLE
chore: audit-first Cursor automation for React parity (DSYS-302)

### DIFF
--- a/.cursor/automations/react-parity-from-mobile.md
+++ b/.cursor/automations/react-parity-from-mobile.md
@@ -26,10 +26,15 @@ Jira pickup for epic **DSYS-302** (_Migrate Legacy Extension Components to MMDS 
 
 ### Priority queue (prefer these first)
 
-| Order | Issue    | Component         | Notes                           |
-| ----- | -------- | ----------------- | ------------------------------- |
-| 1     | DSYS-713 | **ListItem**      | RN + shared types already exist |
-| 2     | DSYS-751 | **SectionHeader** | RN + shared types already exist |
+ListItem depends on Content → BoxRow/BoxColumn. Ship deps before ListItem.
+
+| Order | Issue     | Component         | Notes                                        |
+| ----- | --------- | ----------------- | -------------------------------------------- |
+| 1     | DSYS-1041 | **BoxRow**        | Layout primitive; used by Content + ListItem |
+| 2     | DSYS-1042 | **BoxColumn**     | Layout primitive; used by Content            |
+| 3     | DSYS-1043 | **Content**       | Inner row layout; ListItem wraps this        |
+| 4     | DSYS-713  | **ListItem**      | After BoxRow + Content                       |
+| 5     | DSYS-751  | **SectionHeader** | RN + shared types already exist              |
 
 Then fall through to other unclaimed `parent = DSYS-302` To Do items by Rank.
 
@@ -50,13 +55,14 @@ parent = DSYS-302 AND statusCategory != "Done" AND assignee = currentUser() ORDE
 ### Interactive (IDE / manual run)
 
 1. Prefer **In Progress** assigned to you.
-2. Else prefer priority queue: **DSYS-713** then **DSYS-751** if still To Do.
+2. Else prefer priority queue in order: **DSYS-1041 → DSYS-1042 → DSYS-1043 → DSYS-713 → DSYS-751** if still To Do.
 3. Else first unassigned To Do from Rank order.
+4. Do **not** start ListItem (DSYS-713) while any of BoxRow/BoxColumn/Content blockers are still open (check Jira “is blocked by” links).
 
 ### Scheduled / cloud (“always take backlog”)
 
-1. If **DSYS-713** matches unclaimed To Do → take it.
-2. Else if **DSYS-751** matches unclaimed To Do → take it.
+1. Walk the priority queue in order; take the **first** unclaimed To Do still open.
+2. Skip ListItem if it is blocked by open BoxRow/BoxColumn/Content issues.
 3. Else first result of the unclaimed To Do JQL.
 4. If empty → stop (no PR).
 
@@ -161,9 +167,9 @@ Repository: MetaMask/metamask-design-system @ main (checkout must include .curso
 
 You are bringing React (design-system-react) to parity with existing React Native MMDS components for epic DSYS-302. Follow docs/ai-agents.md: use @ rules — do not invent patterns from memory.
 
-1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, priority queue (DSYS-713 ListItem, then DSYS-751 SectionHeader), audit, and Storybook demo requirements.
+1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, priority queue (BoxRow → BoxColumn → Content → ListItem → SectionHeader), audit, and Storybook demo requirements.
 
-2) Jira (atlassian MCP): claim one unclaimed To Do under parent = DSYS-302 (prefer DSYS-713, then DSYS-751, else Rank ASC). Assign + transition to In Progress. If none, exit with one line and optionally Slack that the backlog was empty.
+2) Jira (atlassian MCP): claim one unclaimed To Do under parent = DSYS-302 following the priority queue (DSYS-1041, DSYS-1042, DSYS-1043, DSYS-713, DSYS-751). Skip ListItem while BoxRow/BoxColumn/Content blockers are open. Assign + transition to In Progress. If none, exit with one line and optionally Slack that the backlog was empty.
 
 3) Audit BEFORE coding (component-migration Phase 1):
    - RN + shared types in this repo

--- a/.cursor/automations/react-parity-from-mobile.md
+++ b/.cursor/automations/react-parity-from-mobile.md
@@ -28,13 +28,31 @@ Jira pickup for epic **DSYS-302** (_Migrate Legacy Extension Components to MMDS 
 
 **Parity strategy (option B):** shared **consumer API** with RN; **flatter React implementation**. Do **not** port RN `BoxRow` / `BoxColumn` / `TextOrChildren` as React building blocks for Content/ListItem — they are RN composition helpers / depth footguns (see `packages/design-system-react-native/src/components/ListItem/PERFORMANCE_AUDIT.md`). No Mobile consumer usage of `BoxRow`/`BoxColumn` today.
 
-| Order | Issue     | Component         | Notes                                                                                 |
-| ----- | --------- | ----------------- | ------------------------------------------------------------------------------------- |
-| 1     | DSYS-1043 | **Content**       | Shared props; implement with direct `Box`/`Text` (no BoxRow/BoxColumn/TextOrChildren) |
-| 2     | DSYS-713  | **ListItem**      | After Content; same flatter approach                                                  |
-| 3     | DSYS-751  | **SectionHeader** | RN + shared types already exist                                                       |
+Walk this list top-down; take the first open unclaimed To Do.
 
-**Out of queue (canceled / deferred):** DSYS-1041 BoxRow, DSYS-1042 BoxColumn — RN-specific helpers; may optimize or remove later, not React parity blockers.
+| Order | Issue     | Component            |
+| ----- | --------- | -------------------- |
+| 1     | DSYS-1043 | **Content**          |
+| 2     | DSYS-713  | **ListItem**         |
+| 3     | DSYS-751  | **SectionHeader**    |
+| 4     | DSYS-750  | **SectionDivider**   |
+| 5     | DSYS-757  | **HeaderRoot**       |
+| 6     | DSYS-758  | **HeaderStandard**   |
+| 7     | DSYS-756  | **TitleSubpage**     |
+| 8     | DSYS-755  | **TitleStandard**    |
+| 9     | DSYS-752  | **TitleAlert**       |
+| 10    | DSYS-749  | **SelectButton**     |
+| 11    | DSYS-716  | **HeaderSearch**     |
+| 12    | DSYS-712  | **KeyValueRow**      |
+| 13    | DSYS-711  | **KeyValueColumn**   |
+| 14    | DSYS-715  | **Spinner**          |
+| 15    | DSYS-714  | **MainActionButton** |
+
+**Notes**
+
+- Content before ListItem (ListItem composes Content). Prefer HeaderRoot before HeaderStandard when both are open.
+- For Content/ListItem: implement with direct `Box`/`Text` (no BoxRow/BoxColumn/TextOrChildren).
+- **Out of queue (canceled):** DSYS-1041 BoxRow, DSYS-1042 BoxColumn.
 
 Then fall through to other unclaimed `parent = DSYS-302` To Do items by Rank.
 
@@ -55,17 +73,16 @@ parent = DSYS-302 AND statusCategory != "Done" AND assignee = currentUser() ORDE
 ### Interactive (IDE / manual run)
 
 1. Prefer **In Progress** assigned to you.
-2. Else prefer priority queue in order: **DSYS-1043 → DSYS-713 → DSYS-751** if still To Do.
+2. Else prefer the **priority queue** above in order (first still To Do).
 3. Else first unassigned To Do from Rank order.
-4. Prefer Content before ListItem when both are open (ListItem composes Content).
+4. Prefer Content before ListItem, and HeaderRoot before HeaderStandard, when both are open.
 
 ### Scheduled / cloud (“always take backlog”)
 
 1. Walk the priority queue in order; take the **first** unclaimed To Do still open.
-2. Prefer Content (DSYS-1043) before ListItem (DSYS-713) when both are unclaimed.
-3. Else first result of the unclaimed To Do JQL.
-4. If empty → stop (no PR).
-5. **Skip** canceled/deferred helper tickets (BoxRow/BoxColumn/TextOrChildren ports).
+2. Else first result of the unclaimed To Do JQL.
+3. If empty → stop (no PR).
+4. **Skip** canceled/deferred helper tickets (BoxRow/BoxColumn/TextOrChildren ports).
 
 **Jira:** Enable Atlassian/Jira MCP on the automation so the agent can search, assign, and transition.
 
@@ -171,9 +188,9 @@ Repository: MetaMask/metamask-design-system @ main (checkout must include .curso
 
 You are bringing React (design-system-react) to parity with existing React Native MMDS components for epic DSYS-302. Follow docs/ai-agents.md: use @ rules — do not invent patterns from memory.
 
-1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, priority queue (Content → ListItem → SectionHeader), flatter-impl strategy, audit, and Storybook demo requirements.
+1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, priority queue (15 components starting Content → ListItem → … → MainActionButton), flatter-impl strategy, audit, and Storybook demo requirements.
 
-2) Jira (atlassian MCP): claim one unclaimed To Do under parent = DSYS-302 following the priority queue (DSYS-1043, DSYS-713, DSYS-751). Prefer Content before ListItem. Skip canceled BoxRow/BoxColumn tickets. Assign + transition to In Progress. If none, exit with one line and optionally Slack that the backlog was empty.
+2) Jira (atlassian MCP): claim one unclaimed To Do under parent = DSYS-302 by walking the priority queue in that file (first open). Skip canceled BoxRow/BoxColumn tickets. Assign + transition to In Progress. If none, exit with one line and optionally Slack that the backlog was empty.
 
 3) Audit BEFORE coding (component-migration Phase 1):
    - RN + shared types in this repo (API/props — not internal RN helper composition)

--- a/.cursor/automations/react-parity-from-mobile.md
+++ b/.cursor/automations/react-parity-from-mobile.md
@@ -1,0 +1,194 @@
+# react-parity-from-mobile
+
+Jira pickup for epic **DSYS-302** (_Migrate Legacy Extension Components to MMDS Monorepo_) — create **React (`design-system-react`)** parity for components that already exist on **React Native**, with an **extension codebase audit** so the web API works for Extension consumers.
+
+## Purpose (version control for Cursor Automations)
+
+[Cursor Automations](https://cursor.com/docs/cloud-agent/automations) prompts in the Cursor product are **not** stored in this git repo. This file **is** the **canonical, reviewable spec**: change it here (PRs, `main`, tags) and treat the UI as a **deployment target**.
+
+- **Stable link** — Prefer the automation checkout includes this file; tell the agent to read `.cursor/automations/react-parity-from-mobile.md`.
+- **Copy-paste** — Paste the cloud prompt block below into a **Private** or **Team Visible** automation. After merging changes here, update the pasted prompt.
+
+**Invoke (IDE):** `@.cursor/automations/react-parity-from-mobile.md`.
+
+**Strategy:** Matches [docs/ai-agents.md](../../docs/ai-agents.md): _reference over duplication_, _checklists over narratives_, _context efficiency_. This file defines **orchestration** (Jira, audit sources, PR identity). **Implementation guardrails** live in `@.cursor/rules/` — agents must read those files, not improvise from this doc alone.
+
+## Scope
+
+| Setting            | Value                                                                                                                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Epic               | **DSYS-302** — _Migrate Legacy Extension Components to MMDS Monorepo_                                                                                                                              |
+| Board (reference)  | [DSYS board — epic filter](https://consensyssoftware.atlassian.net/jira/software/c/projects/DSYS/boards/1888?issueParent=335295)                                                                   |
+| Primary workflow   | `@.cursor/rules/component-migration.md` (extension + mobile → monorepo)                                                                                                                            |
+| Not this epic      | Do **not** use `@.cursor/rules/component-enum-union-migration.md` (that is DSYS-468 internal ADR refactors)                                                                                        |
+| Checkout repo      | `MetaMask/metamask-design-system` @ `main` (or a branch that includes this file)                                                                                                                   |
+| Audit source (web) | [MetaMask Extension component-library](https://github.com/MetaMask/metamask-extension/tree/main/ui/components/component-library) + related `ui/components/ui/` counterparts when named differently |
+
+### Priority queue (prefer these first)
+
+| Order | Issue    | Component         | Notes                           |
+| ----- | -------- | ----------------- | ------------------------------- |
+| 1     | DSYS-713 | **ListItem**      | RN + shared types already exist |
+| 2     | DSYS-751 | **SectionHeader** | RN + shared types already exist |
+
+Then fall through to other unclaimed `parent = DSYS-302` To Do items by Rank.
+
+## 1. Find candidates
+
+```jql
+parent = DSYS-302 AND status = "To Do" AND assignee is EMPTY ORDER BY Rank ASC
+```
+
+Assigned / in-progress (interactive runs):
+
+```jql
+parent = DSYS-302 AND statusCategory != "Done" AND assignee = currentUser() ORDER BY Rank ASC
+```
+
+## 2. Choose one issue
+
+### Interactive (IDE / manual run)
+
+1. Prefer **In Progress** assigned to you.
+2. Else prefer priority queue: **DSYS-713** then **DSYS-751** if still To Do.
+3. Else first unassigned To Do from Rank order.
+
+### Scheduled / cloud (“always take backlog”)
+
+1. If **DSYS-713** matches unclaimed To Do → take it.
+2. Else if **DSYS-751** matches unclaimed To Do → take it.
+3. Else first result of the unclaimed To Do JQL.
+4. If empty → stop (no PR).
+
+**Jira:** Enable Atlassian/Jira MCP on the automation so the agent can search, assign, and transition.
+
+## 3. Pick up in Jira
+
+- If unassigned → set **assignee** to you.
+- If **To Do** → transition to **In Progress** (or project equivalent).
+
+## 4. Audit before implementing (required)
+
+Do **not** scaffold until the comparison table exists. Follow Phase 1 of `@.cursor/rules/component-migration.md`.
+
+### Sources to inspect
+
+| Source                 | Where                                                                                                                                                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **RN (parity target)** | `packages/design-system-react-native/src/components/<Name>/` in this repo                                                                                                                                     |
+| **Shared types**       | `packages/design-system-shared/src/types/<Name>/` if present                                                                                                                                                  |
+| **Extension / web**    | Fetch from `MetaMask/metamask-extension` via `gh` (raw/API) — start at `ui/components/component-library/`; also search `ui/components/ui/` and multichain/activity variants when names differ (esp. ListItem) |
+
+### Comparison table (include in PR)
+
+| Concern                  | Extension / web API | Mobile / RN (MMDS) API | Decision             |
+| ------------------------ | ------------------- | ---------------------- | -------------------- |
+| Prop names               | …                   | …                      | …                    |
+| Types / variants / sizes | …                   | …                      | …                    |
+| Event handlers           | `onClick`           | `onPress`              | Keep both (platform) |
+| Styling                  | `className`         | `twClassName`          | Platform layer only  |
+
+Answer explicitly:
+
+- Which props are shared vs platform-specific?
+- Naming conflicts (`disabled` vs `isDisabled`, etc.)?
+- Conservative vs Unified migration strategy (per component-migration.md)?
+- Does React parity belong in DSR under this name, or is the web analogue differently named? (document mapping)
+
+## 5. Implement React parity
+
+### Guardrails
+
+- ✅ Primary: `@.cursor/rules/component-migration.md`
+- ✅ Scaffold: `@.cursor/rules/component-creation.md` (`yarn create-component:react` — React only when RN already exists)
+- ✅ Architecture / tokens / docs / tests: architecture, styling, documentation, testing rules
+- ❌ Do **not** copy Extension or RN source verbatim — Box/Text + design tokens
+- ❌ Do **not** put `className` / `onClick` in shared types
+- Prefer existing shared types when present; extend carefully if the audit requires shared changes
+
+### Layer 2 rules — read in order
+
+| Order | Rule                                        | Role                              |
+| ----- | ------------------------------------------- | --------------------------------- |
+| 1     | `@.cursor/rules/component-migration.md`     | Audit, strategy, Phase 1–5        |
+| 2     | `@.cursor/rules/component-creation.md`      | Scaffold + transform templates    |
+| 3     | `@.cursor/rules/component-architecture.md`  | ADR-0003/0004, shared vs platform |
+| 4     | `@.cursor/rules/styling.md`                 | Box/Text, tokens                  |
+| 5     | `@.cursor/rules/testing.md`                 | Jest / a11y                       |
+| 6     | `@.cursor/rules/component-documentation.md` | Stories / README                  |
+| 7     | `@.cursor/rules/figma-integration.md`       | Only if Code Connect is in scope  |
+
+**Golden path (layered API):** BadgeStatus under shared + react + react-native packages.
+
+### Verification (from repo root, per `CLAUDE.md`)
+
+```bash
+yarn build && yarn test && yarn lint
+```
+
+Prefer package-scoped test/lint for the touched React package when full monorepo runs are too heavy, but do not skip build/typecheck of affected workspaces.
+
+## 6. Demo Storybook (computer use / demos)
+
+Cloud Automations include **computer use** by default. After implementation + tests pass, **demo the new React stories** and attach artifacts to the PR (screenshots and/or a short recording).
+
+### Steps
+
+1. Start React Storybook from repo root: `yarn storybook` (port **6006**).
+2. Open the browser to the new component’s stories (Default + major prop stories).
+3. Capture **screenshots** of key stories and/or a **short screen recording** walking Default → main variants.
+4. Attach those demos to the **PR** (prefer embedding in the PR description **Screenshots/Recordings** section; also fine as PR comment artifacts).
+5. If Storybook fails to start or stories crash, fix before opening/updating the PR — do not ship without visual evidence unless blocked (then say why in Slack + PR).
+
+**Dashboard:** Enable **Allow posting artifacts to GitHub** under [Cloud Agents → My pull requests](https://cursor.com/dashboard/cloud-agents#my-pull-requests) so demos can land on the PR.
+
+**Environment:** Ensure the cloud agent environment can install deps and run Storybook (same as local `yarn` + `yarn storybook`).
+
+## 7. Open the PR + Slack
+
+- `@.cursor/rules/pr.mdc` + `.github/pull_request_template.md`
+- Include Jira key (e.g. `DSYS-713`)
+- Include the **audit comparison table**, known gaps, and **demo screenshots/recording**
+- **Private / Team Visible** automation → PR as your GitHub user; **Team Owned** → `cursor` service account
+- Notify `#design-system-team` with issue key, component name, and PR link (and note that demos are on the PR)
+
+## Cloud automation — agent instructions (paste into Automations UI)
+
+Paste into **Agent Instructions**. Trigger / tools / Slack are already set in the UI.
+
+```text
+Repository: MetaMask/metamask-design-system @ main (checkout must include .cursor/automations/react-parity-from-mobile.md).
+
+You are bringing React (design-system-react) to parity with existing React Native MMDS components for epic DSYS-302. Follow docs/ai-agents.md: use @ rules — do not invent patterns from memory.
+
+1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, priority queue (DSYS-713 ListItem, then DSYS-751 SectionHeader), audit, and Storybook demo requirements.
+
+2) Jira (atlassian MCP): claim one unclaimed To Do under parent = DSYS-302 (prefer DSYS-713, then DSYS-751, else Rank ASC). Assign + transition to In Progress. If none, exit with one line and optionally Slack that the backlog was empty.
+
+3) Audit BEFORE coding (component-migration Phase 1):
+   - RN + shared types in this repo
+   - Extension/web counterparts via gh from MetaMask/metamask-extension (component-library and differently named ui/ list-item variants)
+   - Write the Extension vs RN comparison table; choose conservative vs unified strategy
+
+4) Implement React parity only:
+   @CLAUDE.md
+   @.cursor/rules/component-migration.md
+   @.cursor/rules/component-creation.md
+   @.cursor/rules/component-architecture.md
+   @.cursor/rules/styling.md
+   @.cursor/rules/testing.md
+   @.cursor/rules/component-documentation.md
+   Do NOT use component-enum-union-migration.md for this epic.
+
+5) Verify from repo root: yarn build && yarn test && yarn lint (or equivalent workspace-scoped checks that cover changed packages).
+
+6) DEMO (required — computer use): start yarn storybook (port 6006), open the new component stories, capture screenshots and/or a short recording of Default + major variants, and attach them to the PR (Screenshots/Recordings section). Fix story/render failures before shipping.
+
+7) Open PR (Open Pull Request tool) per @.cursor/rules/pr.mdc + .github/pull_request_template.md; put Jira key + audit table + demo artifacts in title/body.
+
+8) Slack #design-system-team: issue key, component, PR URL, and that Storybook demos are on the PR.
+```
+
+## 8. Optional post-merge: close Jira
+
+Separate automation: **Pull request merged** → extract `DSYS-<n>` → transition Done → comment with PR URL + merge SHA. Only for DSYS-302 React-parity PRs.

--- a/.cursor/automations/react-parity-from-mobile.md
+++ b/.cursor/automations/react-parity-from-mobile.md
@@ -47,6 +47,14 @@ Walk this list top-down; take the first open unclaimed To Do.
 | 13    | DSYS-711  | **KeyValueColumn**   |
 | 14    | DSYS-715  | **Spinner**          |
 | 15    | DSYS-714  | **MainActionButton** |
+| 16    | TBD       | **ListItemSelect**   |
+| 17    | TBD       | **ListItemMultiSelect** |
+| 18    | TBD       | **KeyValueSelect**   |
+| 19    | TBD       | **HeaderSubpage**    |
+| 20    | TBD       | **Skeleton**         |
+| 21    | TBD       | **FilterButton**     |
+| 22    | TBD       | **FilterButtonGroup** |
+| 23    | TBD       | **SegmentedControl** |
 
 **Notes**
 
@@ -188,7 +196,7 @@ Repository: MetaMask/metamask-design-system @ main (checkout must include .curso
 
 You are bringing React (design-system-react) to parity with existing React Native MMDS components for epic DSYS-302. Follow docs/ai-agents.md: use @ rules — do not invent patterns from memory.
 
-1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, priority queue (15 components starting Content → ListItem → … → MainActionButton), flatter-impl strategy, audit, and Storybook demo requirements.
+1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, the priority queue (starting Content → ListItem → …), flatter-impl strategy, audit, and Storybook demo requirements.
 
 2) Jira (atlassian MCP): claim one unclaimed To Do under parent = DSYS-302 by walking the priority queue in that file (first open). Skip canceled BoxRow/BoxColumn tickets. Assign + transition to In Progress. If none, exit with one line and optionally Slack that the backlog was empty.
 

--- a/.cursor/automations/react-parity-from-mobile.md
+++ b/.cursor/automations/react-parity-from-mobile.md
@@ -26,15 +26,15 @@ Jira pickup for epic **DSYS-302** (_Migrate Legacy Extension Components to MMDS 
 
 ### Priority queue (prefer these first)
 
-ListItem depends on Content → BoxRow/BoxColumn. Ship deps before ListItem.
+**Parity strategy (option B):** shared **consumer API** with RN; **flatter React implementation**. Do **not** port RN `BoxRow` / `BoxColumn` / `TextOrChildren` as React building blocks for Content/ListItem — they are RN composition helpers / depth footguns (see `packages/design-system-react-native/src/components/ListItem/PERFORMANCE_AUDIT.md`). No Mobile consumer usage of `BoxRow`/`BoxColumn` today.
 
-| Order | Issue     | Component         | Notes                                        |
-| ----- | --------- | ----------------- | -------------------------------------------- |
-| 1     | DSYS-1041 | **BoxRow**        | Layout primitive; used by Content + ListItem |
-| 2     | DSYS-1042 | **BoxColumn**     | Layout primitive; used by Content            |
-| 3     | DSYS-1043 | **Content**       | Inner row layout; ListItem wraps this        |
-| 4     | DSYS-713  | **ListItem**      | After BoxRow + Content                       |
-| 5     | DSYS-751  | **SectionHeader** | RN + shared types already exist              |
+| Order | Issue     | Component         | Notes                                                                                 |
+| ----- | --------- | ----------------- | ------------------------------------------------------------------------------------- |
+| 1     | DSYS-1043 | **Content**       | Shared props; implement with direct `Box`/`Text` (no BoxRow/BoxColumn/TextOrChildren) |
+| 2     | DSYS-713  | **ListItem**      | After Content; same flatter approach                                                  |
+| 3     | DSYS-751  | **SectionHeader** | RN + shared types already exist                                                       |
+
+**Out of queue (canceled / deferred):** DSYS-1041 BoxRow, DSYS-1042 BoxColumn — RN-specific helpers; may optimize or remove later, not React parity blockers.
 
 Then fall through to other unclaimed `parent = DSYS-302` To Do items by Rank.
 
@@ -55,16 +55,17 @@ parent = DSYS-302 AND statusCategory != "Done" AND assignee = currentUser() ORDE
 ### Interactive (IDE / manual run)
 
 1. Prefer **In Progress** assigned to you.
-2. Else prefer priority queue in order: **DSYS-1041 → DSYS-1042 → DSYS-1043 → DSYS-713 → DSYS-751** if still To Do.
+2. Else prefer priority queue in order: **DSYS-1043 → DSYS-713 → DSYS-751** if still To Do.
 3. Else first unassigned To Do from Rank order.
-4. Do **not** start ListItem (DSYS-713) while any of BoxRow/BoxColumn/Content blockers are still open (check Jira “is blocked by” links).
+4. Prefer Content before ListItem when both are open (ListItem composes Content).
 
 ### Scheduled / cloud (“always take backlog”)
 
 1. Walk the priority queue in order; take the **first** unclaimed To Do still open.
-2. Skip ListItem if it is blocked by open BoxRow/BoxColumn/Content issues.
+2. Prefer Content (DSYS-1043) before ListItem (DSYS-713) when both are unclaimed.
 3. Else first result of the unclaimed To Do JQL.
 4. If empty → stop (no PR).
+5. **Skip** canceled/deferred helper tickets (BoxRow/BoxColumn/TextOrChildren ports).
 
 **Jira:** Enable Atlassian/Jira MCP on the automation so the agent can search, assign, and transition.
 
@@ -108,9 +109,12 @@ Answer explicitly:
 - ✅ Primary: `@.cursor/rules/component-migration.md`
 - ✅ Scaffold: `@.cursor/rules/component-creation.md` (`yarn create-component:react` — React only when RN already exists)
 - ✅ Architecture / tokens / docs / tests: architecture, styling, documentation, testing rules
+- ✅ **Content / ListItem:** match shared **props** with RN; implement with direct `Box` + leaf `Text` (opt into `SensitiveText` only where privacy masking is required)
 - ❌ Do **not** copy Extension or RN source verbatim — Box/Text + design tokens
 - ❌ Do **not** put `className` / `onClick` in shared types
+- ❌ Do **not** introduce React `BoxRow`, `BoxColumn`, or `TextOrChildren` to unblock Content/ListItem
 - Prefer existing shared types when present; extend carefully if the audit requires shared changes
+- Target tree depth closer to RN `ActionListItem` than RN `Content`/`ListItem` stack (see PERFORMANCE_AUDIT.md)
 
 ### Layer 2 rules — read in order
 
@@ -167,16 +171,16 @@ Repository: MetaMask/metamask-design-system @ main (checkout must include .curso
 
 You are bringing React (design-system-react) to parity with existing React Native MMDS components for epic DSYS-302. Follow docs/ai-agents.md: use @ rules — do not invent patterns from memory.
 
-1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, priority queue (BoxRow → BoxColumn → Content → ListItem → SectionHeader), audit, and Storybook demo requirements.
+1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, priority queue (Content → ListItem → SectionHeader), flatter-impl strategy, audit, and Storybook demo requirements.
 
-2) Jira (atlassian MCP): claim one unclaimed To Do under parent = DSYS-302 following the priority queue (DSYS-1041, DSYS-1042, DSYS-1043, DSYS-713, DSYS-751). Skip ListItem while BoxRow/BoxColumn/Content blockers are open. Assign + transition to In Progress. If none, exit with one line and optionally Slack that the backlog was empty.
+2) Jira (atlassian MCP): claim one unclaimed To Do under parent = DSYS-302 following the priority queue (DSYS-1043, DSYS-713, DSYS-751). Prefer Content before ListItem. Skip canceled BoxRow/BoxColumn tickets. Assign + transition to In Progress. If none, exit with one line and optionally Slack that the backlog was empty.
 
 3) Audit BEFORE coding (component-migration Phase 1):
-   - RN + shared types in this repo
+   - RN + shared types in this repo (API/props — not internal RN helper composition)
    - Extension/web counterparts via gh from MetaMask/metamask-extension (component-library and differently named ui/ list-item variants)
    - Write the Extension vs RN comparison table; choose conservative vs unified strategy
 
-4) Implement React parity only:
+4) Implement React parity only (shared API, flatter impl — NO React BoxRow/BoxColumn/TextOrChildren):
    @CLAUDE.md
    @.cursor/rules/component-migration.md
    @.cursor/rules/component-creation.md
@@ -185,6 +189,7 @@ You are bringing React (design-system-react) to parity with existing React Nativ
    @.cursor/rules/testing.md
    @.cursor/rules/component-documentation.md
    Do NOT use component-enum-union-migration.md for this epic.
+   For Content/ListItem: direct Box + Text; SensitiveText only where product needs masking.
 
 5) Verify from repo root: yarn build && yarn test && yarn lint (or equivalent workspace-scoped checks that cover changed packages).
 

--- a/.cursor/automations/react-parity-from-mobile.md
+++ b/.cursor/automations/react-parity-from-mobile.md
@@ -1,28 +1,29 @@
 # react-parity-from-mobile
 
-Jira pickup for epic **DSYS-302** (_Migrate Legacy Extension Components to MMDS Monorepo_) — create **React (`design-system-react`)** parity for components that already exist on **React Native**, with an **extension codebase audit** so the web API works for Extension consumers.
+Jira pickup for epic **DSYS-302** (_Migrate Legacy Extension Components to MMDS Monorepo_) — **audit Extension consumers first**, then create **React (`design-system-react`)** parity for components that already exist on **React Native**, and prove viability with a **preview package on the same Extension Audit PR**.
 
 ## Purpose (version control for Cursor Automations)
 
 [Cursor Automations](https://cursor.com/docs/cloud-agent/automations) prompts in the Cursor product are **not** stored in this git repo. This file **is** the **canonical, reviewable spec**: change it here (PRs, `main`, tags) and treat the UI as a **deployment target**.
 
 - **Stable link** — Prefer the automation checkout includes this file; tell the agent to read `.cursor/automations/react-parity-from-mobile.md`.
-- **Copy-paste** — Paste the cloud prompt block below into a **Private** or **Team Visible** automation. After merging changes here, update the pasted prompt.
+- **Copy-paste** — Paste the cloud prompt blocks below into **Private** or **Team Visible** automations. After merging changes here, update the pasted prompts.
 
 **Invoke (IDE):** `@.cursor/automations/react-parity-from-mobile.md`.
 
-**Strategy:** Matches [docs/ai-agents.md](../../docs/ai-agents.md): _reference over duplication_, _checklists over narratives_, _context efficiency_. This file defines **orchestration** (Jira, audit sources, PR identity). **Implementation guardrails** live in `@.cursor/rules/` — agents must read those files, not improvise from this doc alone.
+**Strategy:** Matches [docs/ai-agents.md](../../docs/ai-agents.md): _reference over duplication_, _checklists over narratives_, _context efficiency_. This file defines **orchestration** (Jira, audit PR, Slack handoff, preview validation). **Implementation guardrails** live in `@.cursor/rules/` — agents must read those files, not improvise from this doc alone.
 
 ## Scope
 
-| Setting            | Value                                                                                                                                                                                              |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Epic               | **DSYS-302** — _Migrate Legacy Extension Components to MMDS Monorepo_                                                                                                                              |
-| Board (reference)  | [DSYS board — epic filter](https://consensyssoftware.atlassian.net/jira/software/c/projects/DSYS/boards/1888?issueParent=335295)                                                                   |
-| Primary workflow   | `@.cursor/rules/component-migration.md` (extension + mobile → monorepo)                                                                                                                            |
-| Not this epic      | Do **not** use `@.cursor/rules/component-enum-union-migration.md` (that is DSYS-468 internal ADR refactors)                                                                                        |
-| Checkout repo      | `MetaMask/metamask-design-system` @ `main` (or a branch that includes this file)                                                                                                                   |
-| Audit source (web) | [MetaMask Extension component-library](https://github.com/MetaMask/metamask-extension/tree/main/ui/components/component-library) + related `ui/components/ui/` counterparts when named differently |
+| Setting           | Value                                                                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Epic              | **DSYS-302** — _Migrate Legacy Extension Components to MMDS Monorepo_                                                                            |
+| Board (reference) | [DSYS board — epic filter](https://consensyssoftware.atlassian.net/jira/software/c/projects/DSYS/boards/1888?issueParent=335295)                 |
+| Primary workflow  | `@.cursor/rules/component-migration.md` (consumer replaceability audit + extension/mobile → monorepo)                                            |
+| Not this epic     | Do **not** use `@.cursor/rules/component-enum-union-migration.md` (that is DSYS-468 internal ADR refactors)                                      |
+| Repos             | Multi-repo: `MetaMask/metamask-design-system` **and** `MetaMask/metamask-extension`                                                              |
+| Slack             | `#design-system-team` — audit complete posts + **thread reply** gates implementation                                                             |
+| Changelog         | Do **not** edit `packages/**/CHANGELOG.md` on feature PRs — `@.cursor/rules/pr.mdc` + `@.cursor/rules/release-workflow.md`                       |
 
 ### Priority queue (prefer these first)
 
@@ -30,39 +31,72 @@ Jira pickup for epic **DSYS-302** (_Migrate Legacy Extension Components to MMDS 
 
 Walk this list top-down; take the first open unclaimed To Do.
 
-| Order | Issue     | Component            |
-| ----- | --------- | -------------------- |
-| 1     | DSYS-1043 | **Content**          |
-| 2     | DSYS-713  | **ListItem**         |
-| 3     | DSYS-751  | **SectionHeader**    |
-| 4     | DSYS-750  | **SectionDivider**   |
-| 5     | DSYS-757  | **HeaderRoot**       |
-| 6     | DSYS-758  | **HeaderStandard**   |
-| 7     | DSYS-756  | **TitleSubpage**     |
-| 8     | DSYS-755  | **TitleStandard**    |
-| 9     | DSYS-752  | **TitleAlert**       |
-| 10    | DSYS-749  | **SelectButton**     |
-| 11    | DSYS-716  | **HeaderSearch**     |
-| 12    | DSYS-712  | **KeyValueRow**      |
-| 13    | DSYS-711  | **KeyValueColumn**   |
-| 14    | DSYS-715  | **Spinner**          |
-| 15    | DSYS-714  | **MainActionButton** |
-| 16    | TBD       | **ListItemSelect**   |
+| Order | Issue     | Component               |
+| ----- | --------- | ----------------------- |
+| 1     | DSYS-1043 | **Content**             |
+| 2     | DSYS-713  | **ListItem**            |
+| 3     | DSYS-751  | **SectionHeader**       |
+| 4     | DSYS-750  | **SectionDivider**      |
+| 5     | DSYS-757  | **HeaderRoot**          |
+| 6     | DSYS-758  | **HeaderStandard**      |
+| 7     | DSYS-756  | **TitleSubpage**        |
+| 8     | DSYS-755  | **TitleStandard**       |
+| 9     | DSYS-752  | **TitleAlert**          |
+| 10    | DSYS-749  | **SelectButton**        |
+| 11    | DSYS-716  | **HeaderSearch**        |
+| 12    | DSYS-712  | **KeyValueRow**         |
+| 13    | DSYS-711  | **KeyValueColumn**      |
+| 14    | DSYS-715  | **Spinner**             |
+| 15    | DSYS-714  | **MainActionButton**    |
+| 16    | TBD       | **ListItemSelect**      |
 | 17    | TBD       | **ListItemMultiSelect** |
-| 18    | TBD       | **KeyValueSelect**   |
-| 19    | TBD       | **HeaderSubpage**    |
-| 20    | TBD       | **Skeleton**         |
-| 21    | TBD       | **FilterButton**     |
-| 22    | TBD       | **FilterButtonGroup** |
-| 23    | TBD       | **SegmentedControl** |
+| 18    | TBD       | **KeyValueSelect**      |
+| 19    | TBD       | **HeaderSubpage**       |
+| 20    | TBD       | **FilterButton**        |
+| 21    | TBD       | **FilterButtonGroup**   |
+| 22    | TBD       | **SegmentedControl**    |
 
 **Notes**
 
 - Content before ListItem (ListItem composes Content). Prefer HeaderRoot before HeaderStandard when both are open.
 - For Content/ListItem: implement with direct `Box`/`Text` (no BoxRow/BoxColumn/TextOrChildren).
 - **Out of queue (canceled):** DSYS-1041 BoxRow, DSYS-1042 BoxColumn.
+- **Already in React (skip create):** Tag, Skeleton (DSYS-310). Confirm via audit if a ticket remains open (e.g. IconAlert).
+- Jira tickets for this epic are framed **audit-first**; do not jump to scaffolding.
 
 Then fall through to other unclaimed `parent = DSYS-302` To Do items by Rank.
+
+---
+
+## Pipeline overview (audit → Slack → implement → preview)
+
+```text
+[Automation A — Audit]
+  claim Jira → fingerprint RN → find Extension candidates
+  → demo VM before screenshots → open Extension Audit PR
+  → Slack #design-system-team (new thread) “audit complete”
+       ↓
+[Human]
+  review Audit PR: drop / add candidates, mark intentional divergences
+  reply in Slack thread to confirm → continue
+       ↓
+[Automation B — Implement]
+  Slack thread reply trigger → read approved Audit PR
+  → create React parity in design-system → DS PR + Storybook demos
+  → comment on Audit PR + reply in Slack thread with DS PR link
+       ↓
+[Human]
+  @metamaskbot publish-preview on DS PR (org member)
+       ↓
+[Automation C — Preview validate]
+  wait for preview package comment / workflow
+  → update SAME Extension Audit PR with preview dependency + approved pilots
+  → after screenshots → viability report on Audit PR + DS PR + Slack thread
+```
+
+**Handoff object:** the **Extension Audit PR** (not a DS docs PR). It holds candidate inventory, before/after screenshots, design discussion, and later the preview-package pilot diffs.
+
+---
 
 ## 1. Find candidates
 
@@ -81,9 +115,9 @@ parent = DSYS-302 AND statusCategory != "Done" AND assignee = currentUser() ORDE
 ### Interactive (IDE / manual run)
 
 1. Prefer **In Progress** assigned to you.
-2. Else prefer the **priority queue** above in order (first still To Do).
-3. Else first unassigned To Do from Rank order.
-4. Prefer Content before ListItem, and HeaderRoot before HeaderStandard, when both are open.
+2. Else prefer **To Do** assigned to you.
+3. Else prefer the **priority queue** above in order (first still To Do / unassigned unless yours).
+4. Else first unassigned To Do from Rank order.
 
 ### Scheduled / cloud (“always take backlog”)
 
@@ -98,36 +132,79 @@ parent = DSYS-302 AND statusCategory != "Done" AND assignee = currentUser() ORDE
 
 - If unassigned → set **assignee** to you.
 - If **To Do** → transition to **In Progress** (or project equivalent).
+- Comment on the issue that **Phase = Extension consumer audit** (not implementation yet).
 
-## 4. Audit before implementing (required)
+---
 
-Do **not** scaffold until the comparison table exists. Follow Phase 1 of `@.cursor/rules/component-migration.md`.
+## Automation A — Extension consumer audit (required first)
 
-### Sources to inspect
+Do **not** scaffold React components in this phase.
 
-| Source                 | Where                                                                                                                                                                                                         |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **RN (parity target)** | `packages/design-system-react-native/src/components/<Name>/` in this repo                                                                                                                                     |
-| **Shared types**       | `packages/design-system-shared/src/types/<Name>/` if present                                                                                                                                                  |
-| **Extension / web**    | Fetch from `MetaMask/metamask-extension` via `gh` (raw/API) — start at `ui/components/component-library/`; also search `ui/components/ui/` and multichain/activity variants when names differ (esp. ListItem) |
+Follow Phase 1 of `@.cursor/rules/component-migration.md` **plus** the consumer replaceability steps below.
 
-### Comparison table (include in PR)
+### A1. Fingerprint from React Native
 
-| Concern                  | Extension / web API | Mobile / RN (MMDS) API | Decision             |
-| ------------------------ | ------------------- | ---------------------- | -------------------- |
-| Prop names               | …                   | …                      | …                    |
-| Types / variants / sizes | …                   | …                      | …                    |
-| Event handlers           | `onClick`           | `onPress`              | Keep both (platform) |
-| Styling                  | `className`         | `twClassName`          | Platform layer only  |
+From `packages/design-system-react-native/src/components/<Name>/` (+ shared types if present), capture:
 
-Answer explicitly:
+- One-sentence purpose (what the component _is_)
+- Canonical shapes (static title, interactive + chevron, accessories, children, etc.)
+- Default typography / interaction behavior from README + stories
 
-- Which props are shared vs platform-specific?
-- Naming conflicts (`disabled` vs `isDisabled`, etc.)?
-- Conservative vs Unified migration strategy (per component-migration.md)?
-- Does React parity belong in DSR under this name, or is the web analogue differently named? (document mapping)
+This fingerprint drives Extension search when **no same-named legacy component** exists.
 
-## 5. Implement React parity
+### A2. Find Extension candidates (name + structural)
+
+Search `MetaMask/metamask-extension` (`ui/`):
+
+1. **Name / near-name** — `<Name>`, kebab folder, local `const <Name> = …`, `*SectionHeader*`-style variants
+2. **Structural** — compositions matching the fingerprint (e.g. heading row above a list; `ButtonBase`/`role="button"` + title + `ArrowRight`; title + “View all” / “See all”)
+3. **Exclude** page chrome / nav headers / list rows themselves / form labels unless the fingerprint says otherwise
+
+Score each hit: **High / Medium / Low**, with proposed MMDS props mapping.
+
+### A3. Open Extension Audit PR (handoff object)
+
+Repo: **`MetaMask/metamask-extension`**.
+
+PR must include:
+
+| Section                    | Content                                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Jira key                   | e.g. `DSYS-751`                                                                                              |
+| RN fingerprint             | purpose + shapes                                                                                             |
+| Candidate table            | file, route/testid, snippet, proposed props, confidence, status                                              |
+| Status values              | `candidate` \| `approved-pilot` \| `out-of-scope` \| `intentional-divergence`                                |
+| Before screenshots         | demo VM / computer use captures of in-app candidates (mark `needs-manual-screenshot` if blocked)             |
+| Design discussion          | Extension patterns that may be **intentional** vs Mobile (do not force unify)                                |
+| Pilot recommendation       | 1–2 High-confidence call sites for later preview swap                                                        |
+| Checklist                  | Audit complete → Awaiting Slack confirm → Awaiting implement → Awaiting preview → Validated                  |
+
+Do **not** add the preview package or broad replacements in this first push — audit + evidence only (minimal branch scaffolding allowed if needed for screenshots).
+
+### A4. Slack — audit complete (new thread)
+
+Post to **`#design-system-team`**:
+
+- Issue key + component name
+- Extension Audit PR URL
+- Short summary: N candidates, recommended pilots, open design questions
+- Explicit ask: review the Audit PR, then **reply in this thread to confirm** and continue to React implementation
+
+Stop after Slack. Do **not** implement until Automation B is triggered by a confirming thread reply.
+
+---
+
+## Automation B — Implement React parity (after Slack confirm)
+
+**Trigger:** Slack message in the audit thread that clearly confirms continuing (e.g. “LGTM”, “approved”, “continue”, “implement”). If ambiguous, ask once in-thread; do not proceed.
+
+### B1. Read approved audit
+
+- Re-read the Extension Audit PR (latest candidate statuses)
+- Honor `out-of-scope` and `intentional-divergence`
+- Use `approved-pilot` / remaining High candidates to inform API decisions
+
+### B2. Implement in design-system
 
 ### Guardrails
 
@@ -138,6 +215,7 @@ Answer explicitly:
 - ❌ Do **not** copy Extension or RN source verbatim — Box/Text + design tokens
 - ❌ Do **not** put `className` / `onClick` in shared types
 - ❌ Do **not** introduce React `BoxRow`, `BoxColumn`, or `TextOrChildren` to unblock Content/ListItem
+- ❌ Do **not** edit `CHANGELOG.md` on this PR
 - Prefer existing shared types when present; extend carefully if the audit requires shared changes
 - Target tree depth closer to RN `ActionListItem` than RN `Content`/`ListItem` stack (see PERFORMANCE_AUDIT.md)
 
@@ -161,70 +239,98 @@ Answer explicitly:
 yarn build && yarn test && yarn lint
 ```
 
-Prefer package-scoped test/lint for the touched React package when full monorepo runs are too heavy, but do not skip build/typecheck of affected workspaces.
+### B3. Storybook demos (computer use)
 
-## 6. Demo Storybook (computer use / demos)
+1. `yarn storybook` (port **6006**)
+2. Capture Default + major variants
+3. Embed in DS PR **Screenshots/Recordings**
 
-Cloud Automations include **computer use** by default. After implementation + tests pass, **demo the new React stories** and attach artifacts to the PR (screenshots and/or a short recording).
-
-### Steps
-
-1. Start React Storybook from repo root: `yarn storybook` (port **6006**).
-2. Open the browser to the new component’s stories (Default + major prop stories).
-3. Capture **screenshots** of key stories and/or a **short screen recording** walking Default → main variants.
-4. Attach those demos to the **PR** (prefer embedding in the PR description **Screenshots/Recordings** section; also fine as PR comment artifacts).
-5. If Storybook fails to start or stories crash, fix before opening/updating the PR — do not ship without visual evidence unless blocked (then say why in Slack + PR).
-
-**Dashboard:** Enable **Allow posting artifacts to GitHub** under [Cloud Agents → My pull requests](https://cursor.com/dashboard/cloud-agents#my-pull-requests) so demos can land on the PR.
-
-**Environment:** Ensure the cloud agent environment can install deps and run Storybook (same as local `yarn` + `yarn storybook`).
-
-## 7. Open the PR + Slack
+### B4. Open DS PR + notify
 
 - `@.cursor/rules/pr.mdc` + `.github/pull_request_template.md`
-- Include Jira key (e.g. `DSYS-713`)
-- Include the **audit comparison table**, known gaps, and **demo screenshots/recording**
-- **Private / Team Visible** automation → PR as your GitHub user; **Team Owned** → `cursor` service account
-- Notify `#design-system-team` with issue key, component name, and PR link (and note that demos are on the PR)
+- Link **Extension Audit PR** + Jira key
+- Include API comparison table + how audit informed decisions
+- Comment on Extension Audit PR with DS PR URL
+- Reply in the **same Slack thread** with DS PR URL and ask a human to run `@metamaskbot publish-preview` when ready
 
-## Cloud automation — agent instructions (paste into Automations UI)
+---
 
-Paste into **Agent Instructions**. Trigger / tools / Slack are already set in the UI.
+## Automation C — Preview validate on the Audit PR
+
+**Trigger:** DS PR receives preview packages comment after `@metamaskbot publish-preview`, or Slack/human asks to validate. Agents may **try** commenting `@metamaskbot publish-preview`; if unauthorized, ask a human in the Slack thread and wait.
+
+### C1. Reuse the Extension Audit PR branch
+
+On the **same** Audit PR:
+
+1. Point Extension at the preview package, e.g.
+
+   ```json
+   "@metamask/design-system-react": "npm:@metamask-previews/design-system-react@<version-from-comment>"
+   ```
+
+2. Replace only **`approved-pilot`** candidates (default 1–2)
+3. Do not migrate `out-of-scope` / `intentional-divergence` rows
+
+### C2. After screenshots + viability
+
+- Capture after screenshots in demo VM for pilots
+- Update Audit PR description with before/after + viability verdict (`ready` / `needs API change` / `not a fit`)
+- Comment on DS PR + reply in Slack thread
+
+---
+
+## Cloud automation — agent instructions
+
+Configure **three** Automations (or one with clear phase detection). Paste the matching block into **Agent Instructions**. Prefer **multi-repo** environment: design-system + extension. Enable Slack, Open PR, Comment on PR, computer use, Atlassian MCP.
+
+### A — Audit (schedule / backlog pickup)
 
 ```text
-Repository: MetaMask/metamask-design-system @ main (checkout must include .cursor/automations/react-parity-from-mobile.md).
+Multi-repo: MetaMask/metamask-design-system + MetaMask/metamask-extension.
+Read @.cursor/automations/react-parity-from-mobile.md (Pipeline + Automation A).
 
-You are bringing React (design-system-react) to parity with existing React Native MMDS components for epic DSYS-302. Follow docs/ai-agents.md: use @ rules — do not invent patterns from memory.
+You are running AUDIT ONLY for epic DSYS-302. Do NOT scaffold React components.
 
-1) Read @.cursor/automations/react-parity-from-mobile.md for JQL, the priority queue (starting Content → ListItem → …), flatter-impl strategy, audit, and Storybook demo requirements.
-
-2) Jira (atlassian MCP): claim one unclaimed To Do under parent = DSYS-302 by walking the priority queue in that file (first open). Skip canceled BoxRow/BoxColumn tickets. Assign + transition to In Progress. If none, exit with one line and optionally Slack that the backlog was empty.
-
-3) Audit BEFORE coding (component-migration Phase 1):
-   - RN + shared types in this repo (API/props — not internal RN helper composition)
-   - Extension/web counterparts via gh from MetaMask/metamask-extension (component-library and differently named ui/ list-item variants)
-   - Write the Extension vs RN comparison table; choose conservative vs unified strategy
-
-4) Implement React parity only (shared API, flatter impl — NO React BoxRow/BoxColumn/TextOrChildren):
-   @CLAUDE.md
-   @.cursor/rules/component-migration.md
-   @.cursor/rules/component-creation.md
-   @.cursor/rules/component-architecture.md
-   @.cursor/rules/styling.md
-   @.cursor/rules/testing.md
-   @.cursor/rules/component-documentation.md
-   Do NOT use component-enum-union-migration.md for this epic.
-   For Content/ListItem: direct Box + Text; SensitiveText only where product needs masking.
-
-5) Verify from repo root: yarn build && yarn test && yarn lint (or equivalent workspace-scoped checks that cover changed packages).
-
-6) DEMO (required — computer use): start yarn storybook (port 6006), open the new component stories, capture screenshots and/or a short recording of Default + major variants, and attach them to the PR (Screenshots/Recordings section). Fix story/render failures before shipping.
-
-7) Open PR (Open Pull Request tool) per @.cursor/rules/pr.mdc + .github/pull_request_template.md; put Jira key + audit table + demo artifacts in title/body.
-
-8) Slack #design-system-team: issue key, component, PR URL, and that Storybook demos are on the PR.
+1) Claim one unclaimed To Do under parent = DSYS-302 via priority queue in that file. Assign + In Progress. Comment that Phase = Extension consumer audit.
+2) Fingerprint the RN component (README/stories/shared types).
+3) Search metamask-extension for name + structural candidates; score High/Medium/Low; note intentional-divergence questions.
+4) Use computer use / demo VM to capture before screenshots of candidates when possible.
+5) Open an Audit PR on MetaMask/metamask-extension with candidate table, screenshots, design discussion, pilot recommendations. No preview package yet.
+6) Slack #design-system-team (new thread): issue key, component, Audit PR URL, open questions; ask humans to review and reply in-thread to confirm before implementation.
+7) Stop. Do not implement until a confirming Slack thread reply triggers Automation B.
 ```
 
-## 8. Optional post-merge: close Jira
+### B — Implement (Slack thread reply)
 
-Separate automation: **Pull request merged** → extract `DSYS-<n>` → transition Done → comment with PR URL + merge SHA. Only for DSYS-302 React-parity PRs.
+```text
+Multi-repo: MetaMask/metamask-design-system + MetaMask/metamask-extension.
+Read @.cursor/automations/react-parity-from-mobile.md (Automation B).
+
+Triggered by a confirming reply in the #design-system-team audit thread.
+
+1) Parse issue key + Extension Audit PR from the parent Slack thread. Re-read the Audit PR; honor out-of-scope and intentional-divergence.
+2) Implement React parity in design-system-react from RN + approved audit (flatter impl; NO BoxRow/BoxColumn/TextOrChildren; NO CHANGELOG edits).
+   Rules: @CLAUDE.md @.cursor/rules/component-migration.md @.cursor/rules/component-creation.md @.cursor/rules/component-architecture.md @.cursor/rules/styling.md @.cursor/rules/testing.md @.cursor/rules/component-documentation.md
+3) yarn build && yarn test && yarn lint (or scoped equivalents).
+4) Storybook demos (port 6006); attach artifacts to DS PR.
+5) Open DS PR linking Audit PR + Jira; comment on Audit PR; reply in the same Slack thread with DS PR URL and ask for @metamaskbot publish-preview when ready.
+```
+
+### C — Preview validate (preview packages comment / Slack)
+
+```text
+Multi-repo: MetaMask/metamask-design-system + MetaMask/metamask-extension.
+Read @.cursor/automations/react-parity-from-mobile.md (Automation C).
+
+1) Locate preview package versions from the DS PR publish-preview comment (or ask human to comment @metamaskbot publish-preview if missing).
+2) Update the SAME Extension Audit PR: depend on preview package; replace approved-pilot call sites only.
+3) Capture after screenshots; update Audit PR with before/after + viability.
+4) Comment on DS PR + reply in Slack thread with results.
+```
+
+---
+
+## Optional post-merge: close Jira
+
+Separate automation: **Pull request merged** (DS implementation and/or validated Audit PR per team convention) → extract `DSYS-<n>` → transition Done → comment with PR URLs + merge SHA. Only for DSYS-302 React-parity work.

--- a/.cursor/rules/component-migration.md
+++ b/.cursor/rules/component-migration.md
@@ -70,7 +70,11 @@ Use this workflow when:
 
 ### Phase 1: Audit
 
-**For both Extension and Mobile component-library:**
+Phase 1 has **two** parts. For DSYS-302 React parity, complete **both** before scaffolding, and land the consumer audit as an **Extension Audit PR** first (see `@.cursor/automations/react-parity-from-mobile.md`).
+
+#### 1A. API audit (named / library counterparts)
+
+**For both Extension and Mobile component-library (when a counterpart exists):**
 
 1. **Locate component** and document:
 
@@ -94,6 +98,21 @@ Use this workflow when:
    - Which props are platform-specific? (onClick/onPress, className/twClassName)
    - Are there naming conflicts? (disabled vs isDisabled)
    - What's the unified API that serves both platforms?
+
+#### 1B. Consumer replaceability audit (required when no Extension namesake)
+
+Many RN components have **no** legacy Extension component with the same name. Still audit Extension for **replaceable patterns** using the RN component as a fingerprint.
+
+1. **Fingerprint from RN/shared** — purpose, canonical shapes (static / interactive / accessories / children), default typography and interaction from README + stories.
+2. **Search Extension** (`ui/`):
+   - Name / near-name / local helpers
+   - Structural compositions matching the fingerprint (e.g. heading row above a list; title + chevron disclosure; title + “View all”)
+   - Exclude page chrome, nav headers, and list rows unless the fingerprint says otherwise
+3. **Score candidates** — High / Medium / Low with proposed MMDS props mapping.
+4. **Mark intentional divergences** — Extension patterns that should **not** be unified with Mobile (product/design decision); discuss on the Audit PR + Slack.
+5. **Capture before evidence** — demo VM / computer use screenshots of in-app candidates when possible; otherwise file + route/testid + snippet.
+6. **Open an Extension Audit PR** as the handoff object (candidate table, screenshots, design questions, recommended pilots). Do **not** implement React parity until that audit is confirmed (Slack thread reply for DSYS-302).
+7. **Later reuse the same Audit PR** for preview-package pilot replacements and after screenshots.
 
 ### Prop Alignment Principles
 

--- a/.cursor/rules/pr.mdc
+++ b/.cursor/rules/pr.mdc
@@ -87,6 +87,12 @@ When the user types `@pr`, automatically generate a comprehensive pull request d
 - Bug fixes → "Resolves issue with..."
 - New features → "Implements new functionality for..."
 
+**Changelog policy (always apply)**:
+
+- Do not modify any `packages/**/CHANGELOG.md` files in normal feature/fix/chore/docs PRs.
+- Changelogs are updated only on release branches created via `yarn create-release-branch` per `@.cursor/rules/release-workflow.md`.
+- If the diff includes changes to `CHANGELOG.md`, either revert them or convert the work into a release PR instead.
+
 **Example auto-generated descriptions**:
 
 - For Avatar Figma files: "Adds Figma Code Connect integration for Avatar components, ensuring design-to-code alignment between React and React Native implementations."


### PR DESCRIPTION
## **Description**

Adds a version-controlled Cursor Automations spec for epic **DSYS-302** (React parity with existing React Native MMDS components). The Cursor Automations UI does not store prompts in git; this file is the canonical source for Jira pickup, Extension audit, implementation rules, Storybook demos, PR, and Slack steps — matching the existing `enum-shared-type-migration` pattern.

Priority queue starts with **ListItem (DSYS-713)** and **SectionHeader (DSYS-751)**.

## **Related issues**

Fixes: N/A (tooling / agent orchestration for [DSYS-302](https://consensyssoftware.atlassian.net/browse/DSYS-302))

## **Manual testing steps**

1. Open `.cursor/automations/react-parity-from-mobile.md` and confirm JQL, priority queue, and cloud prompt block look correct.
2. In Cursor Automations, paste the cloud prompt into **Design System React Component Parity with React Native** (or `@`-mention this file once merged to `main`).
3. Optionally run the automation once (or invoke `@.cursor/automations/react-parity-from-mobile.md` in IDE) and confirm it targets DSYS-713 first when unclaimed.

## **Screenshots/Recordings**

N/A — docs-only change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable (N/A — markdown automation spec)
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)