### PR TITLE
fix: make Checkbox native input Selenium-visible

### DIFF
--- a/packages/design-system-react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.test.tsx
@@ -76,29 +76,29 @@ describe('Checkbox', () => {
     expect(input).toBeDisabled();
   });
 
-  it('applies invalid border styles', () => {
+  it('applies invalid border styles to the input', () => {
     render(
       <Checkbox
         id="test-checkbox"
         onChange={jest.fn()}
         isSelected={false}
         isInvalid
-        checkboxContainerProps={{ 'data-testid': 'inner' }}
+        inputProps={{ 'data-testid': 'chk-input' }}
       />,
     );
-    expect(screen.getByTestId('inner')).toHaveClass('border-error-default');
+    expect(screen.getByTestId('chk-input')).toHaveClass('border-error-default');
   });
 
-  it('applies selected container styles', () => {
+  it('applies selected styles to the input', () => {
     render(
       <Checkbox
         id="test-checkbox"
         onChange={jest.fn()}
         isSelected
-        checkboxContainerProps={{ 'data-testid': 'inner' }}
+        inputProps={{ 'data-testid': 'chk-input' }}
       />,
     );
-    expect(screen.getByTestId('inner')).toHaveClass(
+    expect(screen.getByTestId('chk-input')).toHaveClass(
       'bg-icon-default',
       'border-icon-default',
     );
@@ -247,23 +247,36 @@ describe('Checkbox', () => {
     expect(screen.getByTestId('chk-input')).toHaveFocus();
   });
 
-  it('applies visible focus styles to the rendered checkbox when input is focused', () => {
+  it('applies focus-visible styles on the input', () => {
     render(
       <Checkbox
         id="test-checkbox"
         isSelected={false}
         onChange={jest.fn()}
         inputProps={{ 'data-testid': 'chk-input' }}
-        checkboxContainerProps={{ 'data-testid': 'inner' }}
       />,
     );
 
-    expect(screen.getByTestId('chk-input')).toHaveClass('peer');
-    expect(screen.getByTestId('inner')).toHaveClass(
-      'peer-focus-visible:outline',
-      'peer-focus-visible:outline-2',
-      'peer-focus-visible:outline-offset-2',
-      'peer-focus-visible:outline-primary-default',
+    expect(screen.getByTestId('chk-input')).toHaveClass(
+      'focus-visible:outline',
+      'focus-visible:outline-2',
+      'focus-visible:outline-offset-2',
+      'focus-visible:outline-primary-default',
     );
+  });
+
+  it('keeps the input Selenium-visible (no opacity-0)', () => {
+    render(
+      <Checkbox
+        id="test-checkbox"
+        isSelected={false}
+        onChange={jest.fn()}
+        inputProps={{ 'data-testid': 'chk-input' }}
+      />,
+    );
+
+    const input = screen.getByTestId('chk-input');
+    expect(input).toHaveClass('appearance-none');
+    expect(input).not.toHaveClass('opacity-0');
   });
 });

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.test.tsx
@@ -265,6 +265,38 @@ describe('Checkbox', () => {
     );
   });
 
+  it('scopes press animation to enabled state on the input', () => {
+    render(
+      <Checkbox
+        id="test-checkbox"
+        isSelected={false}
+        isDisabled
+        onChange={jest.fn()}
+        inputProps={{ 'data-testid': 'chk-input' }}
+      />,
+    );
+
+    expect(screen.getByTestId('chk-input')).toHaveClass(
+      'enabled:active:scale-95',
+    );
+  });
+
+  it('scopes check icon press animation to enabled peer state', () => {
+    render(
+      <Checkbox
+        id="test-checkbox"
+        isSelected
+        isDisabled
+        onChange={jest.fn()}
+        checkedIconProps={{ 'data-testid': 'chk-icon' }}
+      />,
+    );
+
+    expect(screen.getByTestId('chk-icon')).toHaveClass(
+      'peer-enabled:peer-active:scale-95',
+    );
+  });
+
   it('keeps the input Selenium-visible (no opacity-0)', () => {
     render(
       <Checkbox

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.test.tsx
@@ -120,6 +120,19 @@ describe('Checkbox', () => {
     );
   });
 
+  it('prevents label from stretching in flex containers', () => {
+    render(
+      <Checkbox
+        id="test-checkbox"
+        onChange={jest.fn()}
+        isSelected={false}
+        data-testid="chk-label"
+      />,
+    );
+
+    expect(screen.getByTestId('chk-label')).toHaveClass('self-start');
+  });
+
   it('merges className and style on label container', () => {
     render(
       <Checkbox
@@ -262,6 +275,23 @@ describe('Checkbox', () => {
       'focus-visible:outline-2',
       'focus-visible:outline-offset-2',
       'focus-visible:outline-primary-default',
+    );
+  });
+
+  it('scopes hover and press background to enabled state on the input', () => {
+    render(
+      <Checkbox
+        id="test-checkbox"
+        isSelected={false}
+        isDisabled
+        onChange={jest.fn()}
+        inputProps={{ 'data-testid': 'chk-input' }}
+      />,
+    );
+
+    expect(screen.getByTestId('chk-input')).toHaveClass(
+      'enabled:hover:bg-default-hover',
+      'enabled:active:bg-default-pressed',
     );
   });
 

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
@@ -75,7 +75,7 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
 
     // Native input is the visible control (no opacity-0) for Selenium isDisplayed().
     const inputClasses = twMerge(
-      'size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform active:scale-95',
+      'size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform active:scale-95 peer',
       'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default',
       'disabled:cursor-not-allowed',
       baseBg,
@@ -89,7 +89,7 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
     );
 
     const iconClasses = twMerge(
-      'pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transition-opacity',
+      'pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transition peer-active:scale-95',
       isSelected ? 'opacity-100' : 'opacity-0',
       checkedIconClassName,
     );

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
@@ -75,7 +75,7 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
 
     // Native input is the visible control (no opacity-0) for Selenium isDisplayed().
     const inputClasses = twMerge(
-      'peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform active:scale-95',
+      'peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform enabled:active:scale-95',
       'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default',
       'disabled:cursor-not-allowed',
       baseBg,
@@ -89,7 +89,7 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
     );
 
     const iconClasses = twMerge(
-      'pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transition peer-active:scale-95',
+      'pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transition peer-enabled:peer-active:scale-95',
       isSelected ? 'opacity-100' : 'opacity-0',
       checkedIconClassName,
     );

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
@@ -49,6 +49,14 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
 
     useImperativeHandle(ref, () => ({ toggle: handleClick }), [handleClick]);
 
+    const { className: inputClassName, ...restInputProps } = inputProps ?? {};
+    const {
+      className: checkboxContainerClassName,
+      ...restCheckboxContainerProps
+    } = checkboxContainerProps ?? {};
+    const { className: checkedIconClassName, ...restCheckedIconProps } =
+      checkedIconProps ?? {};
+
     const outerClassName = twMerge(
       'inline-flex items-center',
       isDisabled && 'cursor-not-allowed opacity-50',
@@ -65,22 +73,30 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
       baseBorder = 'border-error-default';
     }
 
-    const checkboxClasses = twMerge(
-      'relative flex size-6 items-center justify-center rounded border-2 p-0 transition-transform active:scale-95 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary-default',
+    // Native input is the visible control (no opacity-0) for Selenium isDisplayed().
+    const inputClasses = twMerge(
+      'appearance-none size-6 shrink-0 cursor-pointer rounded border-2 p-0 transition-transform active:scale-95',
+      'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default',
+      'disabled:cursor-not-allowed',
       baseBg,
       baseBorder,
-      checkboxContainerProps?.className,
+      inputClassName,
+    );
+
+    const wrapperClasses = twMerge(
+      'relative inline-flex size-6 items-center justify-center',
+      checkboxContainerClassName,
     );
 
     const iconClasses = twMerge(
-      'pointer-events-none transition-opacity',
+      'pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transition-opacity',
       isSelected ? 'opacity-100' : 'opacity-0',
-      checkedIconProps?.className,
+      checkedIconClassName,
     );
 
     return (
       <label htmlFor={id} className={outerClassName} style={style} {...props}>
-        <div className="relative">
+        <div className={wrapperClasses} {...restCheckboxContainerProps}>
           <input
             type="checkbox"
             id={id}
@@ -89,18 +105,16 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
             aria-invalid={isInvalid}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
-            className="peer absolute inset-0 size-full cursor-pointer opacity-0 disabled:cursor-not-allowed"
-            {...inputProps}
+            className={inputClasses}
+            {...restInputProps}
           />
-          <div className={checkboxClasses} {...checkboxContainerProps}>
-            <Icon
-              name={IconName.Check}
-              color={IconColor.IconInverse}
-              size={IconSize.Sm}
-              {...checkedIconProps}
-              className={iconClasses}
-            />
-          </div>
+          <Icon
+            name={IconName.Check}
+            color={IconColor.IconInverse}
+            size={IconSize.Sm}
+            {...restCheckedIconProps}
+            className={iconClasses}
+          />
         </div>
         {label ? (
           <Text

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
@@ -75,7 +75,7 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
 
     // Native input is the visible control (no opacity-0) for Selenium isDisplayed().
     const inputClasses = twMerge(
-      'appearance-none size-6 shrink-0 cursor-pointer rounded border-2 p-0 transition-transform active:scale-95',
+      'size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform active:scale-95',
       'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default',
       'disabled:cursor-not-allowed',
       baseBg,

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
@@ -75,7 +75,7 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
 
     // Native input is the visible control (no opacity-0) for Selenium isDisplayed().
     const inputClasses = twMerge(
-      'size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform active:scale-95 peer',
+      'peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform active:scale-95',
       'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default',
       'disabled:cursor-not-allowed',
       baseBg,

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.tsx
@@ -58,14 +58,14 @@ export const Checkbox = forwardRef<{ toggle: () => void }, CheckboxProps>(
       checkedIconProps ?? {};
 
     const outerClassName = twMerge(
-      'inline-flex items-center',
+      'inline-flex items-center self-start',
       isDisabled && 'cursor-not-allowed opacity-50',
       className,
     );
 
     const baseBg = isSelected
-      ? 'bg-icon-default hover:bg-icon-default-hover active:bg-icon-default-pressed'
-      : 'bg-default hover:bg-default-hover active:bg-default-pressed';
+      ? 'bg-icon-default enabled:hover:bg-icon-default-hover enabled:active:bg-icon-default-pressed'
+      : 'bg-default enabled:hover:bg-default-hover enabled:active:bg-default-pressed';
     let baseBorder = 'border-default';
     if (isSelected) {
       baseBorder = 'border-icon-default';

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.types.ts
@@ -21,7 +21,8 @@ export type CheckboxProps = Omit<
     labelProps?: Omit<Partial<TextProps>, 'children'>;
 
     /**
-     * Optional props passed to the input element.
+     * Optional props passed to the native input element (the visible control).
+     * Prefer putting test ids here — the input is Selenium-visible and clickable.
      */
     inputProps?: Omit<
       ComponentProps<'input'>,
@@ -31,7 +32,8 @@ export type CheckboxProps = Omit<
     };
 
     /**
-     * Optional props passed to the container div wrapping the checkbox icon.
+     * Optional props passed to the relative wrapper around the input and check icon.
+     * Visual appearance (border, background) is on the input via `inputProps`.
      */
     checkboxContainerProps?: (Omit<ComponentProps<'div'>, 'children'> & {
       className?: string;

--- a/packages/design-system-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/design-system-react/src/components/Checkbox/Checkbox.types.ts
@@ -33,7 +33,6 @@ export type CheckboxProps = Omit<
 
     /**
      * Optional props passed to the relative wrapper around the input and check icon.
-     * Visual appearance (border, background) is on the input via `inputProps`.
      */
     checkboxContainerProps?: (Omit<ComponentProps<'div'>, 'children'> & {
       className?: string;

--- a/packages/design-system-react/src/components/Checkbox/README.mdx
+++ b/packages/design-system-react/src/components/Checkbox/README.mdx
@@ -234,7 +234,7 @@ Optional props passed to the native input element (the visible checkbox control)
 
 ### `checkboxContainerProps`
 
-Optional props passed to the relative wrapper around the input and check icon. Visual appearance (border, background) lives on the input — use `inputProps.className` to override those styles.
+Optional props passed to the relative wrapper around the input and check icon.
 
 <table>
   <thead>

--- a/packages/design-system-react/src/components/Checkbox/README.mdx
+++ b/packages/design-system-react/src/components/Checkbox/README.mdx
@@ -209,7 +209,7 @@ Optional props to be passed to the label's Text component.
 
 ### `inputProps`
 
-Optional props passed to the input element. This allows you to pass additional attributes like data-testid, aria-describedby, etc.
+Optional props passed to the native input element (the visible checkbox control). Prefer putting `data-testid` here — the input is the interactive, Selenium-visible target for clicks and disabled checks.
 
 <table>
   <thead>
@@ -234,7 +234,7 @@ Optional props passed to the input element. This allows you to pass additional a
 
 ### `checkboxContainerProps`
 
-Optional props passed to the container div wrapping the checkbox icon.
+Optional props passed to the relative wrapper around the input and check icon. Visual appearance (border, background) lives on the input — use `inputProps.className` to override those styles.
 
 <table>
   <thead>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

MetaMask Extension Selenium E2E treats `opacity: 0` inputs as not displayed, so `data-testid` on Checkbox `inputProps` fails `clickElement` / `findClickableElement` even though the control works for users.

This aligns Checkbox with the component-library model: the native `<input>` is the visible control (`appearance-none` + border/background), and the check icon is a `pointer-events-none` overlay. One test id on the input is Selenium-visible, clickable, and carries `disabled`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open Storybook → React Components → Checkbox
2. Confirm unchecked / checked / disabled / invalid / focus styles look correct
3. Confirm clicking the box and the label toggles selection
4. Confirm keyboard Tab focuses the input and Enter toggles

## **Screenshots/Recordings**

### **Before**

Native input used `opacity-0` overlay; Selenium `isDisplayed()` returned false for `inputProps` test ids.





https://github.com/user-attachments/assets/f53224b4-3f2a-4eb8-badf-f49f7b69451e



### **After**

Native input is the visible styled control; icon overlays with `pointer-events-none`.

https://github.com/user-attachments/assets/61ef9171-101c-417f-ab56-403f1f5a14dc

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)