### PR TITLE
fix: show authored CSS token values in Storybook swatches

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ const config = createConfig([
       '**/storybook-static/**',
       'merged-packages/**',
       '.yarn/**',
+      '.claude/**',
       'scripts/create-package/package-template/**',
       /**
        * Design System specific ignores

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,6 @@ const config = createConfig([
       '**/storybook-static/**',
       'merged-packages/**',
       '.yarn/**',
-      '.claude/**',
       'scripts/create-package/package-template/**',
       /**
        * Design System specific ignores

--- a/packages/design-tokens/stories/BrandColors.stories.tsx
+++ b/packages/design-tokens/stories/BrandColors.stories.tsx
@@ -51,16 +51,18 @@ export const CSS: Story = {
     return (
       <div className="grid grid-cols-[repeat(auto-fill,300px)] gap-4">
         {/* Mapping through each brand color and rendering a ColorSwatch component for it */}
-        {Object.values(cssBrandColors).map(({ color, name }) => (
-          <ColorSwatch
-            key={name}
-            color={color}
-            backgroundColor={name}
-            textBackgroundColor="transparent"
-            textColor={getContrastYIQ(color, color)}
-            name={name}
-          />
-        ))}
+        {Object.values(cssBrandColors).map(
+          ({ color, resolvedColor, name }) => (
+            <ColorSwatch
+              key={name}
+              color={color}
+              backgroundColor={name}
+              textBackgroundColor="transparent"
+              textColor={getContrastYIQ(resolvedColor, resolvedColor)}
+              name={name}
+            />
+          ),
+        )}
       </div>
     );
   },

--- a/packages/design-tokens/stories/BrandColors.stories.tsx
+++ b/packages/design-tokens/stories/BrandColors.stories.tsx
@@ -51,18 +51,16 @@ export const CSS: Story = {
     return (
       <div className="grid grid-cols-[repeat(auto-fill,300px)] gap-4">
         {/* Mapping through each brand color and rendering a ColorSwatch component for it */}
-        {Object.values(cssBrandColors).map(
-          ({ color, resolvedColor, name }) => (
-            <ColorSwatch
-              key={name}
-              color={color}
-              backgroundColor={name}
-              textBackgroundColor="transparent"
-              textColor={getContrastYIQ(resolvedColor, resolvedColor)}
-              name={name}
-            />
-          ),
-        )}
+        {Object.values(cssBrandColors).map(({ color, resolvedColor, name }) => (
+          <ColorSwatch
+            key={name}
+            color={color}
+            backgroundColor={name}
+            textBackgroundColor="transparent"
+            textColor={getContrastYIQ(resolvedColor, resolvedColor)}
+            name={name}
+          />
+        ))}
       </div>
     );
   },

