### PR TITLE
Release 60.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "59.0.0",
+  "version": "60.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+
 ## [0.39.1]
 
 ### Fixed

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.40.0]
 
-### Uncategorized
+### Added
 
-- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Added `BoxBackgroundColor.BackgroundElevated1`, `BoxBackgroundColor.BackgroundElevated2`, and `BoxBorderColor.BorderAlternative` via `@metamask/design-system-shared` ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+
+### Changed
+
+- Updated `BottomSheetDialog` to use `bg-elevated1` instead of branching on pure-black mode ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Updated `Toast` to use `BackgroundElevated2` in both light and dark themes ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Design-system components no longer branch on `usePureBlack()` for surface styling; consumers should remove `ThemeProvider` `isPureBlack` wiring and use elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 
 ## [0.39.1]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -15,9 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `BottomSheetDialog` to use `bg-elevated1` instead of branching on pure-black mode ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
-- Updated `Toast` to use `BackgroundElevated2` in both light and dark themes ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- **BREAKING:** Updated `BottomSheetDialog` to use `bg-elevated1` instead of branching on pure-black mode; dark-theme sheet surfaces render differently for consumers not already on OLED pure-black ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- **BREAKING:** Updated `Toast` to use `BackgroundElevated2` in both light and dark themes (previously light used `BackgroundDefault` and dark used `BackgroundSection`) ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 - Design-system components no longer branch on `usePureBlack()` for surface styling; consumers should remove `ThemeProvider` `isPureBlack` wiring and use elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 
 ## [0.39.1]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^9.0.0`, which promotes OLED pure-black values into canonical `darkTheme` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 - **BREAKING:** Updated `BottomSheetDialog` to use `bg-elevated1` instead of branching on pure-black mode; dark-theme sheet surfaces render differently for consumers not already on OLED pure-black ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 - **BREAKING:** Updated `Toast` to use `BackgroundElevated2` in both light and dark themes (previously light used `BackgroundDefault` and dark used `BackgroundSection`) ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 - Design-system components no longer branch on `usePureBlack()` for surface styling; consumers should remove `ThemeProvider` `isPureBlack` wiring and use elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0]
+
 ### Uncategorized
 
 - feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
