### PR TITLE
feat: add showCloseButton option to imperative toast API

### DIFF
--- a/packages/design-system-react-native/src/components/Toast/README.md
+++ b/packages/design-system-react-native/src/components/Toast/README.md
@@ -54,7 +54,7 @@ const Demo = () => {
 
 Call `toast.dismiss()` to dismiss the currently visible toast.
 
-Use `closeButtonProps` to access the close button element when you need to set a `testID` or override its accessibility label. With the `toast(...)` / `<Toaster />` flow the close button is always shown; for direct `<Toast />` rendering, provide `onClose` to render it.
+Use `closeButtonProps` to access the close button element when you need to set a `testID` or override its accessibility label. With the `toast(...)` / `<Toaster />` flow the close button is shown by default. Pass `showCloseButton: false` to hide it (swipe, auto-dismiss, and `toast.dismiss()` still work). For direct `<Toast />` rendering, provide `onClose` to render the close button.
 
 `toast(...)` and `toast.dismiss()` throw a descriptive error if called before `<Toaster />` is mounted.
 
@@ -134,6 +134,7 @@ toast({
 - `children`, `childrenWrapperProps` - Optional extra content rendered below the description.
 - `actionButtonLabel`, `actionButtonOnPress`, `actionButtonProps` - Optional action button content and handler.
 - `onClose` - Optional callback invoked when the close button is pressed. Use this for side effects, or to dismiss a direct-rendered `Toast`. A direct-rendered `Toast` only shows a close button when `onClose` is provided.
+- `showCloseButton` - Imperative `toast(...)` only. When `false`, hides the close button. Defaults to `true`.
 - `closeButtonProps` - Optional non-behavioral props merged onto the close `ButtonIcon` when it is rendered.
 - `startAccessory` - Optional leading accessory that overrides the severity icon.
 - `severity` - Optional semantic state used to choose the default icon. Defaults to `ToastSeverity.Default`, which shows no icon.

--- a/packages/design-system-react-native/src/components/Toast/Toast.stories.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toast.stories.tsx
@@ -131,3 +131,36 @@ export const ActionButtonOnPress: Story = {
     title: 'Privacy policy update',
   },
 };
+
+export const ShowCloseButton: Story = {
+  render: () => (
+    <>
+      <Box twClassName="gap-2">
+        <Button
+          onPress={() => {
+            toast({
+              description: 'showCloseButton defaults to true.',
+              severity: ToastSeverity.Success,
+              title: 'Close button visible',
+            });
+          }}
+        >
+          With close button
+        </Button>
+        <Button
+          onPress={() => {
+            toast({
+              description: 'Dismiss via swipe or auto-timeout.',
+              severity: ToastSeverity.Success,
+              showCloseButton: false,
+              title: 'Close button hidden',
+            });
+          }}
+        >
+          Without close button
+        </Button>
+      </Box>
+      <Toaster />
+    </>
+  ),
+};

--- a/packages/design-system-react-native/src/components/Toast/Toast.types.ts
+++ b/packages/design-system-react-native/src/components/Toast/Toast.types.ts
@@ -31,6 +31,12 @@ export type ToastSharedProps = Omit<BannerBaseProps, 'closeButtonProps'> & {
 export type ToastOptions = ToastSharedProps & {
   hasNoTimeout?: boolean;
   topOffset?: number;
+  /**
+   * When `false`, hides the close button on the imperative toast.
+   * Swipe-to-dismiss, auto-dismiss, and `toast.dismiss()` still work.
+   * Defaults to `true`.
+   */
+  showCloseButton?: boolean;
 };
 
 /**

--- a/packages/design-system-react-native/src/components/Toast/Toaster.test.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toaster.test.tsx
@@ -384,6 +384,22 @@ describe('Toaster', () => {
     expect(screen.queryByText('Close button test')).toBeNull();
   });
 
+  it('hides the close button when showCloseButton is false', async () => {
+    render(<Toaster ref={toasterRef} />);
+    await showToastAndWait(toasterRef, {
+      closeButtonProps: {
+        testID: 'dismiss-toast-button',
+      },
+      hasNoTimeout: true,
+      showCloseButton: false,
+      title: 'No close button',
+    });
+
+    expect(screen.getByText('No close button')).toBeDefined();
+    expect(screen.queryByTestId('dismiss-toast-button')).toBeNull();
+    expect(screen.queryByLabelText('Close toast')).toBeNull();
+  });
+
   it('cancels animation when replacing toast with hasNoTimeout false', async () => {
     render(<Toaster ref={toasterRef} />);
 

--- a/packages/design-system-react-native/src/components/Toast/Toaster.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toaster.tsx
@@ -59,6 +59,7 @@ const getToastProps = ({
   onClose: _onClose,
   topOffset: _topOffset,
   twClassName: _twClassName,
+  showCloseButton: _showCloseButton,
   ...toastProps
 }: ToastOptions): Omit<ToastProps, 'twClassName'> => toastProps;
 
@@ -365,14 +366,23 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
       return null;
     }
 
-    const { onClose: toastOnClose, twClassName: toastTwClassName } =
-      toastOptions;
+    const {
+      onClose: toastOnClose,
+      showCloseButton = true,
+      twClassName: toastTwClassName,
+    } = toastOptions;
     const toastProps = getToastProps(toastOptions);
     const { actionButtonLabel, actionButtonOnPress, ...restToastProps } =
       toastProps;
     const toastTwClassNames = [twClassName, toastTwClassName]
       .filter(Boolean)
       .join(' ');
+    const handleClose = showCloseButton
+      ? () => {
+          closeToast();
+          toastOnClose?.();
+        }
+      : undefined;
 
     const onAnimatedViewLayout = (e: LayoutChangeEvent) => {
       const { height } = e.nativeEvent.layout;
@@ -420,19 +430,13 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
               {...toastProps}
               actionButtonLabel={actionButtonLabel}
               actionButtonOnPress={actionButtonOnPress}
-              onClose={() => {
-                closeToast();
-                toastOnClose?.();
-              }}
+              onClose={handleClose}
               twClassName={toastTwClassNames}
             />
           ) : (
             <Toast
               {...restToastProps}
-              onClose={() => {
-                closeToast();
-                toastOnClose?.();
-              }}
+              onClose={handleClose}
               twClassName={toastTwClassNames}
             />
           )}

--- a/packages/design-system-react/src/components/Toast/README.mdx
+++ b/packages/design-system-react/src/components/Toast/README.mdx
@@ -62,7 +62,7 @@ const Demo = () => {
 
 Call `toast.dismiss()` to dismiss the currently visible toast.
 
-Use `closeButtonProps` to access the close button element when you need to set a `data-testid` or override its accessibility label. With the `toast(...)` / `<Toaster />` flow the close button is shown because `<Toaster />` wires `onClose` internally; for direct `<Toast />` rendering, provide `onClose` to render it.
+Use `closeButtonProps` to access the close button element when you need to set a `data-testid` or override its accessibility label. With the `toast(...)` / `<Toaster />` flow the close button is shown by default. Pass `showCloseButton: false` to hide it (auto-dismiss and `toast.dismiss()` still work). For direct `<Toast />` rendering, provide `onClose` to render the close button.
 
 If `toast(...)` is called before `<Toaster />` mounts, the latest toast renders after mount. If `toast.dismiss()` is called before mount, it clears the pending toast.
 
@@ -179,6 +179,7 @@ toast({
 - `children`, `childrenWrapperProps` - Optional extra content rendered below the description.
 - `actionButtonLabel`, `actionButtonOnClick`, `actionButtonProps` - Optional action button content and handler.
 - `onClose` - Optional callback invoked when the close button is clicked. Also renders the close button on direct `<Toast />`.
+- `showCloseButton` - Imperative `toast(...)` only. When `false`, hides the close button. Defaults to `true`.
 - `closeButtonProps` - Optional non-behavioural props merged onto the close `ButtonIcon` when it is rendered.
 - `startAccessory` - Optional leading accessory that overrides the severity icon.
 - `severity` - Optional semantic state used to choose the default icon. Defaults to `ToastSeverity.Default`, which shows no icon.

--- a/packages/design-system-react/src/components/Toast/Toast.types.ts
+++ b/packages/design-system-react/src/components/Toast/Toast.types.ts
@@ -46,6 +46,12 @@ export type ToastOptions = ToastProps & {
    * Defaults to false.
    */
   hasNoTimeout?: boolean;
+  /**
+   * When `false`, hides the close button on the imperative toast.
+   * Auto-dismiss and `toast.dismiss()` still work.
+   * Defaults to `true`.
+   */
+  showCloseButton?: boolean;
 };
 
 /**

--- a/packages/design-system-react/src/components/Toast/Toaster.test.tsx
+++ b/packages/design-system-react/src/components/Toast/Toaster.test.tsx
@@ -217,6 +217,25 @@ describe('Toaster', () => {
     expect(screen.queryByText('Closeable')).not.toBeInTheDocument();
   });
 
+  it('hides the close button when showCloseButton is false', async () => {
+    render(<Toaster ref={toasterRef} />);
+
+    await showToastAndFlush(toasterRef, {
+      closeButtonProps: {
+        'data-testid': 'dismiss-toast-button',
+      },
+      hasNoTimeout: true,
+      showCloseButton: false,
+      title: 'No close button',
+    });
+
+    expect(screen.getByText('No close button')).toBeInTheDocument();
+    expect(screen.queryByTestId('dismiss-toast-button')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /close toast/iu }),
+    ).not.toBeInTheDocument();
+  });
+
   it('replaces existing toast when showToast is called again', async () => {
     render(<Toaster ref={toasterRef} />);
 

--- a/packages/design-system-react/src/components/Toast/Toaster.test.tsx
+++ b/packages/design-system-react/src/components/Toast/Toaster.test.tsx
@@ -230,7 +230,9 @@ describe('Toaster', () => {
     });
 
     expect(screen.getByText('No close button')).toBeInTheDocument();
-    expect(screen.queryByTestId('dismiss-toast-button')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('dismiss-toast-button'),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: /close toast/iu }),
     ).not.toBeInTheDocument();

--- a/packages/design-system-react/src/components/Toast/Toaster.tsx
+++ b/packages/design-system-react/src/components/Toast/Toaster.tsx
@@ -57,6 +57,7 @@ const subscribeToToastStore = (listener: ToastStoreListener) => {
 
 const getToastProps = ({
   hasNoTimeout: _hasNoTimeout,
+  showCloseButton: _showCloseButton,
   ...toastProps
 }: ToastOptions): ToastProps => toastProps;
 
@@ -227,11 +228,18 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
       return null;
     }
 
+    const { showCloseButton = true } = toastOptions;
     const {
       onClose: toastOnClose,
       className: toastClassName,
       ...toastProps
     } = getToastProps(toastOptions);
+    const handleClose = showCloseButton
+      ? () => {
+          clearStoreToastOptions();
+          toastOnClose?.();
+        }
+      : undefined;
 
     return (
       <div
@@ -256,10 +264,7 @@ const ToasterComponent = forwardRef<ToasterRef, ToasterProps>(
           <Toast
             {...toastProps}
             className={toastClassName}
-            onClose={() => {
-              clearStoreToastOptions();
-              toastOnClose?.();
-            }}
+            onClose={handleClose}
           />
         </div>
       </div>


### PR DESCRIPTION
## **Description**

Mobile consumers need toasts without a close button (e.g. watchlist confirmations), but the imperative `toast(...)` API always wired `onClose` through `Toaster`, so the X could not be hidden.

This adds `showCloseButton?: boolean` to `ToastOptions` (default `true`) for both React and React Native. When `false`, `Toaster` omits `onClose` so the close button does not render; swipe (RN), auto-dismiss, and `toast.dismiss()` still work. Docs, RN Storybook (`ShowCloseButton`), and unit tests are updated.

### Visuals

For context, the legacy component-library toast has this behavior. This is the intended outcome. Currently, it cannot be recreated.

https://github.com/user-attachments/assets/88814f2a-0458-4ef9-824b-278a7501bde6


### API usage
The mobile repo always uses the imperative API `(toast(...) + <Toaster />)`. Direct `<Toast />` is not a substitute for that flow, so close-button visibility has to be controllable via `ToastOptions`.

<img width="553" height="213" alt="Screenshot 2026-08-12 at 9 59 21 PM" src="https://github.com/user-attachments/assets/78ef13ec-4751-4943-9308-435a061dd645" />



## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn storybook:ios` (or Android) and open **Components/Toast → ShowCloseButton**.
2. Tap **With close button** — confirm the X is visible and dismisses the toast.
3. Tap **Without close button** — confirm no X; dismiss via swipe and/or auto-timeout.
4. (Web) Confirm `toast({ showCloseButton: false, ... })` hides the close button while auto-dismiss / `toast.dismiss()` still work.

## **Screenshots/Recordings**

### **Before**

Toasts always show closed button when I tried to migrate it. 

https://github.com/user-attachments/assets/4c3ec8f4-9f9f-483b-8c54-9b44fec2c143

### **After**

https://github.com/user-attachments/assets/9e368065-b0d7-4469-8ab5-943bb6f8019d

Consumers should call this behavior this way:

<img width="463" height="152" alt="Screenshot 2026-08-12 at 10 04 53 PM" src="https://github.com/user-attachments/assets/d3d22570-5f4c-4089-b39d-6748f902753b" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)