### PR TITLE
Release 59.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.1]
+
 ### Uncategorized
 
 - fix: Align swipe dismiss constants and finalize handling ([#1427](https://github.com/MetaMask/metamask-design-system/pull/1427))
@@ -663,7 +665,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.1...HEAD
+[0.39.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.0...@metamask/design-system-react-native@0.39.1
 [0.39.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.1...@metamask/design-system-react-native@0.39.0
 [0.38.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.0...@metamask/design-system-react-native@0.38.1
 [0.38.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.37.0...@metamask/design-system-react-native@0.38.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.39.1]
 
-### Uncategorized
+### Fixed
 
-- fix: Align swipe dismiss constants and finalize handling ([#1427](https://github.com/MetaMask/metamask-design-system/pull/1427))
+- Fixed `Toast` swipe-to-dismiss so a pan that fails after activation (for example when horizontal movement exceeds the fail offset) springs back to its visible position and resumes auto-dismiss instead of staying mid-offset ([#1427](https://github.com/MetaMask/metamask-design-system/pull/1427))
 
 ## [0.39.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: Align swipe dismiss constants and finalize handling ([#1427](https://github.com/MetaMask/metamask-design-system/pull/1427))
+
 ## [0.39.0]
 
 ### Added

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.2]
+
 ### Uncategorized
 
 - fix: make Checkbox native input Selenium-visible ([#1437](https://github.com/MetaMask/metamask-design-system/pull/1437))
@@ -459,7 +461,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.2...HEAD
+[0.35.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.1...@metamask/design-system-react@0.35.2
 [0.35.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.0...@metamask/design-system-react@0.35.1
 [0.35.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.34.0...@metamask/design-system-react@0.35.0
 [0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.33.0...@metamask/design-system-react@0.34.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: make Checkbox native input Selenium-visible ([#1437](https://github.com/MetaMask/metamask-design-system/pull/1437))
+
 ## [0.35.1]
 
 ### Fixed

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.2]
 
-### Uncategorized
+### Fixed
 
-- fix: make Checkbox native input Selenium-visible ([#1437](https://github.com/MetaMask/metamask-design-system/pull/1437))
+- Fixed `Checkbox` so the native `<input>` is the visible, clickable control instead of an `opacity-0` overlay; use `inputProps` for `data-testid` so Selenium E2E tests can find and click the control ([#1437](https://github.com/MetaMask/metamask-design-system/pull/1437))
 
 ## [0.35.1]
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Release 59.0.0

Patch release with Checkbox E2E visibility fix for React web and Toast swipe-to-dismiss reliability fix for React Native.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.32.0**
- `@metamask/design-system-react`: **0.35.2**
- `@metamask/design-system-react-native`: **0.39.1**
- `@metamask/design-tokens`: **8.7.0**

### 🌐 React Web Updates (0.35.2)

#### Fixed

- Fixed `Checkbox` so the native `<input>` is the visible, clickable control instead of an `opacity-0` overlay; use `inputProps` for `data-testid` so Selenium E2E tests can find and click the control ([#1437](https://github.com/MetaMask/metamask-design-system/pull/1437))

### 📱 React Native Updates (0.39.1)

#### Fixed

- Fixed `Toast` swipe-to-dismiss so a pan that fails after activation (for example when horizontal movement exceeds the fail offset) springs back to its visible position and resumes auto-dismiss instead of staying mid-offset ([#1427](https://github.com/MetaMask/metamask-design-system/pull/1427))

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: No changes (0.32.0)
  - [x] design-system-react: Patch (0.35.1 → 0.35.2) - Bug fix
  - [x] design-system-react-native: Patch (0.39.0 → 0.39.1) - Bug fix
  - [x] design-tokens: No changes (8.7.0)
- [x] No breaking changes in this release
- [x] All changes accounted for in changelogs

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] PR title is exactly `Release 59.0.0` (no `chore:` prefix)
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

## Merge instructions

**Squash & merge** and confirm the final commit message is exactly:

```
Release 59.0.0
```

Do **not** use `chore: Release 59.0.0` or any other prefix.

Made with [Cursor](https://cursor.com)