@@ -669,7 +671,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.40.0...HEAD
+[0.40.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.1...@metamask/design-system-react-native@0.40.0
 [0.39.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.0...@metamask/design-system-react-native@0.39.1
 [0.39.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.1...@metamask/design-system-react-native@0.39.0
 [0.38.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.0...@metamask/design-system-react-native@0.38.1

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -15,10 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^9.0.0`, which promotes OLED pure-black values into canonical `darkTheme` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- Updated peer dependency to `@metamask/design-tokens@^9.0.0` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - Required coordination bump; visual impact comes from the design-tokens 9.0.0 dark theme change for apps not already on OLED pure-black
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
-- **BREAKING:** Updated `BottomSheetDialog` to use `bg-elevated1` instead of branching on pure-black mode; dark-theme sheet surfaces render differently for consumers not already on OLED pure-black ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
-- **BREAKING:** Updated `Toast` to use `BackgroundElevated2` in both light and dark themes (previously light used `BackgroundDefault` and dark used `BackgroundSection`) ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Updated `BottomSheetDialog` to use `bg-elevated1` instead of branching on pure-black mode ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+  - `elevated1` resolves to the same value as the previous pure-black path (`background.alternative`, `#0d0d0f`); appearance is unchanged for OLED pure-black consumers
+- Updated `Toast` to use `BackgroundElevated2` instead of theme-conditional `BackgroundDefault` / `BackgroundSection` ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+  - `elevated2` maps to `background.default` in light and `background.section` in dark, matching the previous branch; appearance is unchanged
 - Design-system components no longer branch on `usePureBlack()` for surface styling; consumers should remove `ThemeProvider` `isPureBlack` wiring and use elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",
@@ -89,7 +89,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-twrnc-preset": "^0.8.0",
+    "@metamask/design-system-twrnc-preset": "^0.9.0",
     "@metamask/design-tokens": "^8.2.0",
     "@metamask/utils": "^11.11.0",
     "lodash": "^4.17.21",

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -90,7 +90,7 @@
   },
   "peerDependencies": {
     "@metamask/design-system-twrnc-preset": "^0.9.0",
-    "@metamask/design-tokens": "^8.2.0",
+    "@metamask/design-tokens": "^9.0.0",
     "@metamask/utils": "^11.11.0",
     "lodash": "^4.17.21",
     "react": ">=18.2.0",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+
 ## [0.35.2]
 
 ### Fixed

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -15,10 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^9.0.0`, which promotes OLED pure-black values into canonical `darkTheme` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- Updated peer dependency to `@metamask/design-tokens@^9.0.0` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - Required coordination bump; visual impact comes from the design-tokens 9.0.0 dark theme change for apps not already on OLED pure-black
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
-- **BREAKING:** Updated `ModalContent` to use `BackgroundElevated1` and `BorderAlternative` instead of branching on pure-black mode; dark-theme dialog surfaces and borders render differently for consumers not already on OLED pure-black ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
-- **BREAKING:** Updated `Toast` to use `BackgroundElevated2` instead of `BackgroundSection` ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Updated `ModalContent` to use `BackgroundElevated1` and `BorderAlternative` instead of branching on pure-black mode ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+  - `elevated1` and `border.alternative` resolve to the same values as the previous pure-black path (`background.alternative`, `border.muted`); appearance is unchanged for OLED pure-black consumers
+- Updated `Toast` to use `BackgroundElevated2` instead of `BackgroundSection` ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+  - Dark theme unchanged (`elevated2` matches `background.section`); light theme changes from `background.section` (`#F3F5F9`) to `background.elevated2` / `background.default` (`#FFFFFF`)
 - Design-system components no longer branch on `usePureBlack()` for surface styling; consumers should remove `PureBlackProvider` / `data-pure-black` wiring and use elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^9.0.0`, which promotes OLED pure-black values into canonical `darkTheme` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 - **BREAKING:** Updated `ModalContent` to use `BackgroundElevated1` and `BorderAlternative` instead of branching on pure-black mode; dark-theme dialog surfaces and borders render differently for consumers not already on OLED pure-black ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 - **BREAKING:** Updated `Toast` to use `BackgroundElevated2` instead of `BackgroundSection` ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 - Design-system components no longer branch on `usePureBlack()` for surface styling; consumers should remove `PureBlackProvider` / `data-pure-black` wiring and use elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0]
+
 ### Uncategorized
 
 - feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
@@ -465,7 +467,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.2...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.36.0...HEAD
+[0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.2...@metamask/design-system-react@0.36.0
 [0.35.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.1...@metamask/design-system-react@0.35.2
 [0.35.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.0...@metamask/design-system-react@0.35.1
 [0.35.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.34.0...@metamask/design-system-react@0.35.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -15,9 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `ModalContent` to use `BackgroundElevated1` and `BorderAlternative` instead of branching on pure-black mode ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
-- Updated `Toast` to use `BackgroundElevated2` instead of `BackgroundSection` ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- **BREAKING:** Updated `ModalContent` to use `BackgroundElevated1` and `BorderAlternative` instead of branching on pure-black mode; dark-theme dialog surfaces and borders render differently for consumers not already on OLED pure-black ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- **BREAKING:** Updated `Toast` to use `BackgroundElevated2` instead of `BackgroundSection` ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 - Design-system components no longer branch on `usePureBlack()` for surface styling; consumers should remove `PureBlackProvider` / `data-pure-black` wiring and use elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 
 ## [0.35.2]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.36.0]
 
-### Uncategorized
+### Added
 
-- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Added `BoxBackgroundColor.BackgroundElevated1`, `BoxBackgroundColor.BackgroundElevated2`, and `BoxBorderColor.BorderAlternative` via `@metamask/design-system-shared` ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+
+### Changed
+
+- Updated `ModalContent` to use `BackgroundElevated1` and `BorderAlternative` instead of branching on pure-black mode ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Updated `Toast` to use `BackgroundElevated2` instead of `BackgroundSection` ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Design-system components no longer branch on `usePureBlack()` for surface styling; consumers should remove `PureBlackProvider` / `data-pure-black` wiring and use elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 
 ## [0.35.2]
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.35.2",
+  "version": "0.36.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",
@@ -83,7 +83,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-tailwind-preset": "^0.10.0",
+    "@metamask/design-system-tailwind-preset": "^0.11.0",
     "@metamask/design-tokens": "^8.1.0",
     "@metamask/utils": "^11.11.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -84,7 +84,7 @@
   },
   "peerDependencies": {
     "@metamask/design-system-tailwind-preset": "^0.11.0",
-    "@metamask/design-tokens": "^8.1.0",
+    "@metamask/design-tokens": "^9.0.0",
     "@metamask/utils": "^11.11.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+
 ## [0.32.0]
 
 ### Added

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.33.0]
 
-### Uncategorized
+### Added
 
-- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Added `BoxBackgroundColor.BackgroundElevated1` and `BoxBackgroundColor.BackgroundElevated2` for stepped surface elevation over scrims and floating UI ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Added `BoxBorderColor.BorderAlternative` for hairline borders on elevated surfaces ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 
 ## [0.32.0]
 

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0]
+
 ### Uncategorized
 
 - feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
@@ -325,7 +327,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.32.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.33.0...HEAD
+[0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.32.0...@metamask/design-system-shared@0.33.0
 [0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.31.0...@metamask/design-system-shared@0.32.0
 [0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.30.0...@metamask/design-system-shared@0.31.0
 [0.30.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.29.0...@metamask/design-system-shared@0.30.0

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0]
 
-### Uncategorized
+### Added
 
-- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Added `background.elevated1`, `background.elevated2`, and `border.alternative` Tailwind color utilities mapped to new design tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 
 ## [0.10.0]
 

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0]
+
 ### Uncategorized
 
 - feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
@@ -95,7 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.10.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.11.0...HEAD
+[0.11.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.10.0...@metamask/design-system-tailwind-preset@0.11.0
 [0.10.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.9.0...@metamask/design-system-tailwind-preset@0.10.0
 [0.9.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.8.0...@metamask/design-system-tailwind-preset@0.9.0
 [0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.7.0...@metamask/design-system-tailwind-preset@0.8.0

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^9.0.0`, which promotes OLED pure-black values into canonical `darkTheme` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- Updated peer dependency to `@metamask/design-tokens@^9.0.0` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - Required coordination bump; visual impact comes from the design-tokens 9.0.0 dark theme change for apps not already on OLED pure-black
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 
 ## [0.10.0]

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+
 ## [0.10.0]
 
 ### Changed

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `background.elevated1`, `background.elevated2`, and `border.alternative` Tailwind color utilities mapped to new design tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
 
+### Changed
+
+- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^9.0.0`, which promotes OLED pure-black values into canonical `darkTheme` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
+
 ## [0.10.0]
 
 ### Changed

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -57,7 +57,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^8.0.0",
+    "@metamask/design-tokens": "^9.0.0",
     "tailwindcss": "^3.0.0"
   },
   "engines": {

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-tailwind-preset",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Design System Tailwind CSS preset for MetaMask projects",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0]
+
 ### Uncategorized
 
 - feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
@@ -89,7 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MetaMask design token integration for React Native
 - TWRNC preset configuration with MetaMask styling utilities
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.8.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.9.0...HEAD
+[0.9.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.8.0...@metamask/design-system-twrnc-preset@0.9.0
 [0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.7.0...@metamask/design-system-twrnc-preset@0.8.0
 [0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.6.0...@metamask/design-system-twrnc-preset@0.7.0
 [0.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.5.0...@metamask/design-system-twrnc-preset@0.6.0

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+
 ## [0.8.0]
 
 ### Added

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^9.0.0`, which promotes OLED pure-black values into canonical `darkTheme` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 - **BREAKING:** `getThemeColors()` no longer varies by `isPureBlack`; OLED values are now canonical on the dark theme ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 - **BREAKING:** `pureBlackThemeColors` is deprecated and now aliases dark theme colors ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0]
 
-### Uncategorized
+### Added
 
-- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Added `bg-elevated1`, `bg-elevated2`, and `border-alternative` twrnc color classes from new design tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+
+### Changed
+
+- `getThemeColors()` no longer varies by `isPureBlack`; OLED values are now canonical on the dark theme ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- `pureBlackThemeColors` is deprecated and now aliases dark theme colors ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
 
 ## [0.8.0]
 

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -15,11 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^9.0.0`, which promotes OLED pure-black values into canonical `darkTheme` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- Updated peer dependency to `@metamask/design-tokens@^9.0.0` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - Required coordination bump; visual impact comes from the design-tokens 9.0.0 dark theme change for apps not already on OLED pure-black
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
-- **BREAKING:** `getThemeColors()` no longer varies by `isPureBlack`; OLED values are now canonical on the dark theme ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- `getThemeColors()` no longer varies by `isPureBlack`; OLED values are now canonical on the dark theme ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - No visual change for callers already passing `isPureBlack=true`
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
-- **BREAKING:** `pureBlackThemeColors` is deprecated and now aliases dark theme colors ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- `pureBlackThemeColors` is deprecated and now aliases dark theme colors ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
 
 ## [0.8.0]
 

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `getThemeColors()` no longer varies by `isPureBlack`; OLED values are now canonical on the dark theme ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
-- `pureBlackThemeColors` is deprecated and now aliases dark theme colors ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- **BREAKING:** `getThemeColors()` no longer varies by `isPureBlack`; OLED values are now canonical on the dark theme ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
+- **BREAKING:** `pureBlackThemeColors` is deprecated and now aliases dark theme colors ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
 
 ## [0.8.0]
 

--- a/packages/design-system-twrnc-preset/package.json
+++ b/packages/design-system-twrnc-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-twrnc-preset",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Design System twrnc Preset",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-twrnc-preset/package.json
+++ b/packages/design-system-twrnc-preset/package.json
@@ -82,7 +82,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^8.0.0",
+    "@metamask/design-tokens": "^9.0.0",
     "react": ">=18.2.0"
   },
   "engines": {

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- chore: promote pure black OLED values into canonical darkTheme ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+
 ## [8.7.0]
 
 ### Added

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.8.0]
+
 ### Uncategorized
 
 - feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
@@ -458,7 +460,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.7.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.8.0...HEAD
+[8.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.7.0...@metamask/design-tokens@8.8.0
 [8.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.6.0...@metamask/design-tokens@8.7.0
 [8.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.5.0...@metamask/design-tokens@8.6.0
 [8.5.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.4.0...@metamask/design-tokens@8.5.0

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.8.0]
 
-### Uncategorized
+### Added
 
-- feat: add temporary elevated and border-alternative tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
-- chore: promote pure black OLED values into canonical darkTheme ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- Added `background.elevated1` and `background.elevated2` for stepped surface elevation over scrims and floating UI (e.g. modals, toasts, menus) ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+- Added `border.alternative` for hairline borders on elevated surfaces in dark mode ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
+
+### Changed
+
+- Updated canonical `darkTheme` to use OLED pure-black surface values (previously only available via `pureBlackDarkTheme` or `data-pure-black` overrides) ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- `resolveDarkTheme()` now always returns canonical `darkTheme`; the `isPureBlack` parameter is ignored but retained for call-site compatibility ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
 
 ## [8.7.0]
 

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -18,9 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Updated canonical `darkTheme` to use OLED pure-black surface values (previously only available via `pureBlackDarkTheme` or `data-pure-black` overrides) ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
   - `background.default` changes from `#222325` to `#000000`; section, alternative, muted, and border values shift to the OLED palette
+  - Apps already on pure-black / OLED dark mode (e.g. MetaMask extension and mobile) already use these values and should see no visual change
+  - Apps on legacy default dark without pure-black overrides will see dark-theme UI changes on upgrade
   - See [Migration Guide](./MIGRATION.md#from-version-8x-to-900)
-- **BREAKING:** `resolveDarkTheme()` now always returns canonical `darkTheme`; the `isPureBlack` parameter is ignored but retained for call-site compatibility ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
-  - See [Migration Guide](./MIGRATION.md#from-version-8x-to-900)
+- `resolveDarkTheme()` now always returns canonical `darkTheme`; the `isPureBlack` parameter is ignored but retained for call-site compatibility ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - No additional visual impact for callers already passing `isPureBlack=true`; see [Migration Guide](./MIGRATION.md#from-version-8x-to-900)
 
 ## [8.7.0]
 

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.8.0]
+## [9.0.0]
 
 ### Added
 
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated canonical `darkTheme` to use OLED pure-black surface values (previously only available via `pureBlackDarkTheme` or `data-pure-black` overrides) ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
-- `resolveDarkTheme()` now always returns canonical `darkTheme`; the `isPureBlack` parameter is ignored but retained for call-site compatibility ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+- **BREAKING:** Updated canonical `darkTheme` to use OLED pure-black surface values (previously only available via `pureBlackDarkTheme` or `data-pure-black` overrides) ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - `background.default` changes from `#222325` to `#000000`; section, alternative, muted, and border values shift to the OLED palette
+  - See [Migration Guide](./MIGRATION.md#from-version-8x-to-900)
+- **BREAKING:** `resolveDarkTheme()` now always returns canonical `darkTheme`; the `isPureBlack` parameter is ignored but retained for call-site compatibility ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
+  - See [Migration Guide](./MIGRATION.md#from-version-8x-to-900)
 
 ## [8.7.0]
 
@@ -465,8 +468,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.8.0...HEAD
-[8.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.7.0...@metamask/design-tokens@8.8.0
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@9.0.0...HEAD
+[9.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.7.0...@metamask/design-tokens@9.0.0
 [8.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.6.0...@metamask/design-tokens@8.7.0
 [8.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.5.0...@metamask/design-tokens@8.6.0
 [8.5.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.4.0...@metamask/design-tokens@8.5.0

--- a/packages/design-tokens/MIGRATION.md
+++ b/packages/design-tokens/MIGRATION.md
@@ -24,17 +24,19 @@ OLED pure-black dark theme values are now canonical on `darkTheme`, and new elev
 - `background.default` changes from `#222325` to `#000000`
 - Section, alternative, muted, border, and hover/pressed values shift to the OLED palette
 
-**Pure-black helpers (breaking behavior, compatible signatures):**
+**Pure-black helpers (compatible signatures, no visual change on OLED path):**
 
 - `resolveDarkTheme(isPureBlack)` always returns `darkTheme`; the `isPureBlack` argument is ignored
 - `@metamask/design-system-twrnc-preset` `getThemeColors(theme, isPureBlack)` ignores `isPureBlack`
 - `pureBlackThemeColors` is deprecated and aliases `darkTheme` colors
+- Callers already on pure-black / OLED mode receive the same token values; remove redundant provider wiring
 
-**New elevated surface tokens (additive):**
+**New elevated surface tokens (additive, semantic unification):**
 
-- `background.elevated1` — one level above base; use for surfaces over scrims (modals, bottom sheets)
-- `background.elevated2` — two levels above base; use for floating UI (toasts, menus, popovers)
-- `border.alternative` — hairline border for elevated surfaces in dark mode
+- `background.elevated1` — one level above base; use for surfaces over scrims (modals, bottom sheets). In light, matches `background.default`; in dark on OLED, matches `background.alternative`
+- `background.elevated2` — two levels above base; use for floating UI (toasts, menus, popovers). In light, matches `background.default`; in dark on OLED, matches `background.section`
+- `border.alternative` — hairline border for elevated surfaces in dark mode; on OLED, matches `border.muted`
+- These tokens replace theme-conditional swaps (e.g. `isPureBlack ? alternative : default`) with a single semantic class per surface type
 
 ### Migration
 
@@ -123,9 +125,9 @@ const theme = darkTheme;
 
 ### Impact
 
-- **Apps already on pure-black / OLED mode:** Minimal visual change; remove redundant provider wiring
-- **Apps on default dark theme without pure-black:** Background and elevation colors will change on upgrade; review dark-mode UI and visual regression snapshots
-- **Custom styling tied to old grey900-based hierarchy:** Update to use `background.elevated1`, `background.elevated2`, and `border.alternative` for stepped surfaces
+- **Apps already on pure-black / OLED mode (MetaMask extension and mobile):** No visual change from design-tokens 9.0.0 or design-system component updates; remove redundant `PureBlackProvider`, `data-pure-black`, and `isPureBlack` wiring and adopt elevated tokens in custom UI
+- **Apps on legacy default dark theme without pure-black:** Background and elevation colors will change on upgrade; review dark-mode UI and visual regression snapshots
+- **Custom styling tied to old grey900-based hierarchy:** Update to use `background.elevated1`, `background.elevated2`, and `border.alternative` for stepped surfaces instead of branching on pure-black mode
 
 ## Tailwind CSS v3 to v4
 

--- a/packages/design-tokens/MIGRATION.md
+++ b/packages/design-tokens/MIGRATION.md
@@ -2,6 +2,7 @@
 
 This guide provides detailed instructions for migrating your project from one version of the `@metamask/design-tokens` to another.
 
+- [From version 8.x to 9.0.0](#from-version-8x-to-900)
 - [Tailwind CSS v3 to v4](#tailwind-css-v3-to-v4)
 - [From version 8.2.2 to 8.3.0](#from-version-822-to-830)
 - [From version 7.0.0 to 8.0.0](#from-version-700-to-800)
@@ -10,6 +11,121 @@ This guide provides detailed instructions for migrating your project from one ve
 - [From version 4.1.0 to 5.0.0](#from-version-410-to-500)
 - [From version 3.0.0 to 4.0.0](#from-version-300-to-400)
 - [From version 2.1.1 to 3.0.0](#from-version-211-to-300)
+
+## From version 8.x to 9.0.0
+
+OLED pure-black dark theme values are now canonical on `darkTheme`, and new elevated surface tokens replace the temporary pure-black provider pattern.
+
+### What changed
+
+**Canonical dark theme values (breaking):**
+
+- `darkTheme` now uses OLED pure-black surface values that were previously only available via `pureBlackDarkTheme` or `data-pure-black` CSS overrides
+- `background.default` changes from `#222325` to `#000000`
+- Section, alternative, muted, border, and hover/pressed values shift to the OLED palette
+
+**Pure-black helpers (breaking behavior, compatible signatures):**
+
+- `resolveDarkTheme(isPureBlack)` always returns `darkTheme`; the `isPureBlack` argument is ignored
+- `@metamask/design-system-twrnc-preset` `getThemeColors(theme, isPureBlack)` ignores `isPureBlack`
+- `pureBlackThemeColors` is deprecated and aliases `darkTheme` colors
+
+**New elevated surface tokens (additive):**
+
+- `background.elevated1` — one level above base; use for surfaces over scrims (modals, bottom sheets)
+- `background.elevated2` — two levels above base; use for floating UI (toasts, menus, popovers)
+- `border.alternative` — hairline border for elevated surfaces in dark mode
+
+### Migration
+
+**Remove pure-black provider wiring:**
+
+```tsx
+// Before (8.x) — web
+<html data-pure-black={isPureBlack || undefined}>
+  <PureBlackProvider isPureBlack={isPureBlack}>{children}</PureBlackProvider>
+</html>;
+
+// After (9.0.0) — web
+// Remove data-pure-black and PureBlackProvider; darkTheme is already OLED pure-black
+{
+  children;
+}
+```
+
+```tsx
+// Before (8.x) — React Native
+<ThemeProvider theme={Theme.Dark} isPureBlack={isPureBlack}>
+  {children}
+</ThemeProvider>
+
+// After (9.0.0) — React Native
+<ThemeProvider theme={Theme.Dark}>
+  {children}
+</ThemeProvider>
+```
+
+**Replace isPureBlack branching with elevated tokens:**
+
+```tsx
+// Before (8.x)
+import {
+  BoxBackgroundColor,
+  usePureBlack,
+} from '@metamask/design-system-react';
+
+const isPureBlack = usePureBlack();
+
+<Box
+  backgroundColor={
+    isPureBlack
+      ? BoxBackgroundColor.BackgroundAlternative
+      : BoxBackgroundColor.BackgroundDefault
+  }
+/>;
+
+// After (9.0.0)
+import {
+  BoxBackgroundColor,
+  BoxBorderColor,
+} from '@metamask/design-system-react';
+
+<Box
+  backgroundColor={BoxBackgroundColor.BackgroundElevated1}
+  borderColor={BoxBorderColor.BorderAlternative}
+  borderWidth={1}
+/>;
+```
+
+```tsx
+// Before (8.x) — React Native custom surface
+const isPureBlack = usePureBlack();
+tw.style(isPureBlack ? 'bg-alternative' : 'bg-default');
+
+// After (9.0.0)
+tw.style('bg-elevated1');
+```
+
+**Update resolveDarkTheme / getThemeColors call sites:**
+
+```tsx
+// Before (8.x)
+import { resolveDarkTheme } from '@metamask/design-tokens';
+
+const theme = resolveDarkTheme(isPureBlack);
+
+// After (9.0.0)
+import { darkTheme } from '@metamask/design-tokens';
+
+const theme = darkTheme;
+// resolveDarkTheme(isPureBlack) still compiles but isPureBlack is ignored
+```
+
+### Impact
+
+- **Apps already on pure-black / OLED mode:** Minimal visual change; remove redundant provider wiring
+- **Apps on default dark theme without pure-black:** Background and elevation colors will change on upgrade; review dark-mode UI and visual regression snapshots
+- **Custom styling tied to old grey900-based hierarchy:** Update to use `background.elevated1`, `background.elevated2`, and `border.alternative` for stepped surfaces
 
 ## Tailwind CSS v3 to v4
 

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "8.8.0",
+  "version": "9.0.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "8.7.0",
+  "version": "8.8.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,7 +3411,7 @@ __metadata:
     typescript: "npm:~5.2.2"
   peerDependencies:
     "@metamask/design-system-twrnc-preset": ^0.9.0
-    "@metamask/design-tokens": ^8.2.0
+    "@metamask/design-tokens": ^9.0.0
     "@metamask/utils": ^11.11.0
     lodash: ^4.17.21
     react: ">=18.2.0"
@@ -3461,7 +3461,7 @@ __metadata:
     typescript: "npm:~5.2.2"
   peerDependencies:
     "@metamask/design-system-tailwind-preset": ^0.11.0
-    "@metamask/design-tokens": ^8.1.0
+    "@metamask/design-tokens": ^9.0.0
     "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3507,7 +3507,7 @@ __metadata:
     ts-jest: "npm:^29.2.5"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^8.0.0
+    "@metamask/design-tokens": ^9.0.0
     tailwindcss: ^3.0.0
   languageName: unknown
   linkType: soft
@@ -3539,7 +3539,7 @@ __metadata:
     twrnc: "npm:^4.5.1"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^8.0.0
+    "@metamask/design-tokens": ^9.0.0
     react: ">=18.2.0"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -3410,7 +3410,7 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-twrnc-preset": ^0.8.0
+    "@metamask/design-system-twrnc-preset": ^0.9.0
     "@metamask/design-tokens": ^8.2.0
     "@metamask/utils": ^11.11.0
     lodash: ^4.17.21
@@ -3460,7 +3460,7 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-tailwind-preset": ^0.10.0
+    "@metamask/design-system-tailwind-preset": ^0.11.0
     "@metamask/design-tokens": ^8.1.0
     "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0


### PR DESCRIPTION
## Release 60.0.0

This release adds elevated surface tokens, promotes OLED pure-black values into canonical `darkTheme` as `@metamask/design-tokens@9.0.0` (major), and removes pure-black provider branching from design-system components in favor of semantic elevated tokens.

**For MetaMask extension and mobile (already on OLED pure-black):** No visual change expected. The work is removing redundant `PureBlackProvider` / `data-pure-black` / `isPureBlack` wiring and adopting elevated tokens in custom UI.

**For legacy default-dark consumers:** The 9.0.0 dark theme change (`background.default` `#222325` → `#000000`) is the substantive break.

Implementation shipped in [#1444](https://github.com/MetaMask/metamask-design-system/pull/1444) and [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445); this PR publishes version bumps, changelogs, and migration docs.

### 📦 Package Versions

- `@metamask/design-tokens`: **9.0.0** (major — canonical dark theme values)
- `@metamask/design-system-shared`: **0.33.0**
- `@metamask/design-system-react`: **0.36.0**
- `@metamask/design-system-react-native`: **0.40.0**
- `@metamask/design-system-tailwind-preset`: **0.11.0**
- `@metamask/design-system-twrnc-preset`: **0.9.0**

### 🎨 Design Tokens (9.0.0)

#### Added ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))

- Added `background.elevated1` and `background.elevated2` for stepped surface elevation (modals, toasts, menus)
- Added `border.alternative` for hairline borders on elevated surfaces in dark mode
- Elevated tokens map to existing values per theme (e.g. `elevated2` = `default` in light, `section` in dark on OLED) so floating UI uses one semantic token instead of theme branching

#### Changed — Breaking ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))

- **BREAKING:** Canonical `darkTheme` now uses OLED pure-black surface values (`background.default` `#222325` → `#000000`)
  - Extension and mobile already on pure-black: **no visual change**
  - Legacy default-dark apps: **will see dark-theme UI changes**
- `resolveDarkTheme()` always returns canonical `darkTheme`; `isPureBlack` ignored (no additional visual impact for callers already passing `true`)
- See [Migration Guide](./packages/design-tokens/MIGRATION.md#from-version-8x-to-900)

### 🔄 Shared Type Updates (0.33.0)

#### Elevated surface tokens ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))

- Added `BoxBackgroundColor.BackgroundElevated1`, `BackgroundElevated2`, and `BoxBorderColor.BorderAlternative`
- Enables consistent elevated surface styling across React and React Native

### 🌐 React Web Updates (0.36.0)

#### Added ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))

- Exposed elevated Box enum values from `@metamask/design-system-shared`

#### Changed

- Updated peer dependency to `@metamask/design-tokens@^9.0.0` and `@metamask/design-system-tailwind-preset@^0.11.0` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
- Updated `ModalContent` to `BackgroundElevated1` + `BorderAlternative` — same values as previous pure-black path for OLED consumers ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
- Updated `Toast` to `BackgroundElevated2` — dark unchanged; light changes from section grey to white ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
- Remove `PureBlackProvider` / `data-pure-black` wiring; use elevated tokens in custom UI ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))

### 📱 React Native Updates (0.40.0)

#### Added ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))

- Exposed elevated Box enum values from `@metamask/design-system-shared`

#### Changed

- Updated peer dependency to `@metamask/design-tokens@^9.0.0` and `@metamask/design-system-twrnc-preset@^0.9.0` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
- Updated `BottomSheetDialog` to `bg-elevated1` — same value as previous pure-black path; appearance unchanged for OLED consumers ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
- Updated `Toast` to `BackgroundElevated2` — replaces theme branch with one token mapping to same values per theme; appearance unchanged ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
- Remove `ThemeProvider` `isPureBlack` wiring; use elevated tokens in custom UI ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444), [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))

### 🎨 Preset Updates

#### Tailwind Preset (0.11.0)

- Added `background.elevated1`, `background.elevated2`, and `border.alternative` utilities ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
- Updated peer dependency to `@metamask/design-tokens@^9.0.0` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))

#### twrnc Preset (0.9.0)

- Added `bg-elevated1`, `bg-elevated2`, and `border-alternative` classes ([#1445](https://github.com/MetaMask/metamask-design-system/pull/1445))
- Updated peer dependency to `@metamask/design-tokens@^9.0.0` ([#1444](https://github.com/MetaMask/metamask-design-system/pull/1444))
- `getThemeColors()` ignores `isPureBlack` — no visual change for callers already passing `true`
- `pureBlackThemeColors` deprecated; aliases dark theme colors

### ⚠️ Breaking Changes

#### Canonical OLED dark theme (`@metamask/design-tokens@9.0.0`)

**What Changed:**

- Default `darkTheme` token values changed from legacy grey900-based palette to OLED pure-black
- Only affects consumers **not** already on pure-black / OLED mode

**Migration:**

```tsx
// Remove pure-black wiring — darkTheme is now OLED by default
// Replace theme branching with semantic elevated tokens
<Box backgroundColor={BoxBackgroundColor.BackgroundElevated1} borderColor={BoxBorderColor.BorderAlternative} borderWidth={1} />
```

**Impact:**

- **Extension / mobile (OLED default):** No visual change; remove provider wiring
- **Legacy default-dark / third-party:** Review dark-mode UI and update snapshots

See [Design Tokens Migration Guide](./packages/design-tokens/MIGRATION.md#from-version-8x-to-900)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-tokens: **major** (8.7.0 → 9.0.0) — canonical darkTheme for legacy default-dark consumers
  - [x] design-system-shared: minor (0.32.0 → 0.33.0) — new Box enum values
  - [x] design-system-react: minor (0.35.2 → 0.36.0) — semantic elevated tokens, peer dep coordination
  - [x] design-system-react-native: minor (0.39.1 → 0.40.0) — semantic elevated tokens, peer dep coordination
  - [x] design-system-tailwind-preset: minor (0.10.0 → 0.11.0) — new utilities + peer dep
  - [x] design-system-twrnc-preset: minor (0.8.0 → 0.9.0) — new classes + pure-black consolidation
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples
- [x] Peer dependency bumps captured in changelogs
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs
- [ ] Peer dependency bumps are reflected in package changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major `@metamask/design-tokens` dark-theme value changes can alter UI for consumers not already on OLED pure-black; coordinated peer bumps require upgrading the full design-system stack together.
> 
> **Overview**
> **Release 60.0.0** publishes version bumps, changelogs, lockfile peer ranges, and a new **8.x → 9.0.0** section in `MIGRATION.md` for work already merged in [#1444](https://github.com/MetaMask/metamask-design-system/pull/1444) and [#1445](https://github.com/MetaMask/metamask-design-system/pull/1445).
> 
> `@metamask/design-tokens` goes **9.0.0** with **breaking** canonical `darkTheme` (OLED pure-black surfaces), plus additive `background.elevated1` / `elevated2` and `border.alternative`. Downstream packages bump in lockstep: **shared 0.33.0**, **react 0.36.0**, **react-native 0.40.0**, **tailwind-preset 0.11.0**, **twrnc-preset 0.9.0**, all requiring `@metamask/design-tokens@^9.0.0` (and matching preset peer bumps on web/mobile).
> 
> Changelog entries document consumer impact: drop `PureBlackProvider` / `data-pure-black` / `ThemeProvider` `isPureBlack` for surfaces; use elevated tokens instead of `usePureBlack()` branching. **Web `Toast`** may look whiter in light mode (`BackgroundElevated2` vs `BackgroundSection`); OLED-first apps are called out as largely unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7f134feed4e231e6fe47ccaa29f612f9c4d062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->