### PR TITLE
chore: promote pure black OLED values into canonical darkTheme

### DIFF
--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Promoted pure black (OLED) color values into canonical `darkTheme` / dark CSS tokens so default dark mode matches `pureBlackDarkTheme` ([TMCU-987](https://consensyssoftware.atlassian.net/browse/TMCU-987))
+- Promoted pure black (OLED) color values into canonical `darkTheme` / dark CSS tokens so default dark mode matches `pureBlackDarkTheme`; `background.default` uses brand `black` ([TMCU-987](https://consensyssoftware.atlassian.net/browse/TMCU-987))
 
 ## [8.7.0]
 

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Promoted pure black (OLED) color values into canonical `darkTheme` / dark CSS tokens so default dark mode matches `pureBlackDarkTheme` ([TMCU-987](https://consensyssoftware.atlassian.net/browse/TMCU-987))
+
 ## [8.7.0]
 
 ### Added

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Promoted pure black (OLED) color values into canonical `darkTheme` / dark CSS tokens so default dark mode matches `pureBlackDarkTheme`; `background.default` uses brand `black` ([TMCU-987](https://consensyssoftware.atlassian.net/browse/TMCU-987))
-
 ## [8.7.0]
 
 ### Added

--- a/packages/design-tokens/src/css/dark-theme-colors.css
+++ b/packages/design-tokens/src/css/dark-theme-colors.css
@@ -10,7 +10,7 @@
   /* Background default should be the darkest shade, 0 elevation.
   Section is +1 elevation, subsection is +2 elevation.
   Alternative should be deprecated. */
-  --color-background-default: #000000;
+  --color-background-default: var(--brand-colors-black);
   --color-background-section: #18181b;
   --color-background-subsection: #222226;
   --color-background-alternative: #0d0d0f;

--- a/packages/design-tokens/src/css/dark-theme-colors.css
+++ b/packages/design-tokens/src/css/dark-theme-colors.css
@@ -2,6 +2,9 @@
  * Dark Theme Colors
  *
  * Canonical dark theme values match pure black (OLED) surfaces.
+ *
+ * TODO(TMCU-987): Remove the provisional note below once PureBlackProvider,
+ * pureBlackDarkTheme overrides, and pure-black-dark-theme-colors.css are deleted.
  * Provisional `[data-pure-black]` overrides remain in
  * `pure-black-dark-theme-colors.css` until client providers are removed.
  */

--- a/packages/design-tokens/src/css/dark-theme-colors.css
+++ b/packages/design-tokens/src/css/dark-theme-colors.css
@@ -1,59 +1,56 @@
 /**
  * Dark Theme Colors
+ *
+ * Canonical dark theme values match pure black (OLED) surfaces.
+ * Provisional `[data-pure-black]` overrides remain in
+ * `pure-black-dark-theme-colors.css` until client providers are removed.
  */
 [data-theme='dark'],
 .dark {
   /* Background default should be the darkest shade, 0 elevation.
   Section is +1 elevation, subsection is +2 elevation.
   Alternative should be deprecated. */
-  --color-background-default: var(--brand-colors-grey-grey900);
-  --color-background-section: var(--brand-colors-grey-grey800);
-  --color-background-subsection: var(--brand-colors-grey-grey700);
-  --color-background-alternative: var(--brand-colors-grey-grey1000);
+  --color-background-default: #000000;
+  --color-background-section: #18181b;
+  --color-background-subsection: #222226;
+  --color-background-alternative: #0d0d0f;
 
   /* Applied to interactive elements, such as buttons.
-  For dark mode, we apply pure white with 4% opacity so these
-  tokens inherit the background hue of 264.5. */
-  --color-background-muted: #ffffff0a;
-  --color-background-muted-hover: #ffffff14;
-  --color-background-muted-pressed: #ffffff1f;
+  Cool-tinted white opacities so muted surfaces inherit the OLED hue. */
+  --color-background-muted: #e2e2ff1b;
+  --color-background-muted-hover: #e2e2ff26;
+  --color-background-muted-pressed: #e2e2ff30;
 
   /* Ensures visual consistency with section and subsection. */
-  --color-background-default-hover: var(--brand-colors-grey-grey800);
-  --color-background-default-pressed: var(--brand-colors-grey-grey700);
+  --color-background-default-hover: #18181b;
+  --color-background-default-pressed: #222226;
 
   /* Hover state surface for background/alternative (#0d0d0e) */
   --color-background-alternative-hover: #0d0d0e;
   --color-background-alternative-pressed: #161617;
 
-  /* These have opacities of pure white for general usage. 
-  We set 8% for hover and 12% for pressed so these tokens pick up
-  background hues and are consistent with +1 and +2 elevations.*/
-  --color-background-hover: #ffffff0a;
-  --color-background-pressed: #ffffff1f;
+  /* General purpose hover / pressed tints. */
+  --color-background-hover: #e2e2ff1b;
+  --color-background-pressed: #e2e2ff30;
 
-  /* These are our content colors. 
-  Contrast ratio of alternative: 7.4 on default, 8.5 on section. 
-  Contrast ratio of muted: 2.0 on default, 1.8 on section.*/
+  /* These are our content colors. */
   --color-text-default: var(--brand-colors-grey-grey000);
   --color-text-alternative: var(--brand-colors-grey-grey300);
-  --color-text-muted: var(--brand-colors-grey-grey600);
+  --color-text-muted: var(--brand-colors-grey-grey500);
 
   --color-icon-default: var(--brand-colors-grey-grey000);
   --color-icon-default-hover: #f0f0f0;
   --color-icon-default-pressed: #d0d0d0;
 
   --color-icon-alternative: var(--brand-colors-grey-grey300);
-  --color-icon-muted: var(--brand-colors-grey-grey600);
-  --color-icon-inverse: var(--brand-colors-grey-grey900);
+  --color-icon-muted: var(--brand-colors-grey-grey500);
+  --color-icon-inverse: #0d0d0f;
 
-  /* Contrast of border-default: 3:3 on bg-default, 3.0 on section.
-  We use 8% opacify of pure white for border-muted so it maintains
-  sufficient contrast on bg-default and bg-section.*/
+  /* Contrast of border-default: 3:3 on bg-default, 3.0 on section. */
   --color-border-default: var(--brand-colors-grey-grey500);
-  --color-border-muted: #ffffff14;
+  --color-border-muted: #e2e2ff26;
 
-  /* Derived from the same hue as bg-default, 264.5, for visual
+  /* Derived from the same hue as bg-default for visual
   consistency. Ensures we don't have too much "red".
   Opacities are 72% and 84% for default and alternative. */
   --color-overlay-default: #030304b8;
@@ -66,8 +63,8 @@
   --color-primary-alternative: var(--brand-colors-blue-blue200);
   /* Muted color for primary semantic elements (#8b99ff26) */
   --color-primary-muted: #8b99ff26;
-  /* For elements placed on top of primary/default (#121314) */
-  --color-primary-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of primary/default (#0d0d0f) */
+  --color-primary-inverse: #0d0d0f;
   /* Hover state surface for primary/default (#9eaaff) */
   --color-primary-default-hover: #9eaaff;
   /* Pressed state surface for primary/default (#c7ceff) */
@@ -82,8 +79,8 @@
   --color-error-alternative: var(--brand-colors-red-red200);
   /* Muted color for error semantic (#ff758426) */
   --color-error-muted: #ff758426;
-  /* For elements placed on top of error/default (#121314) */
-  --color-error-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of error/default (#0d0d0f) */
+  --color-error-inverse: #0d0d0f;
   /* Hover state surface for error/default (#ff8a96) */
   --color-error-default-hover: #ff8a96;
   /* Pressed state surface for error/default (#ffb2bb) */
@@ -96,8 +93,8 @@
   --color-warning-default: var(--brand-colors-yellow-yellow200);
   /* Muted color option for warning semantic (#f0b03426) */
   --color-warning-muted: #f0b03426;
-  /* For elements placed on top of warning/default (#121314) */
-  --color-warning-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of warning/default (#0d0d0f) */
+  --color-warning-inverse: #0d0d0f;
   /* Hover state surface for warning/default (#f3be59) */
   --color-warning-default-hover: #f3be59;
   /* Pressed state surface for warning/default (#f6cd7f) */
@@ -110,8 +107,8 @@
   --color-success-default: var(--brand-colors-lime-lime100);
   /* Muted color for positive semantic (#baf24a26) */
   --color-success-muted: #baf24a26;
-  /* For elements placed on top of success/default (#121314) */
-  --color-success-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of success/default (#0d0d0f) */
+  --color-success-inverse: #0d0d0f;
   /* Hover state surface for success/default (#c9f570) */
   --color-success-default-hover: #c9f570;
   /* Pressed state surface for success/default (#d7f796) */
@@ -124,8 +121,8 @@
   --color-info-default: var(--brand-colors-blue-blue300);
   /* Muted color for informational semantic (#8b99ff26) */
   --color-info-muted: #8b99ff26;
-  /* For elements placed on top of info/default (#121314) */
-  --color-info-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of info/default (#0d0d0f) */
+  --color-info-inverse: #0d0d0f;
   /* Expressive color in light orange (#ffa680) */
   --color-accent01-light: var(--brand-colors-orange-orange200);
   /* Expressive color in orange (#ff5c16) */
@@ -152,8 +149,8 @@
   --color-accent04-dark: var(--brand-colors-indigo-indigo800);
   /* For Flask primary accent color (#d27dff) */
   --color-flask-default: var(--brand-colors-purple-purple300);
-  /* For elements placed on top of flask/default (#121314) */
-  --color-flask-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of flask/default (#0d0d0f) */
+  --color-flask-inverse: #0d0d0f;
   /* For neutral drop shadow color (black-40%) */
   --color-shadow-default: #00000066;
   /* For primary drop shadow color (#8b99ff33) */

--- a/packages/design-tokens/src/css/darkTheme.test.ts
+++ b/packages/design-tokens/src/css/darkTheme.test.ts
@@ -22,6 +22,9 @@ describe('Dark Theme Colors CSS', () => {
             const shade: string | undefined = parts[1];
             if (color && shade) {
               cssValue = `var(--brand-colors-${color}-${color}${shade})`;
+            } else if (color && !shade) {
+              // Shade-less brand tokens (e.g. black, white)
+              cssValue = `var(--brand-colors-${color})`;
             } else {
               throw new Error(`Invalid color or shade: ${value as string}`);
             }

--- a/packages/design-tokens/src/css/pure-black-dark-theme-colors.css
+++ b/packages/design-tokens/src/css/pure-black-dark-theme-colors.css
@@ -14,7 +14,7 @@
 .dark [data-pure-black='true'],
 [data-pure-black='true'] .dark,
 [data-theme='dark'] [data-pure-black='true'] .dark {
-  --color-background-default: #000000;
+  --color-background-default: var(--brand-colors-black);
   --color-background-alternative: #0d0d0f;
   --color-background-section: #18181b;
   --color-background-subsection: #222226;

--- a/packages/design-tokens/src/css/pure-black-dark-theme-colors.css
+++ b/packages/design-tokens/src/css/pure-black-dark-theme-colors.css
@@ -7,6 +7,10 @@
  * Canonical: `[data-theme='dark'][data-pure-black='true']` on the document root
  * (extension `setTheme`, Storybook document sync). Descendant selectors support
  * scoped wrappers (e.g. Storybook "Both" mode side-by-side previews).
+ *
+ * TODO(TMCU-987): Delete this file (and its import) once clients remove
+ * PureBlackProvider / data-pure-black wiring. Values are already folded into
+ * dark-theme-colors.css.
  */
 [data-theme='dark'][data-pure-black='true'],
 .dark[data-pure-black='true'],

--- a/packages/design-tokens/src/figma/darkTheme.json
+++ b/packages/design-tokens/src/figma/darkTheme.json
@@ -1,7 +1,7 @@
 {
   "background": {
     "default": {
-      "value": "#000000",
+      "value": "{black}",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For default neutral surface."

--- a/packages/design-tokens/src/figma/darkTheme.json
+++ b/packages/design-tokens/src/figma/darkTheme.json
@@ -1,43 +1,43 @@
 {
   "background": {
     "default": {
-      "value": "{grey.900}",
+      "value": "#000000",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For default neutral surface."
     },
     "alternative": {
-      "value": "{grey.1000}",
+      "value": "#0d0d0f",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For sunken neutral surface below background/default."
     },
     "section": {
-      "value": "{grey.800}",
+      "value": "#18181b",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For section bg usually over background/default."
     },
     "subsection": {
-      "value": "{grey.700}",
+      "value": "#222226",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For subsection bg usually over background/section."
     },
     "muted": {
-      "value": "#ffffff0a",
+      "value": "#e2e2ff1b",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For muted neutral surface."
     },
     "default-hover": {
-      "value": "{grey.800}",
+      "value": "#18181b",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Hover state surface for background/default."
     },
     "default-pressed": {
-      "value": "{grey.700}",
+      "value": "#222226",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Pressed state surface for background/default."
@@ -55,25 +55,25 @@
       "description": "Pressed state surface for background/alternative."
     },
     "muted-hover": {
-      "value": "#ffffff14",
+      "value": "#e2e2ff26",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Hover state surface for background/muted."
     },
     "muted-pressed": {
-      "value": "#ffffff1f",
+      "value": "#e2e2ff30",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Pressed state surface for background/muted."
     },
     "hover": {
-      "value": "#ffffff0a",
+      "value": "#e2e2ff1b",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "General purpose hover state tint."
     },
     "pressed": {
-      "value": "#ffffff1f",
+      "value": "#e2e2ff30",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "General purpose pressed state tint."
@@ -93,7 +93,7 @@
       "description": "Softer color for text."
     },
     "muted": {
-      "value": "{grey.600}",
+      "value": "{grey.500}",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Muted color for text (Not accessible)."
@@ -125,13 +125,13 @@
       "description": "Softer color for icons, following text/alternative."
     },
     "muted": {
-      "value": "{grey.600}",
+      "value": "{grey.500}",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Muted color for icons (Not accessible), following text/muted."
     },
     "inverse": {
-      "value": "{grey.900}",
+      "value": "#0d0d0f",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For elements placed on top of icon.default fill."
@@ -145,7 +145,7 @@
       "description": "Default color for borders."
     },
     "muted": {
-      "value": "#ffffff14",
+      "value": "#e2e2ff26",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "Muted color for borders."
@@ -191,7 +191,7 @@
       "description": "Muted color for primary semantic elements."
     },
     "inverse": {
-      "value": "{grey.900}",
+      "value": "#0d0d0f",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For elements placed on top of primary/default fill."
@@ -241,7 +241,7 @@
       "description": "Muted color for error semantic."
     },
     "inverse": {
-      "value": "{grey.900}",
+      "value": "#0d0d0f",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For elements placed on top of error/default fill."
@@ -285,7 +285,7 @@
       "description": "Muted color option for warning semantic."
     },
     "inverse": {
-      "value": "{grey.900}",
+      "value": "#0d0d0f",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For elements placed on top of warning/default fill."
@@ -329,7 +329,7 @@
       "description": "Muted color for positive semantic."
     },
     "inverse": {
-      "value": "{grey.900}",
+      "value": "#0d0d0f",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For elements placed on top of success/default fill."
@@ -373,7 +373,7 @@
       "description": "Muted color for informational semantic."
     },
     "inverse": {
-      "value": "{grey.900}",
+      "value": "#0d0d0f",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For elements placed on top of info/default fill."
@@ -467,7 +467,7 @@
       "description": "For Flask primary accent color."
     },
     "inverse": {
-      "value": "{grey.900}",
+      "value": "#0d0d0f",
       "type": "color",
       "parent": "Theme Colors/Dark mode",
       "description": "For elements placed on top of flask/default."

--- a/packages/design-tokens/src/js/themes/darkTheme/colors.test.ts
+++ b/packages/design-tokens/src/js/themes/darkTheme/colors.test.ts
@@ -31,10 +31,13 @@ function resolveColorReferences(
       const match = theme[key].match(/\{(.+?)\}/u);
       if (match) {
         const [colorFamily, shade] = match[1].split('.');
-        if (colors[colorFamily]?.[shade]) {
+        if (shade && colors[colorFamily]?.[shade]) {
           theme[key] = colors[colorFamily][shade].value.toLowerCase();
-        } else if (rootTheme?.[colorFamily]?.[shade]?.value) {
+        } else if (shade && rootTheme?.[colorFamily]?.[shade]?.value) {
           theme[key] = rootTheme[colorFamily][shade].value.toLowerCase();
+        } else if (!shade && colors[colorFamily]?.value) {
+          // Shade-less brand tokens (e.g. black, white)
+          theme[key] = colors[colorFamily].value.toLowerCase();
         }
       }
     } else if (typeof theme[key] === 'string' && theme[key].startsWith('#')) {

--- a/packages/design-tokens/src/js/themes/darkTheme/colors.ts
+++ b/packages/design-tokens/src/js/themes/darkTheme/colors.ts
@@ -3,40 +3,40 @@ import type { ThemeColors } from '../types';
 
 export const colors: ThemeColors = {
   background: {
-    /** For default neutral surface (#222325) */
-    default: brandColor.grey900,
-    /** For sunken neutral surface below background/default. (#121314) */
-    alternative: brandColor.grey1000,
-    /** For section bg usually over background/default (#31333A) */
-    section: brandColor.grey800,
-    /** For subsection bg usually over background/section (#222325) */
-    subsection: brandColor.grey700,
-    /** For muted neutral surface (#ffffff0a) */
-    muted: '#ffffff0a',
-    /** Hover state surface for background/default */
-    defaultHover: '#1c1d1f',
-    /** Pressed state surface for background/default */
-    defaultPressed: '#252628',
+    /** For default neutral surface (#000000) */
+    default: '#000000',
+    /** For sunken neutral surface below background/default. (#0d0d0f) */
+    alternative: '#0d0d0f',
+    /** For section bg usually over background/default (#18181b) */
+    section: '#18181b',
+    /** For subsection bg usually over background/section (#222226) */
+    subsection: '#222226',
+    /** For muted neutral surface (#e2e2ff1b) */
+    muted: '#e2e2ff1b',
+    /** Hover state surface for background/default (#18181b) */
+    defaultHover: '#18181b',
+    /** Pressed state surface for background/default (#222226) */
+    defaultPressed: '#222226',
     /** Hover state surface for background/alternative (#0d0d0e) */
     alternativeHover: '#0d0d0e',
     /** Pressed state surface for background/alternative (#161617) */
     alternativePressed: '#161617',
-    /** Hover state surface for background/muted (#ffffff14) */
-    mutedHover: '#ffffff14',
-    /** Pressed state surface for background/muted (#ffffff1f) */
-    mutedPressed: '#ffffff1f',
-    /** General purpose hover state tint (#ffffff0a) */
-    hover: '#ffffff0a',
-    /** General purpose pressed state tint (#ffffff1f) */
-    pressed: '#ffffff1f',
+    /** Hover state surface for background/muted (#e2e2ff26) */
+    mutedHover: '#e2e2ff26',
+    /** Pressed state surface for background/muted (#e2e2ff30) */
+    mutedPressed: '#e2e2ff30',
+    /** General purpose hover state tint (#e2e2ff1b) */
+    hover: '#e2e2ff1b',
+    /** General purpose pressed state tint (#e2e2ff30) */
+    pressed: '#e2e2ff30',
   },
   text: {
     /** Default color for text (#FFFFFF) */
     default: brandColor.grey000,
     /** Softer color for text (#858B9A) */
     alternative: brandColor.grey300,
-    /** Muted color for text (Not accessible) (#686E7D) */
-    muted: brandColor.grey600,
+    /** Muted color for text (Not accessible) (#66676A) */
+    muted: brandColor.grey500,
   },
   icon: {
     /** Default color for icons (#FFFFFF) */
@@ -47,16 +47,16 @@ export const colors: ThemeColors = {
     defaultPressed: '#d0d0d0',
     /** Softer color for icons (#858B9A) */
     alternative: brandColor.grey300,
-    /** Muted color for icons (Not accessible) (#686E7D) */
-    muted: brandColor.grey600,
-    /** For elements placed on top of icon.default fill (#121314) */
-    inverse: brandColor.grey900,
+    /** Muted color for icons (Not accessible) (#66676A) */
+    muted: brandColor.grey500,
+    /** For elements placed on top of icon.default fill (#0d0d0f) */
+    inverse: '#0d0d0f',
   },
   border: {
     /** Default color for borders */
     default: brandColor.grey500,
-    /** Muted color for borders (#ffffff14) */
-    muted: '#ffffff14',
+    /** Muted color for borders (#e2e2ff26) */
+    muted: '#e2e2ff26',
   },
   overlay: {
     /** Default color for overlays (scrim) (#030304b8) */
@@ -73,8 +73,8 @@ export const colors: ThemeColors = {
     alternative: brandColor.blue200,
     /** Muted color for primary semantic elements (#8b99ff26) */
     muted: '#8b99ff26',
-    /** For elements placed on top of primary/default (#121314) */
-    inverse: brandColor.grey900,
+    /** For elements placed on top of primary/default (#0d0d0f) */
+    inverse: '#0d0d0f',
     /** Hover state surface for primary/default (#9eaaff) */
     defaultHover: '#9eaaff',
     /** Pressed state surface for primary/default (#c7ceff) */
@@ -91,8 +91,8 @@ export const colors: ThemeColors = {
     alternative: brandColor.red200,
     /** Muted color for error semantic (#FF758426) */
     muted: '#ff758426',
-    /** For elements placed on top of error/default fill (#121314) */
-    inverse: brandColor.grey900,
+    /** For elements placed on top of error/default fill (#0d0d0f) */
+    inverse: '#0d0d0f',
 
     /** Hover state surface for error/default (#ff8a96) */
     defaultHover: '#ff8a96',
@@ -109,8 +109,8 @@ export const colors: ThemeColors = {
     default: brandColor.yellow200,
     /** Muted color option for warning semantic (#f0b03426) */
     muted: '#f0b03426',
-    /** For elements placed on top of warning/default fill (#121314) */
-    inverse: brandColor.grey900,
+    /** For elements placed on top of warning/default fill (#0d0d0f) */
+    inverse: '#0d0d0f',
     /** Hover state surface for warning/default (#f3be59) */
     defaultHover: '#f3be59',
     /** Pressed state surface for warning/default (#f6cd7f) */
@@ -126,8 +126,8 @@ export const colors: ThemeColors = {
     default: brandColor.lime100,
     /** Muted color for positive semantic (#baf24a26) */
     muted: '#baf24a26',
-    /** For elements placed on top of success/default fill (#121314) */
-    inverse: brandColor.grey900,
+    /** For elements placed on top of success/default fill (#0d0d0f) */
+    inverse: '#0d0d0f',
     /** Hover state surface for success/default (#c9f570) */
     defaultHover: '#c9f570',
     /** Pressed state surface for success/default (#d7f796) */
@@ -143,8 +143,8 @@ export const colors: ThemeColors = {
     default: brandColor.blue300,
     /** Muted color for informational semantic (#8b99ff26) */
     muted: '#8b99ff26',
-    /** For elements placed on top of info/default (#121314) */
-    inverse: brandColor.grey900,
+    /** For elements placed on top of info/default (#0d0d0f) */
+    inverse: '#0d0d0f',
   },
   accent01: {
     /** Expressive color in light orange (#ffa680) */
@@ -181,8 +181,8 @@ export const colors: ThemeColors = {
   flask: {
     /** For Flask primary accent color (#D27DFF) */
     default: brandColor.purple300,
-    /** For elements placed on top of flask/default fill (#121314) */
-    inverse: brandColor.grey900,
+    /** For elements placed on top of flask/default fill (#0d0d0f) */
+    inverse: '#0d0d0f',
   },
   shadow: {
     /** For neutral drop shadow color (#00000066) */

--- a/packages/design-tokens/src/js/themes/darkTheme/colors.ts
+++ b/packages/design-tokens/src/js/themes/darkTheme/colors.ts
@@ -4,7 +4,7 @@ import type { ThemeColors } from '../types';
 export const colors: ThemeColors = {
   background: {
     /** For default neutral surface (#000000) */
-    default: '#000000',
+    default: brandColor.black,
     /** For sunken neutral surface below background/default. (#0d0d0f) */
     alternative: '#0d0d0f',
     /** For section bg usually over background/default (#18181b) */

--- a/packages/design-tokens/src/js/themes/pureBlackDarkTheme/colorOverrides.ts
+++ b/packages/design-tokens/src/js/themes/pureBlackDarkTheme/colorOverrides.ts
@@ -6,8 +6,9 @@ import type { DeepPartial } from '../utils/deepMerge';
  * Token deltas applied on top of darkTheme to produce pureBlackDarkTheme.
  * Only values that differ from grey dark are listed here.
  *
- * Note: canonical darkTheme now uses these same OLED values. This override
- * object remains until client PureBlack providers are removed (TMCU-987).
+ * TODO(TMCU-987): Remove this file (and pureBlackDarkTheme / resolveDarkTheme)
+ * once clients remove PureBlackProvider. Canonical darkTheme already uses these
+ * same OLED values; this override object is provisional scaffolding only.
  */
 export const pureBlackDarkColorOverrides = {
   background: {

--- a/packages/design-tokens/src/js/themes/pureBlackDarkTheme/colorOverrides.ts
+++ b/packages/design-tokens/src/js/themes/pureBlackDarkTheme/colorOverrides.ts
@@ -11,7 +11,7 @@ import type { DeepPartial } from '../utils/deepMerge';
  */
 export const pureBlackDarkColorOverrides = {
   background: {
-    default: '#000000',
+    default: brandColor.black,
     alternative: '#0d0d0f',
     section: '#18181b',
     subsection: '#222226',

--- a/packages/design-tokens/src/js/themes/pureBlackDarkTheme/colorOverrides.ts
+++ b/packages/design-tokens/src/js/themes/pureBlackDarkTheme/colorOverrides.ts
@@ -5,6 +5,9 @@ import type { DeepPartial } from '../utils/deepMerge';
 /**
  * Token deltas applied on top of darkTheme to produce pureBlackDarkTheme.
  * Only values that differ from grey dark are listed here.
+ *
+ * Note: canonical darkTheme now uses these same OLED values. This override
+ * object remains until client PureBlack providers are removed (TMCU-987).
  */
 export const pureBlackDarkColorOverrides = {
   background: {

--- a/packages/design-tokens/src/tailwind/theme.css
+++ b/packages/design-tokens/src/tailwind/theme.css
@@ -269,60 +269,55 @@
 
 /**
  * Dark Theme Colors
+ *
+ * Canonical dark theme values match pure black (OLED) surfaces.
  */
 [data-theme='dark'],
 .dark {
   /* Background default should be the darkest shade, 0 elevation.
   Section is +1 elevation, subsection is +2 elevation.
   Alternative should be deprecated. */
-  --color-background-default: var(--brand-colors-grey-grey900);
-  --color-background-section: var(--brand-colors-grey-grey800);
-  --color-background-subsection: var(--brand-colors-grey-grey700);
-  --color-background-alternative: var(--brand-colors-grey-grey1000);
+  --color-background-default: #000000;
+  --color-background-section: #18181b;
+  --color-background-subsection: #222226;
+  --color-background-alternative: #0d0d0f;
 
   /* Applied to interactive elements, such as buttons.
-  For dark mode, we apply pure white with 4% opacity so these
-  tokens inherit the background hue of 264.5. */
-  --color-background-muted: #ffffff0a;
-  --color-background-muted-hover: #ffffff14;
-  --color-background-muted-pressed: #ffffff1f;
+  Cool-tinted white opacities so muted surfaces inherit the OLED hue. */
+  --color-background-muted: #e2e2ff1b;
+  --color-background-muted-hover: #e2e2ff26;
+  --color-background-muted-pressed: #e2e2ff30;
 
   /* Ensures visual consistency with section and subsection. */
-  --color-background-default-hover: var(--brand-colors-grey-grey800);
-  --color-background-default-pressed: var(--brand-colors-grey-grey700);
+  --color-background-default-hover: #18181b;
+  --color-background-default-pressed: #222226;
 
   /* Hover state surface for background/alternative (#0d0d0e) */
   --color-background-alternative-hover: #0d0d0e;
   --color-background-alternative-pressed: #161617;
 
-  /* These have opacities of pure white for general usage. 
-  We set 8% for hover and 12% for pressed so these tokens pick up
-  background hues and are consistent with +1 and +2 elevations.*/
-  --color-background-hover: #ffffff0a;
-  --color-background-pressed: #ffffff1f;
+  /* General purpose hover / pressed tints. */
+  --color-background-hover: #e2e2ff1b;
+  --color-background-pressed: #e2e2ff30;
 
-  /* These are our content colors. 
-  Contrast ratio of alternative: 7.4 on default, 8.5 on section. 
-  Contrast ratio of muted: 2.0 on default, 1.8 on section.*/
+  /* These are our content colors. */
   --color-text-default: var(--brand-colors-grey-grey000);
   --color-text-alternative: var(--brand-colors-grey-grey300);
-  --color-text-muted: var(--brand-colors-grey-grey600);
+  --color-text-muted: var(--brand-colors-grey-grey500);
 
   --color-icon-default: var(--brand-colors-grey-grey000);
   --color-icon-default-hover: #f0f0f0;
   --color-icon-default-pressed: #d0d0d0;
 
   --color-icon-alternative: var(--brand-colors-grey-grey300);
-  --color-icon-muted: var(--brand-colors-grey-grey600);
-  --color-icon-inverse: var(--brand-colors-grey-grey900);
+  --color-icon-muted: var(--brand-colors-grey-grey500);
+  --color-icon-inverse: #0d0d0f;
 
-  /* Contrast of border-default: 3:3 on bg-default, 3.0 on section.
-  We use 8% opacify of pure white for border-muted so it maintains
-  sufficient contrast on bg-default and bg-section.*/
+  /* Contrast of border-default: 3:3 on bg-default, 3.0 on section. */
   --color-border-default: var(--brand-colors-grey-grey500);
-  --color-border-muted: #ffffff14;
+  --color-border-muted: #e2e2ff26;
 
-  /* Derived from the same hue as bg-default, 264.5, for visual
+  /* Derived from the same hue as bg-default for visual
   consistency. Ensures we don't have too much "red".
   Opacities are 72% and 84% for default and alternative. */
   --color-overlay-default: #030304b8;
@@ -335,8 +330,8 @@
   --color-primary-alternative: var(--brand-colors-blue-blue200);
   /* Muted color for primary semantic elements (#8b99ff26) */
   --color-primary-muted: #8b99ff26;
-  /* For elements placed on top of primary/default (#121314) */
-  --color-primary-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of primary/default (#0d0d0f) */
+  --color-primary-inverse: #0d0d0f;
   /* Hover state surface for primary/default (#9eaaff) */
   --color-primary-default-hover: #9eaaff;
   /* Pressed state surface for primary/default (#c7ceff) */
@@ -351,8 +346,8 @@
   --color-error-alternative: var(--brand-colors-red-red200);
   /* Muted color for error semantic (#ff758426) */
   --color-error-muted: #ff758426;
-  /* For elements placed on top of error/default (#121314) */
-  --color-error-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of error/default (#0d0d0f) */
+  --color-error-inverse: #0d0d0f;
   /* Hover state surface for error/default (#ff8a96) */
   --color-error-default-hover: #ff8a96;
   /* Pressed state surface for error/default (#ffb2bb) */
@@ -365,8 +360,8 @@
   --color-warning-default: var(--brand-colors-yellow-yellow200);
   /* Muted color option for warning semantic (#f0b03426) */
   --color-warning-muted: #f0b03426;
-  /* For elements placed on top of warning/default (#121314) */
-  --color-warning-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of warning/default (#0d0d0f) */
+  --color-warning-inverse: #0d0d0f;
   /* Hover state surface for warning/default (#f3be59) */
   --color-warning-default-hover: #f3be59;
   /* Pressed state surface for warning/default (#f6cd7f) */
@@ -379,8 +374,8 @@
   --color-success-default: var(--brand-colors-lime-lime100);
   /* Muted color for positive semantic (#baf24a26) */
   --color-success-muted: #baf24a26;
-  /* For elements placed on top of success/default (#121314) */
-  --color-success-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of success/default (#0d0d0f) */
+  --color-success-inverse: #0d0d0f;
   /* Hover state surface for success/default (#c9f570) */
   --color-success-default-hover: #c9f570;
   /* Pressed state surface for success/default (#d7f796) */
@@ -393,8 +388,8 @@
   --color-info-default: var(--brand-colors-blue-blue300);
   /* Muted color for informational semantic (#8b99ff26) */
   --color-info-muted: #8b99ff26;
-  /* For elements placed on top of info/default (#121314) */
-  --color-info-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of info/default (#0d0d0f) */
+  --color-info-inverse: #0d0d0f;
   /* Expressive color in light orange (#ffa680) */
   --color-accent01-light: var(--brand-colors-orange-orange200);
   /* Expressive color in orange (#ff5c16) */
@@ -421,8 +416,8 @@
   --color-accent04-dark: var(--brand-colors-indigo-indigo800);
   /* For Flask primary accent color (#d27dff) */
   --color-flask-default: var(--brand-colors-purple-purple300);
-  /* For elements placed on top of flask/default (#121314) */
-  --color-flask-inverse: var(--brand-colors-grey-grey900);
+  /* For elements placed on top of flask/default (#0d0d0f) */
+  --color-flask-inverse: #0d0d0f;
   /* For neutral drop shadow color (black-40%) */
   --color-shadow-default: #00000066;
   /* For primary drop shadow color (#8b99ff33) */

--- a/packages/design-tokens/src/tailwind/theme.css
+++ b/packages/design-tokens/src/tailwind/theme.css
@@ -271,6 +271,9 @@
  * Dark Theme Colors
  *
  * Canonical dark theme values match pure black (OLED) surfaces.
+ *
+ * TODO(TMCU-987): Drop the OLED migration note above once PureBlackProvider and
+ * pure-black override files are removed in the follow-up cleanup.
  */
 [data-theme='dark'],
 .dark {

--- a/packages/design-tokens/src/tailwind/theme.css
+++ b/packages/design-tokens/src/tailwind/theme.css
@@ -277,7 +277,7 @@
   /* Background default should be the darkest shade, 0 elevation.
   Section is +1 elevation, subsection is +2 elevation.
   Alternative should be deprecated. */
-  --color-background-default: #000000;
+  --color-background-default: var(--brand-colors-black);
   --color-background-section: #18181b;
   --color-background-subsection: #222226;
   --color-background-alternative: #0d0d0f;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Pure black has shipped in the clients, so we no longer need a separate grey dark palette as the default. This PR promotes the `pureBlackDarkTheme` OLED color values into the canonical `darkTheme` sources (JS, CSS, Figma sync JSON, and Tailwind dark block) so default dark mode matches pure black.

`PureBlackProvider`, `resolveDarkTheme`, `pureBlackDarkTheme`, and `pure-black-dark-theme-colors.css` are intentionally left in place until clients remove provider wiring; those removals complete the remaining work on TMCU-987.

## **Related issues**

Fixes: [TMCU-987](https://consensyssoftware.atlassian.net/browse/TMCU-987) (token fold phase; provider/API removal follows client cleanup)

## **Manual testing steps**

1. Open Storybook React and set theme to Dark (with Pure black off).
2. Confirm background surfaces use OLED values (`#000000` default, elevated section/subsection, cool-tinted muted).
3. Toggle Pure black on and confirm colors do not change (overrides are now redundant with base dark).
4. Spot-check Storybook React Native dark / pure black backgrounds the same way.
5. Run `@metamask/design-tokens` tests and confirm they pass.

## **Screenshots/Recordings**

N/A — token value promotion; visual parity with existing pure black preview.

### **Before**

Grey dark theme (`grey900` default, white-opacity muted surfaces)

https://github.com/user-attachments/assets/8143d59c-8153-4b1a-9744-b226715aa1db

### **After**

OLED dark theme (`#000000` default, pure-black elevation / muted / inverse tokens)

https://github.com/user-attachments/assets/d6b55edb-2f60-4ffb-9c19-a9aab363afb9

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)