--- a/packages/design-tokens/stories/ThemeColors.stories.tsx
+++ b/packages/design-tokens/stories/ThemeColors.stories.tsx
@@ -68,13 +68,13 @@ export const CSSLightTheme = {
     return (
       <div className="grid grid-cols-[repeat(auto-fill,300px)] gap-4">
         {Object.entries(lightThemeColors).map(
-          ([name, { color, name: colorName }]) => (
+          ([name, { color, resolvedColor, name: colorName }]) => (
             <ColorSwatch
               key={name}
               color={color}
               textBackgroundColor="transparent"
               textColor={getContrastYIQ(
-                color,
+                resolvedColor,
                 lightThemeJS.colors.background.default, // TODO Use CSS instead of JS object once CSS object is cleaned up
               )}
               backgroundColor={colorName}
@@ -104,7 +104,7 @@ export const CSSDarkTheme = {
     return (
       <div className="grid grid-cols-[repeat(auto-fill,300px)] gap-4">
         {Object.entries(darkThemeColors).map(
-          ([name, { color, name: colorName }]) => (
+          ([name, { color, resolvedColor, name: colorName }]) => (
             <ColorSwatch
               key={name}
               color={color}
@@ -112,7 +112,7 @@ export const CSSDarkTheme = {
               backgroundColor={colorName}
               borderColor="var(--color-border-muted)"
               textBackgroundColor="transparent"
-              textColor={getContrastYIQ(color, backgroundDefault)}
+              textColor={getContrastYIQ(resolvedColor, backgroundDefault)}
             />
           ),
         )}

--- a/packages/design-tokens/stories/test-utils/getCSSVariablesFromStylesheet.ts
+++ b/packages/design-tokens/stories/test-utils/getCSSVariablesFromStylesheet.ts
@@ -5,13 +5,74 @@
 // Define a type for the color object
 export type Color = {
   [key: string]: {
+    /**
+     * Authored stylesheet value (e.g. `#ffffff` or `var(--brand-colors-white)`).
+     */
     color: string;
     name: string;
+    /**
+     * Computed color used for swatch contrast. Normalized so short hex like
+     * `#fff` becomes `#ffffff`.
+     */
+    resolvedColor: string;
   };
 };
 
 /**
+ * Expands 3/4-digit hex to 6/8-digit form. Leaves other color strings unchanged.
+ *
+ * @param value - A CSS color string.
+ * @returns Long-form hex when given short hex; otherwise the original value.
+ */
+const expandShortHex = (value: string): string => {
+  const match = /^#([0-9a-f]{3,4})$/iu.exec(value.trim());
+  if (!match?.[1]) {
+    return value;
+  }
+
+  const short = match[1];
+  return `#${[...short].map((char) => `${char}${char}`).join('')}`;
+};
+
+/**
+ * Whether a CSS rule selector belongs to the requested theme.
+ *
+ * @param selector - A single selector from a style rule.
+ * @param theme - Light or dark theme.
+ * @param isPureBlack - When true with dark theme, include pure-black override rules.
+ * @returns True when the selector should be read for this theme.
+ */
+const matchesThemeSelector = (
+  selector: string,
+  theme: 'light' | 'dark',
+  isPureBlack: boolean,
+): boolean => {
+  const trimmed = selector.trim();
+
+  if (theme === 'light') {
+    return (
+      trimmed === ':root' ||
+      trimmed === "[data-theme='light']" ||
+      trimmed === '.light'
+    );
+  }
+
+  const isDarkBase =
+    trimmed === "[data-theme='dark']" || trimmed === '.dark';
+  const isPureBlackRule = trimmed.includes('data-pure-black');
+
+  if (isPureBlack) {
+    return isDarkBase || isPureBlackRule;
+  }
+
+  return isDarkBase;
+};
+
+/**
  * Retrieves CSS variables from the stylesheet, correctly handling combined selectors.
+ *
+ * Displays authored declaration values (not browser-serialized computed colors),
+ * so `#ffffff` stays `#ffffff` instead of collapsing to `#fff`.
  *
  * @param varPrefix - The prefix of the CSS variables to retrieve.
  * @param theme - The theme to retrieve variables for ('light' or 'dark').
@@ -25,9 +86,7 @@ export const getCSSVariablesFromStylesheet = (
 ): Color => {
   const cssVariables: Color = {};
 
-  console.log(`Getting CSS variables for ${theme} theme`);
-
-  // Create a temporary div to get the computed styles for the correct theme
+  // Temporary themed node so resolved colors reflect the active theme for contrast.
   const tempDiv = document.createElement('div');
   if (theme === 'dark') {
     tempDiv.setAttribute('data-theme', 'dark');
@@ -40,15 +99,7 @@ export const getCSSVariablesFromStylesheet = (
     tempDiv.classList.add('light');
   }
 
-  // Add the div to the document temporarily
   document.body.appendChild(tempDiv);
-
-  const validSelectors =
-    theme === 'light'
-      ? [':root', "[data-theme='light']", '.light']
-      : ["[data-theme='dark']", '.dark'];
-
-  console.log('Looking for selectors:', validSelectors);
 
   Array.from(document.styleSheets)
     .flatMap((styleSheet) => {
@@ -75,44 +126,31 @@ export const getCSSVariablesFromStylesheet = (
     .filter((cssRule) => cssRule.type === CSSRule.STYLE_RULE)
     .filter((cssRule: CSSRule) => {
       const selectors = (cssRule as CSSStyleRule).selectorText.split(',');
-      const matches = selectors.some((selector) =>
-        validSelectors.includes(selector.trim()),
+      return selectors.some((selector) =>
+        matchesThemeSelector(selector, theme, isPureBlack),
       );
-
-      if (matches) {
-        console.log(
-          'Found matching selector:',
-          (cssRule as CSSStyleRule).selectorText,
-        );
-      }
-
-      return matches;
     })
     .forEach((cssRule: CSSRule) => {
       const style = (cssRule as CSSStyleRule).style;
       for (let i = 0; i < style.length; i++) {
         const varName = style[i];
         if (varName?.startsWith(varPrefix)) {
-          // Get computed style from our temporary themed div instead of document.documentElement
-          const value = getComputedStyle(tempDiv)
-            .getPropertyValue(varName)
-            .trim();
+          // Prefer the authored declaration over getComputedStyle serialization.
+          const authoredValue = style.getPropertyValue(varName).trim();
+          const resolvedValue = expandShortHex(
+            getComputedStyle(tempDiv).getPropertyValue(varName).trim(),
+          );
           const name = varName.replace(varPrefix, '').replace(/-/g, ' ');
           cssVariables[name] = {
-            color: value,
+            color: authoredValue,
+            resolvedColor: resolvedValue,
             name: `var(${varName})`,
           };
         }
       }
     });
 
-  // Clean up - remove the temporary div
   document.body.removeChild(tempDiv);
-
-  console.log(
-    `Found ${Object.keys(cssVariables).length} CSS variables:`,
-    cssVariables,
-  );
 
   return cssVariables;
 };

--- a/packages/design-tokens/stories/test-utils/getCSSVariablesFromStylesheet.ts
+++ b/packages/design-tokens/stories/test-utils/getCSSVariablesFromStylesheet.ts
@@ -57,8 +57,7 @@ const matchesThemeSelector = (
     );
   }
 
-  const isDarkBase =
-    trimmed === "[data-theme='dark']" || trimmed === '.dark';
+  const isDarkBase = trimmed === "[data-theme='dark']" || trimmed === '.dark';
   const isPureBlackRule = trimmed.includes('data-pure-black');
 
   if (isPureBlack) {

--- a/packages/design-tokens/stories/test-utils/getContrastYIQ.ts
+++ b/packages/design-tokens/stories/test-utils/getContrastYIQ.ts
@@ -1,8 +1,24 @@
 /**
+ * Expands 3/4-digit hex to 6/8-digit form. Leaves other color strings unchanged.
+ *
+ * @param value - A CSS color string.
+ * @returns Long-form hex when given short hex; otherwise the original value.
+ */
+const expandShortHex = (value: string): string => {
+  const match = /^#([0-9a-f]{3,4})$/iu.exec(value.trim());
+  if (!match?.[1]) {
+    return value.trim();
+  }
+
+  return `#${[...match[1]].map((char) => `${char}${char}`).join('')}`;
+};
+
+/**
  * Determines the appropriate contrast text color (black or white) based on the given background color.
  * The function takes into account the alpha transparency of the hex color, blending it with the background color if necessary.
  *
- * @param hexcolor - The hex color code which may include alpha transparency (e.g., '#RRGGBBAA').
+ * @param hexcolor - The hex color code which may include alpha transparency
+ * (e.g. `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`).
  * @param backgroundColor - The hex color code of the default background color hexcolor will appear on (e.g., '#RRGGBB').
  * @returns Returns 'black' if the contrast is better with black text, otherwise returns 'white'.
  */
@@ -11,7 +27,8 @@ export const getContrastYIQ = (
   backgroundColor: string,
 ): string => {
   // Remove the '#' from the hex color if present
-  const modifiedHexcolor = hexcolor.replace('#', '');
+  const modifiedHexcolor = expandShortHex(hexcolor).replace('#', '');
+  const normalizedBackground = expandShortHex(backgroundColor);
 
   // Variables to store the red, green, blue, and alpha values
   let red: number;
@@ -34,9 +51,9 @@ export const getContrastYIQ = (
   }
 
   // Extract the RGB values from the background color
-  const bgR = parseInt(backgroundColor.slice(1, 3), 16);
-  const bgG = parseInt(backgroundColor.slice(3, 5), 16);
-  const bgB = parseInt(backgroundColor.slice(5, 7), 16);
+  const bgR = parseInt(normalizedBackground.slice(1, 3), 16);
+  const bgG = parseInt(normalizedBackground.slice(3, 5), 16);
+  const bgB = parseInt(normalizedBackground.slice(5, 7), 16);
 
   // Blend the text color with the background color based on the alpha value
   red = Math.round(red * a + (1 - a) * bgR);

--- a/packages/design-tokens/stories/test-utils/getContrastYIQ.ts
+++ b/packages/design-tokens/stories/test-utils/getContrastYIQ.ts
@@ -1,3 +1,10 @@
+type Rgba = {
+  red: number;
+  green: number;
+  blue: number;
+  alpha: number;
+};
+
 /**
  * Expands 3/4-digit hex to 6/8-digit form. Leaves other color strings unchanged.
  *
@@ -14,55 +21,95 @@ const expandShortHex = (value: string): string => {
 };
 
 /**
- * Determines the appropriate contrast text color (black or white) based on the given background color.
- * The function takes into account the alpha transparency of the hex color, blending it with the background color if necessary.
+ * Parses a CSS color into RGBA channel values.
  *
- * @param hexcolor - The hex color code which may include alpha transparency
- * (e.g. `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`).
- * @param backgroundColor - The hex color code of the default background color hexcolor will appear on (e.g., '#RRGGBB').
+ * Supports `transparent`, `#RGB(A)`, `#RRGGBB(AA)`, `rgb()`, and `rgba()`.
+ *
+ * @param value - A CSS color string.
+ * @returns Parsed channels, or null when the format is unsupported.
+ */
+const parseCssColor = (value: string): Rgba | null => {
+  const trimmed = value.trim().toLowerCase();
+
+  if (trimmed === 'transparent') {
+    return { red: 0, green: 0, blue: 0, alpha: 0 };
+  }
+
+  const hex = expandShortHex(trimmed).replace('#', '');
+  if (/^[0-9a-f]{6}$/u.test(hex)) {
+    return {
+      red: parseInt(hex.slice(0, 2), 16),
+      green: parseInt(hex.slice(2, 4), 16),
+      blue: parseInt(hex.slice(4, 6), 16),
+      alpha: 1,
+    };
+  }
+  if (/^[0-9a-f]{8}$/u.test(hex)) {
+    return {
+      red: parseInt(hex.slice(0, 2), 16),
+      green: parseInt(hex.slice(2, 4), 16),
+      blue: parseInt(hex.slice(4, 6), 16),
+      alpha: parseInt(hex.slice(6, 8), 16) / 255,
+    };
+  }
+
+  const rgbMatch =
+    /^rgba?\(\s*([0-9.]+)\s*,\s*([0-9.]+)\s*,\s*([0-9.]+)(?:\s*,\s*([0-9.]+))?\s*\)$/u.exec(
+      trimmed,
+    );
+  if (rgbMatch) {
+    return {
+      red: Number(rgbMatch[1]),
+      green: Number(rgbMatch[2]),
+      blue: Number(rgbMatch[3]),
+      alpha: rgbMatch[4] === undefined ? 1 : Number(rgbMatch[4]),
+    };
+  }
+
+  return null;
+};
+
+/**
+ * Determines the appropriate contrast text color (black or white) based on the given background color.
+ * The function takes into account the alpha transparency of the color, blending it with the background color if necessary.
+ *
+ * @param color - CSS color which may include alpha transparency
+ * (e.g. `transparent`, `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`, `rgb()`, `rgba()`).
+ * @param backgroundColor - The color the swatch appears on (e.g. `#RRGGBB`).
  * @returns Returns 'black' if the contrast is better with black text, otherwise returns 'white'.
  */
 export const getContrastYIQ = (
-  hexcolor: string,
+  color: string,
   backgroundColor: string,
 ): string => {
-  // Remove the '#' from the hex color if present
-  const modifiedHexcolor = expandShortHex(hexcolor).replace('#', '');
-  const normalizedBackground = expandShortHex(backgroundColor);
+  const foreground = parseCssColor(color) ??
+    parseCssColor(backgroundColor) ?? {
+      red: 255,
+      green: 255,
+      blue: 255,
+      alpha: 1,
+    };
+  const background = parseCssColor(backgroundColor) ?? {
+    red: 255,
+    green: 255,
+    blue: 255,
+    alpha: 1,
+  };
 
-  // Variables to store the red, green, blue, and alpha values
-  let red: number;
-  let green: number;
-  let blue: number;
-  let a = 1; // Default alpha value is 1 (fully opaque)
+  // Blend the foreground with the background based on alpha (transparent → background only)
+  const red = Math.round(
+    foreground.red * foreground.alpha + (1 - foreground.alpha) * background.red,
+  );
+  const green = Math.round(
+    foreground.green * foreground.alpha +
+      (1 - foreground.alpha) * background.green,
+  );
+  const blue = Math.round(
+    foreground.blue * foreground.alpha +
+      (1 - foreground.alpha) * background.blue,
+  );
 
-  // Check if the hex color includes alpha transparency
-  if (modifiedHexcolor.length === 8) {
-    // If alpha is present (RRGGBBAA)
-    red = parseInt(modifiedHexcolor.slice(0, 2), 16);
-    green = parseInt(modifiedHexcolor.slice(2, 4), 16);
-    blue = parseInt(modifiedHexcolor.slice(4, 6), 16);
-    a = parseInt(modifiedHexcolor.slice(6, 8), 16) / 255; // Convert alpha to a range of 0 to 1
-  } else {
-    // If no alpha is present (RRGGBB)
-    red = parseInt(modifiedHexcolor.slice(0, 2), 16);
-    green = parseInt(modifiedHexcolor.slice(2, 4), 16);
-    blue = parseInt(modifiedHexcolor.slice(4, 6), 16);
-  }
-
-  // Extract the RGB values from the background color
-  const bgR = parseInt(normalizedBackground.slice(1, 3), 16);
-  const bgG = parseInt(normalizedBackground.slice(3, 5), 16);
-  const bgB = parseInt(normalizedBackground.slice(5, 7), 16);
-
-  // Blend the text color with the background color based on the alpha value
-  red = Math.round(red * a + (1 - a) * bgR);
-  green = Math.round(green * a + (1 - a) * bgG);
-  blue = Math.round(blue * a + (1 - a) * bgB);
-
-  // Calculate the YIQ value to determine the brightness
   const yiq = (red * 299 + green * 587 + blue * 114) / 1000;
 
-  // Return 'black' if the YIQ value is 128 or greater, otherwise return 'white'
   return yiq >= 128 ? 'black' : 'white';
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

CSS Theme Colors / Brand Colors Storybook swatches were showing browser-serialized computed colors (e.g. `#fff` for white) instead of the authored stylesheet values (`#ffffff`, `var(--brand-colors-white)`, etc.). Short hex also broke `getContrastYIQ`, so labels on pure-white swatches rendered white-on-white.

This change:
- Reads the authored CSS declaration for display
- Keeps a normalized resolved color for contrast (`#fff` → `#ffffff`)
- Updates Theme Colors and Brand Colors CSS stories to use `resolvedColor` for label contrast

Also ignores `.claude/**` in eslint so local Claude worktrees do not fail `yarn lint` / pre-push.

## **Related issues**

Fixes: N/A (Storybook docs quality fix)

## **Manual testing steps**

1. Run Storybook React and open **Design Tokens → Color → Theme Colors → CSS Light Theme**.
2. Confirm white surfaces (`background-default`, `subsection`, etc.) show authored values (e.g. `var(--brand-colors-…)` or `#ffffff`), not `#fff`.
3. Confirm swatch labels are black/readable on white cards.
4. Open **CSS Dark Theme** and **Brand Colors → CSS**; confirm hex/var display and contrast still look correct.
5. Toggle pure black on CSS Dark Theme and confirm override values still appear when applicable.

## **Screenshots/Recordings**

### **Before**

Pure-white swatches showed `#fff` with white-on-white labels (only visible when selected).

https://github.com/user-attachments/assets/97d374a6-12fd-4521-a820-95a934896d5e


### **After**

Authored stylesheet values are shown; labels use normalized resolved colors for contrast.

https://github.com/user-attachments/assets/4f698d31-a322-4cae-8082-b2946692f84d

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)