### PR TITLE
Release 61.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "60.0.0",
+  "version": "61.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -16,8 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated `BannerBase` to center-align compact content (title-only, description-only, or title with a single-line description or string children) and top-align multi-line stacks, custom React node children, or below-action layouts; inherited by `BannerAlert` and `Toast` ([#1447](https://github.com/MetaMask/metamask-design-system/pull/1447))
-- Removed `ThemeProvider` `isPureBlack` wiring and shared `PureBlack` context; use semantic elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
-  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
 
 ### Fixed
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0]
+
+### Added
+
+- Added `showCloseButton` to `ToastOptions` for the imperative `toast(...)` API (default `true`); when `false`, the close button is hidden while swipe-to-dismiss, auto-dismiss, and `toast.dismiss()` still work ([#1446](https://github.com/MetaMask/metamask-design-system/pull/1446))
+
+### Changed
+
+- Updated `BannerBase` to center-align compact content (title-only, description-only, or title with a single-line description or string children) and top-align multi-line stacks, custom React node children, or below-action layouts; inherited by `BannerAlert` and `Toast` ([#1447](https://github.com/MetaMask/metamask-design-system/pull/1447))
+- Removed `ThemeProvider` `isPureBlack` wiring and shared `PureBlack` context; use semantic elevated tokens (`bg-elevated1`, `bg-elevated2`, `border-alternative`) instead ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
+
+### Fixed
+
+- Fixed `Checkbox` unselected state to use a transparent background instead of `background.default` ([#1451](https://github.com/MetaMask/metamask-design-system/pull/1451))
+
 ## [0.40.0]
 
 ### Added
@@ -683,7 +699,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.40.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.41.0...HEAD
+[0.41.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.40.0...@metamask/design-system-react-native@0.41.0
 [0.40.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.1...@metamask/design-system-react-native@0.40.0
 [0.39.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.0...@metamask/design-system-react-native@0.39.1
 [0.39.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.38.1...@metamask/design-system-react-native@0.39.0

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0]
+
+### Added
+
+- Added `showCloseButton` to `ToastOptions` for the imperative `toast(...)` API (default `true`); when `false`, the close button is hidden while auto-dismiss and `toast.dismiss()` still work ([#1446](https://github.com/MetaMask/metamask-design-system/pull/1446))
+
+### Changed
+
+- Updated `BannerBase` to center-align compact content (title-only, description-only, or title with a single-line description or string children) and top-align multi-line stacks, custom React node children, or below-action layouts; inherited by `BannerAlert` and `Toast` ([#1447](https://github.com/MetaMask/metamask-design-system/pull/1447))
+- Removed `PureBlackProvider`, `usePureBlack`, and `data-pure-black` wiring; use semantic elevated tokens (`BackgroundElevated1`, `BackgroundElevated2`, `BorderAlternative`) instead ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
+
+### Fixed
+
+- Fixed `Checkbox` unselected state to use a transparent background instead of `background.default` ([#1451](https://github.com/MetaMask/metamask-design-system/pull/1451))
+
 ## [0.36.0]
 
 ### Added
@@ -479,7 +495,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.36.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.0...HEAD
+[0.37.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.36.0...@metamask/design-system-react@0.37.0
 [0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.2...@metamask/design-system-react@0.36.0
 [0.35.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.1...@metamask/design-system-react@0.35.2
 [0.35.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.0...@metamask/design-system-react@0.35.1

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -16,8 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated `BannerBase` to center-align compact content (title-only, description-only, or title with a single-line description or string children) and top-align multi-line stacks, custom React node children, or below-action layouts; inherited by `BannerAlert` and `Toast` ([#1447](https://github.com/MetaMask/metamask-design-system/pull/1447))
-- Removed `PureBlackProvider`, `usePureBlack`, and `data-pure-black` wiring; use semantic elevated tokens (`BackgroundElevated1`, `BackgroundElevated2`, `BorderAlternative`) instead ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
-  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-8x-to-900)
+- **BREAKING:** Removed `PureBlackProvider` and `usePureBlack` exports ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - Remove `PureBlackProvider` wrapping and `data-pure-black` on the document root
+  - Use semantic elevated tokens (`BackgroundElevated1`, `BackgroundElevated2`, `BorderAlternative`) for stepped surfaces instead of pure-black branching
+  - See [Migration Guide](./MIGRATION.md#from-version-0360-to-0370)
 
 ### Fixed
 

--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -48,6 +48,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TextFieldSearch Component](#textfieldsearch-component)
   - [FormTextField Component](#formtextfield-component)
 - [Version Updates](#version-updates)
+  - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
   - [From version 0.34.0 to 0.35.0](#from-version-0340-to-0350)
   - [From version 0.27.x to 0.28.0](#from-version-027x-to-0280)
   - [From version 0.25.0 to 0.26.0](#from-version-0250-to-0260)
@@ -3581,6 +3582,58 @@ The new `TextFieldSearch` reuses `TextField`'s Tailwind chrome instead of the `m
 `FormTextField` uses Tailwind utilities (`flex flex-col`) on the root and design-token classes on the composed `Label`/`TextField`/`HelpText` instead of the `mm-form-text-field` SCSS module. Custom container styles should be passed via `className`; legacy `mm-form-text-field--*` classes are no longer applied.
 
 ## Version Updates
+
+### From version 0.36.0 to 0.37.0
+
+<a id="from-version-0360-to-0370"></a>
+
+#### PureBlackProvider and usePureBlack removed
+
+**What changed:**
+
+- Removed `PureBlackProvider` and `usePureBlack` exports from `@metamask/design-system-react`
+- OLED pure-black dark theme values remain canonical on `darkTheme` (since `@metamask/design-tokens@9.0.0`); elevated tokens replace pure-black branching for stepped surfaces
+
+**Migration:**
+
+```tsx
+// Before (0.36.x)
+import {
+  PureBlackProvider,
+  usePureBlack,
+  Box,
+  BoxBackgroundColor,
+} from '@metamask/design-system-react';
+
+<html data-pure-black={isPureBlack || undefined}>
+  <PureBlackProvider isPureBlack={isPureBlack}>{children}</PureBlackProvider>
+</html>;
+
+const isPureBlack = usePureBlack();
+<Box
+  backgroundColor={
+    isPureBlack
+      ? BoxBackgroundColor.BackgroundAlternative
+      : BoxBackgroundColor.BackgroundDefault
+  }
+/>;
+
+// After (0.37.0)
+import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
+
+{
+  children;
+}
+
+<Box backgroundColor={BoxBackgroundColor.BackgroundElevated1} />;
+```
+
+**Impact:**
+
+- Call sites importing `PureBlackProvider` or `usePureBlack` will fail at compile time until removed
+- Remove `data-pure-black` from the document root; dark theme CSS already uses OLED values
+- For stepped surfaces (modals, toasts, menus), use `BackgroundElevated1`, `BackgroundElevated2`, and `BorderAlternative` instead of branching on pure-black mode
+- See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000) for related removals in other packages
 
 ### From version 0.34.0 to 0.35.0
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Release 61.0.0

Toast migration improvements (#1446, #1447) plus follow-up changes already on `main` in the published packages (#1450, #1451).

### 📦 Package Versions

- `@metamask/design-system-react`: **0.37.0**
- `@metamask/design-system-react-native`: **0.41.0**

### 🌐 React Web Updates (0.37.0)

#### Added

- Added `showCloseButton` to `ToastOptions` for the imperative `toast(...)` API (default `true`); when `false`, the close button is hidden while auto-dismiss and `toast.dismiss()` still work ([#1446](https://github.com/MetaMask/metamask-design-system/pull/1446))

#### Changed

- Updated `BannerBase` to center-align compact content (title-only, description-only, or title with a single-line description or string children) and top-align multi-line stacks, custom React node children, or below-action layouts; inherited by `BannerAlert` and `Toast` ([#1447](https://github.com/MetaMask/metamask-design-system/pull/1447))
- **BREAKING:** Removed `PureBlackProvider` and `usePureBlack` exports ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
  - Remove `PureBlackProvider` wrapping and `data-pure-black` on the document root
  - Use semantic elevated tokens for stepped surfaces instead of pure-black branching
  - See [React Migration Guide](./packages/design-system-react/MIGRATION.md#from-version-0360-to-0370)

#### Fixed

- Fixed `Checkbox` unselected state to use a transparent background instead of `background.default` ([#1451](https://github.com/MetaMask/metamask-design-system/pull/1451))

### 📱 React Native Updates (0.41.0)

#### Added

- Added `showCloseButton` to `ToastOptions` for the imperative `toast(...)` API (default `true`); when `false`, the close button is hidden while swipe-to-dismiss, auto-dismiss, and `toast.dismiss()` still work ([#1446](https://github.com/MetaMask/metamask-design-system/pull/1446))

#### Changed

- Updated `BannerBase` to center-align compact content (title-only, description-only, or title with a single-line description or string children) and top-align multi-line stacks, custom React node children, or below-action layouts; inherited by `BannerAlert` and `Toast` ([#1447](https://github.com/MetaMask/metamask-design-system/pull/1447))

#### Fixed

- Fixed `Checkbox` unselected state to use a transparent background instead of `background.default` ([#1451](https://github.com/MetaMask/metamask-design-system/pull/1451))

### ⚠️ Breaking Changes

#### PureBlackProvider removed (React Web Only)

**What Changed:**

- Removed `PureBlackProvider` and `usePureBlack` exports from `@metamask/design-system-react`

**Migration:**

```tsx
// Before (0.36.x)
import { PureBlackProvider, usePureBlack } from '@metamask/design-system-react';

<html data-pure-black={isPureBlack || undefined}>
  <PureBlackProvider isPureBlack={isPureBlack}>{children}</PureBlackProvider>
</html>;

// After (0.37.0)
{
  children;
}
```

**Impact:**

- TypeScript will fail until imports and provider wiring are removed
- Pure-black / `isPureBlack` removals in `@metamask/design-system-twrnc-preset` and `@metamask/design-system-shared` are documented in [design-tokens MIGRATION.md](./packages/design-tokens/MIGRATION.md#from-version-9x-to-1000) and ship with those packages when they are next released

See [React Migration Guide](./packages/design-system-react/MIGRATION.md#from-version-0360-to-0370)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-react: minor (0.36.0 → 0.37.0) — includes breaking PureBlack export removal
  - [x] design-system-react-native: minor (0.40.0 → 0.41.0)
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples
- [x] PR references included in changelog entries
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [ ] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

## Test plan

- [ ] Confirm CI passes, including release conflict check
- [ ] Spot-check Toast Storybook: **ShowCloseButton**, **Spacing**, **ActionButton** (web + RN)
- [ ] Spot-check Checkbox unselected background (web + RN)
- [ ] Verify PureBlack imports fail as expected after upgrade

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release metadata only, but web 0.37.0 documents a breaking public API removal (`PureBlackProvider` / `usePureBlack`) that will fail consumer builds until they migrate.
> 
> **Overview**
> Publishes **monorepo 61.0.0**: `@metamask/design-system-react` **0.37.0** and `@metamask/design-system-react-native` **0.41.0**. This PR is version/changelog/migration docs only.
> 
> Both packages document `showCloseButton` on the imperative toast API, `BannerBase` compact vs multi-line alignment (inherited by `BannerAlert`/`Toast`), and a transparent unselected `Checkbox` background.
> 
> **Web 0.37.0 is breaking:** `PureBlackProvider` and `usePureBlack` are removed; `MIGRATION.md` now covers swapping to elevated tokens (`BackgroundElevated1`/`BackgroundElevated2`/`BorderAlternative`) and dropping `data-pure-black`. RN 0.41.0 does not list that as a new breaking changelog item (pure-black consumer guidance already landed in 0.40.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d787aa87fefa6f4ade7c9753b56b59d591a8a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->