### PR TITLE
Release 62.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "61.0.0",
+  "version": "62.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0]
+
 ### Uncategorized
 
 - feat: cache avatar raster images with expo-image ([#1454](https://github.com/MetaMask/metamask-design-system/pull/1454))
@@ -702,7 +704,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.41.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.0...HEAD
+[0.42.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.41.0...@metamask/design-system-react-native@0.42.0
 [0.41.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.40.0...@metamask/design-system-react-native@0.41.0
 [0.40.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.1...@metamask/design-system-react-native@0.40.0
 [0.39.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.0...@metamask/design-system-react-native@0.39.1

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: cache avatar raster images with expo-image ([#1454](https://github.com/MetaMask/metamask-design-system/pull/1454))
+- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
+
 ## [0.41.0]
 
 ### Added

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `imageProps.resizeMode` overrides no longer apply; use `contentFit` instead
   - `onImageLoad` and `onImageError` receive `expo-image` event payloads instead of React Native `NativeSyntheticEvent` wrappers
   - See [Migration Guide](./MIGRATION.md#from-version-0410-to-0420)
-- Updated peer dependencies to `@metamask/design-tokens@^10.0.0` and `@metamask/design-system-twrnc-preset@^0.10.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+- **BREAKING:** Updated peer dependencies to `@metamask/design-tokens@^10.0.0` and `@metamask/design-system-twrnc-preset@^0.10.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
   - Coordinates with deferred PureBlack scaffolding removals now published in those packages
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000)
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.42.0]
 
-### Uncategorized
+### Changed
 
-- feat: cache avatar raster images with expo-image ([#1454](https://github.com/MetaMask/metamask-design-system/pull/1454))
-- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
+- **BREAKING:** Raster images in `ImageOrSvg` (used by `AvatarToken`, `AvatarNetwork`, `AvatarFavicon`, and `BadgeNetwork`) now use `expo-image` so remote URIs are disk-cached ([#1454](https://github.com/MetaMask/metamask-design-system/pull/1454))
+  - Adds `expo-image` (`>=3.0.0`) as a required peer dependency
+  - `imageProps.resizeMode` overrides no longer apply; use `contentFit` instead
+  - `onImageLoad` and `onImageError` receive `expo-image` event payloads instead of React Native `NativeSyntheticEvent` wrappers
+  - See [Migration Guide](./MIGRATION.md#from-version-0410-to-0420)
+- Updated peer dependencies to `@metamask/design-tokens@^10.0.0` and `@metamask/design-system-twrnc-preset@^0.10.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - Coordinates with deferred PureBlack scaffolding removals now published in those packages
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000)
 
 ## [0.41.0]
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -4,7 +4,7 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Table of Contents
 
-- [From version 0.x.0 to 0.x.0](#from-version-0x0-to-0x0)
+- [From version 0.41.0 to 0.42.0](#from-version-0410-to-0420)
 - [From version 0.37.0 to 0.38.0](#from-version-0370-to-0380)
 - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
 - [From version 0.35.0 to 0.36.0](#from-version-0350-to-0360)
@@ -50,7 +50,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TabEmptyState Component](#tabemptystate-component)
   - [Toast Component](#toast-component)
 - [Version Updates](#version-updates)
-  - [From version 0.x.0 to 0.x.0](#from-version-0x0-to-0x0)
+  - [From version 0.41.0 to 0.42.0](#from-version-0410-to-0420)
   - [From version 0.37.0 to 0.38.0](#from-version-0370-to-0380)
   - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
   - [From version 0.35.0 to 0.36.0](#from-version-0350-to-0360)
@@ -72,9 +72,9 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Version Updates
 
-### From version 0.x.0 to 0.x.0
+### From version 0.41.0 to 0.42.0
 
-<a id="from-version-0x0-to-0x0"></a>
+<a id="from-version-0410-to-0420"></a>
 
 <a id="imageorsvg-expo-image"></a>
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",
@@ -90,8 +90,8 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-twrnc-preset": "^0.9.0",
-    "@metamask/design-tokens": "^9.0.0",
+    "@metamask/design-system-twrnc-preset": "^0.10.0",
+    "@metamask/design-tokens": "^10.0.0",
     "@metamask/utils": "^11.11.0",
     "expo-image": ">=3.0.0",
     "lodash": "^4.17.21",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.37.1]
 
-### Uncategorized
+### Changed
 
-- fix(react): update Popover background color to bg-elevated2 ([#1458](https://github.com/MetaMask/metamask-design-system/pull/1458))
-- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
+- Updated peer dependency to `@metamask/design-tokens@^10.0.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - Coordinates with `@metamask/design-tokens@10.0.0` PureBlack API removals; no additional React API changes in this patch
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000)
+
+### Fixed
+
+- Updated `Popover` default surface and arrow to `BackgroundElevated2` so floating UI is elevated above base surfaces ([#1458](https://github.com/MetaMask/metamask-design-system/pull/1458))
 
 ## [0.37.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix(react): update Popover background color to bg-elevated2 ([#1458](https://github.com/MetaMask/metamask-design-system/pull/1458))
+- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
+
 ## [0.37.0]
 
 ### Added

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.1]
+
 ### Uncategorized
 
 - fix(react): update Popover background color to bg-elevated2 ([#1458](https://github.com/MetaMask/metamask-design-system/pull/1458))
@@ -502,7 +504,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.1...HEAD
+[0.37.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.0...@metamask/design-system-react@0.37.1
 [0.37.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.36.0...@metamask/design-system-react@0.37.0
 [0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.2...@metamask/design-system-react@0.36.0
 [0.35.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.1...@metamask/design-system-react@0.35.2

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.37.1]
+## [0.38.0]
 
 ### Changed
 
-- Updated peer dependency to `@metamask/design-tokens@^10.0.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
-  - Coordinates with `@metamask/design-tokens@10.0.0` PureBlack API removals; no additional React API changes in this patch
+- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^10.0.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - Coordinates with `@metamask/design-tokens@10.0.0` PureBlack API removals; no additional React API changes beyond what 0.37.0 already shipped
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000)
 
 ### Fixed
@@ -509,8 +509,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.1...HEAD
-[0.37.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.0...@metamask/design-system-react@0.37.1
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.0...HEAD
+[0.38.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.0...@metamask/design-system-react@0.38.0
 [0.37.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.36.0...@metamask/design-system-react@0.37.0
 [0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.2...@metamask/design-system-react@0.36.0
 [0.35.2]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.1...@metamask/design-system-react@0.35.2

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^10.0.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
-  - Coordinates with `@metamask/design-tokens@10.0.0` PureBlack API removals; no additional React API changes beyond what 0.37.0 already shipped
+- **BREAKING:** Updated peer dependencies to `@metamask/design-tokens@^10.0.0` and `@metamask/design-system-tailwind-preset@^0.12.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - Coordinates with `@metamask/design-tokens@10.0.0` PureBlack API removals and `@metamask/design-system-tailwind-preset@0.12.0` peer alignment; no additional React API changes beyond what 0.37.0 already shipped
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000)
 
 ### Fixed

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",
@@ -84,7 +84,7 @@
   },
   "peerDependencies": {
     "@metamask/design-system-tailwind-preset": "^0.11.0",
-    "@metamask/design-tokens": "^9.0.0",
+    "@metamask/design-tokens": "^10.0.0",
     "@metamask/utils": "^11.11.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",
@@ -83,7 +83,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-tailwind-preset": "^0.11.0",
+    "@metamask/design-system-tailwind-preset": "^0.12.0",
     "@metamask/design-tokens": "^10.0.0",
     "@metamask/utils": "^11.11.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
+- chore(deps-dev): bump @metamask/auto-changelog from 6.1.1 to 6.2.0 ([#1452](https://github.com/MetaMask/metamask-design-system/pull/1452))
+- chore: remove PureBlack providers and provisional OLED scaffolding ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+
 ## [0.33.0]
 
 ### Added

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.34.0]
 
-### Uncategorized
+### Changed
 
-- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
-- chore(deps-dev): bump @metamask/auto-changelog from 6.1.1 to 6.2.0 ([#1452](https://github.com/MetaMask/metamask-design-system/pull/1452))
-- chore: remove PureBlack providers and provisional OLED scaffolding ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+- **BREAKING:** Removed `PureBlackContext`, `PureBlackContextValue`, and `PureBlackProviderProps` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000)
 
 ## [0.33.0]
 

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0]
+
 ### Uncategorized
 
 - chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
@@ -334,7 +336,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.33.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.34.0...HEAD
+[0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.33.0...@metamask/design-system-shared@0.34.0
 [0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.32.0...@metamask/design-system-shared@0.33.0
 [0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.31.0...@metamask/design-system-shared@0.32.0
 [0.31.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.30.0...@metamask/design-system-shared@0.31.0

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0]
+
+### Changed
+
+- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^10.0.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - Required coordination bump with `@metamask/design-tokens@10.0.0`; preset utilities unchanged since 0.11.0
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000)
+
 ## [0.11.0]
 
 ### Added
@@ -103,7 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.11.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.12.0...HEAD
+[0.12.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.11.0...@metamask/design-system-tailwind-preset@0.12.0
 [0.11.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.10.0...@metamask/design-system-tailwind-preset@0.11.0
 [0.10.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.9.0...@metamask/design-system-tailwind-preset@0.10.0
 [0.9.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.8.0...@metamask/design-system-tailwind-preset@0.9.0

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
-- chore(deps-dev): bump @metamask/auto-changelog from 6.1.1 to 6.2.0 ([#1452](https://github.com/MetaMask/metamask-design-system/pull/1452))
-
 ## [0.11.0]
 
 ### Added

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
+- chore(deps-dev): bump @metamask/auto-changelog from 6.1.1 to 6.2.0 ([#1452](https://github.com/MetaMask/metamask-design-system/pull/1452))
+
 ## [0.11.0]
 
 ### Added

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -57,7 +57,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^9.0.0",
+    "@metamask/design-tokens": "^10.0.0",
     "tailwindcss": "^3.0.0"
   },
   "engines": {

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-tailwind-preset",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Design System Tailwind CSS preset for MetaMask projects",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
+- chore(deps-dev): bump @metamask/auto-changelog from 6.1.1 to 6.2.0 ([#1452](https://github.com/MetaMask/metamask-design-system/pull/1452))
+- chore: remove PureBlack providers and provisional OLED scaffolding ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+
 ## [0.9.0]
 
 ### Added

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0]
 
-### Uncategorized
+### Changed
 
-- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
-- chore(deps-dev): bump @metamask/auto-changelog from 6.1.1 to 6.2.0 ([#1452](https://github.com/MetaMask/metamask-design-system/pull/1452))
-- chore: remove PureBlack providers and provisional OLED scaffolding ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+- **BREAKING:** Removed `ThemeProvider` `isPureBlack` prop, `usePureBlack` hook, and `pureBlackThemeColors` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - `getThemeColors()` and `generateTailwindConfig()` no longer accept an `isPureBlack` second argument
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000)
+- Updated peer dependency to `@metamask/design-tokens@^10.0.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
 
 ## [0.9.0]
 

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0]
+
 ### Uncategorized
 
 - chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
@@ -107,7 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MetaMask design token integration for React Native
 - TWRNC preset configuration with MetaMask styling utilities
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.9.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.10.0...HEAD
+[0.10.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.9.0...@metamask/design-system-twrnc-preset@0.10.0
 [0.9.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.8.0...@metamask/design-system-twrnc-preset@0.9.0
 [0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.7.0...@metamask/design-system-twrnc-preset@0.8.0
 [0.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.6.0...@metamask/design-system-twrnc-preset@0.7.0

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Removed `ThemeProvider` `isPureBlack` prop, `usePureBlack` hook, and `pureBlackThemeColors` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
   - `getThemeColors()` and `generateTailwindConfig()` no longer accept an `isPureBlack` second argument
   - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-9x-to-1000)
-- Updated peer dependency to `@metamask/design-tokens@^10.0.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^10.0.0` ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
 
 ## [0.9.0]
 

--- a/packages/design-system-twrnc-preset/package.json
+++ b/packages/design-system-twrnc-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-twrnc-preset",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Design System twrnc Preset",
   "keywords": [
     "MetaMask",
@@ -82,7 +82,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^9.0.0",
+    "@metamask/design-tokens": "^10.0.0",
     "react": ">=18.2.0"
   },
   "engines": {

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.0.0]
 
-### Uncategorized
+### Changed
 
-- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
-- chore(deps-dev): bump @metamask/auto-changelog from 6.1.1 to 6.2.0 ([#1452](https://github.com/MetaMask/metamask-design-system/pull/1452))
-- chore: remove PureBlack providers and provisional OLED scaffolding ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
-- fix: show authored CSS token values in Storybook swatches ([#1448](https://github.com/MetaMask/metamask-design-system/pull/1448))
+- **BREAKING:** Removed provisional pure-black scaffolding ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+  - Removed `pureBlackDarkTheme`, `resolveDarkTheme()`, and `pure-black-dark-theme-colors.css` / `[data-pure-black]` CSS override path
+  - Canonical `darkTheme` already uses OLED values since 9.0.0; use `background.elevated1`, `background.elevated2`, and `border.alternative` for stepped surfaces
+  - See [Migration Guide](./MIGRATION.md#from-version-9x-to-1000)
 
 ## [9.0.0]
 

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0]
+
 ### Uncategorized
 
 - chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
@@ -477,7 +479,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@9.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@10.0.0...HEAD
+[10.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@9.0.0...@metamask/design-tokens@10.0.0
 [9.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.7.0...@metamask/design-tokens@9.0.0
 [8.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.6.0...@metamask/design-tokens@8.7.0
 [8.6.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.5.0...@metamask/design-tokens@8.6.0

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(deps-dev): bump @metamask/auto-changelog from 6.2.0 to 6.2.1 ([#1456](https://github.com/MetaMask/metamask-design-system/pull/1456))
+- chore(deps-dev): bump @metamask/auto-changelog from 6.1.1 to 6.2.0 ([#1452](https://github.com/MetaMask/metamask-design-system/pull/1452))
+- chore: remove PureBlack providers and provisional OLED scaffolding ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))
+- fix: show authored CSS token values in Storybook swatches ([#1448](https://github.com/MetaMask/metamask-design-system/pull/1448))
+
 ## [9.0.0]
 
 ### Added

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,8 +3411,8 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-twrnc-preset": ^0.9.0
-    "@metamask/design-tokens": ^9.0.0
+    "@metamask/design-system-twrnc-preset": ^0.10.0
+    "@metamask/design-tokens": ^10.0.0
     "@metamask/utils": ^11.11.0
     expo-image: ">=3.0.0"
     lodash: ^4.17.21
@@ -3463,7 +3463,7 @@ __metadata:
     typescript: "npm:~5.2.2"
   peerDependencies:
     "@metamask/design-system-tailwind-preset": ^0.11.0
-    "@metamask/design-tokens": ^9.0.0
+    "@metamask/design-tokens": ^10.0.0
     "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3509,7 +3509,7 @@ __metadata:
     ts-jest: "npm:^29.2.5"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^9.0.0
+    "@metamask/design-tokens": ^10.0.0
     tailwindcss: ^3.0.0
   languageName: unknown
   linkType: soft
@@ -3541,7 +3541,7 @@ __metadata:
     twrnc: "npm:^4.5.1"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^9.0.0
+    "@metamask/design-tokens": ^10.0.0
     react: ">=18.2.0"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,7 +3462,7 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-tailwind-preset": ^0.11.0
+    "@metamask/design-system-tailwind-preset": ^0.12.0
     "@metamask/design-tokens": ^10.0.0
     "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0


### PR DESCRIPTION
## Release 62.0.0

This release publishes deferred PureBlack scaffolding removals from release 61 ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450)), adds disk-cached avatar raster images via `expo-image` on React Native ([#1454](https://github.com/MetaMask/metamask-design-system/pull/1454)), and fixes `Popover` elevated surface styling on React Web ([#1458](https://github.com/MetaMask/metamask-design-system/pull/1458)).

**For MetaMask extension and mobile (already on OLED pure-black):** PureBlack removal is API cleanup only — no visual change expected. Mobile avatar caching is additive; install `expo-image` and review only if you override `resizeMode` or read `onImageError` event payloads.

### 📦 Package Versions

- `@metamask/design-tokens`: **10.0.0** (major — PureBlack scaffolding removal)
- `@metamask/design-system-shared`: **0.34.0**
- `@metamask/design-system-twrnc-preset`: **0.10.0**
- `@metamask/design-system-tailwind-preset`: **0.12.0**
- `@metamask/design-system-react`: **0.38.0**
- `@metamask/design-system-react-native`: **0.42.0**

### 🎨 Design Tokens (10.0.0)

#### Changed — Breaking ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))

- **BREAKING:** Removed provisional pure-black scaffolding
  - Removed `pureBlackDarkTheme`, `resolveDarkTheme()`, and `pure-black-dark-theme-colors.css` / `[data-pure-black]` CSS override path
  - Canonical `darkTheme` already uses OLED values since 9.0.0; use `background.elevated1`, `background.elevated2`, and `border.alternative` for stepped surfaces
  - See [Migration Guide](./packages/design-tokens/MIGRATION.md#from-version-9x-to-1000)

### 🔄 Shared Type Updates (0.34.0)

#### Changed — Breaking ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))

**What Changed:**

- Removed `PureBlackContext`, `PureBlackContextValue`, and `PureBlackProviderProps`

**Impact:**

- Consumers importing PureBlack types from shared must remove those imports and follow the design-tokens migration

### 🌐 React Web Updates (0.38.0)

#### Changed — Breaking ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))

- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^10.0.0`
  - Coordinates with `@metamask/design-tokens@10.0.0` PureBlack API removals; no additional React API changes beyond what 0.37.0 already shipped
  - See [design-tokens Migration Guide](./packages/design-tokens/MIGRATION.md#from-version-9x-to-1000)

#### Fixed

- Updated `Popover` default surface and arrow to `BackgroundElevated2` so floating UI is elevated above base surfaces ([#1458](https://github.com/MetaMask/metamask-design-system/pull/1458))

### 📱 React Native Updates (0.42.0)

#### Changed — Breaking ([#1454](https://github.com/MetaMask/metamask-design-system/pull/1454))

- **BREAKING:** Raster images in `ImageOrSvg` (used by `AvatarToken`, `AvatarNetwork`, `AvatarFavicon`, and `BadgeNetwork`) now use `expo-image` so remote URIs are disk-cached
  - Adds `expo-image` (`>=3.0.0`) as a required peer dependency
  - `imageProps.resizeMode` overrides no longer apply; use `contentFit` instead
  - `onImageLoad` and `onImageError` receive `expo-image` event payloads instead of React Native `NativeSyntheticEvent` wrappers
  - Migration: [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0410-to-0420)

#### Changed — Breaking ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))

- **BREAKING:** Updated peer dependencies to `@metamask/design-tokens@^10.0.0` and `@metamask/design-system-twrnc-preset@^0.10.0`
  - Coordinates with deferred PureBlack scaffolding removals now published in those packages
  - See [design-tokens Migration Guide](./packages/design-tokens/MIGRATION.md#from-version-9x-to-1000)

### 🎨 Preset Updates

#### Tailwind Preset (0.12.0) — Breaking ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))

- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^10.0.0`
  - Required coordination bump; preset utilities unchanged since 0.11.0
  - See [design-tokens Migration Guide](./packages/design-tokens/MIGRATION.md#from-version-9x-to-1000)

#### twrnc Preset (0.10.0) — Breaking ([#1450](https://github.com/MetaMask/metamask-design-system/pull/1450))

- Removed `ThemeProvider` `isPureBlack` prop, `usePureBlack` hook, and `pureBlackThemeColors`
- `getThemeColors()` and `generateTailwindConfig()` no longer accept an `isPureBlack` second argument
- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^10.0.0`

### ⚠️ Breaking Changes

#### PureBlack scaffolding removal (All platforms)

**What Changed:**

- Removed `pureBlackDarkTheme`, `resolveDarkTheme()`, `PureBlackProvider`, `PureBlackContext`, `ThemeProvider` `isPureBlack`, `usePureBlack`, and related APIs
- `getThemeColors(theme, isPureBlack)` / `generateTailwindConfig(theme, isPureBlack)` second arguments removed

**Migration:**

```tsx
// Before
import { resolveDarkTheme, pureBlackDarkTheme } from '@metamask/design-tokens';
import { PureBlackProvider } from '@metamask/design-system-react';

const theme = resolveDarkTheme(isPureBlack);
<PureBlackProvider isPureBlack={isPureBlack}>{children}</PureBlackProvider>;

// After
import { darkTheme } from '@metamask/design-tokens';

const theme = darkTheme;
{children}
```

**Impact:**

- Extension / mobile already on OLED: remove dead wiring only
- Any remaining `isPureBlack` / `data-pure-black` usage must be deleted

See [Design Tokens Migration Guide](./packages/design-tokens/MIGRATION.md#from-version-9x-to-1000)

#### ImageOrSvg expo-image (React Native only)

**What Changed:**

- `resizeMode` overrides on `imageOrSvgProps.imageProps` are ignored; `contentFit` is required
- `onImageError` payloads use `event.error` instead of `event.nativeEvent.error`

**Migration:**

```tsx
// Before (0.41.0)
<AvatarNetwork
  src={{ uri: 'https://example.com/network.png' }}
  imageOrSvgProps={{ imageProps: { resizeMode: 'cover' } }}
/>

// After (0.42.0)
<AvatarNetwork
  src={{ uri: 'https://example.com/network.png' }}
  imageOrSvgProps={{ imageProps: { contentFit: 'cover' } }}
/>
```

**Impact:**

- MetaMask Mobile production usage audited: no `resizeMode` overrides; install `expo-image` peer only
- Affects consumers passing `resizeMode` or reading native event wrapper shapes

See migration guides for complete instructions:

- [Design Tokens Migration Guide](./packages/design-tokens/MIGRATION.md#from-version-9x-to-1000)
- [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0410-to-0420)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-tokens: **major** (9.0.0 → 10.0.0) — PureBlack scaffolding removal
  - [x] design-system-shared: minor (0.33.0 → 0.34.0) — PureBlackContext removal
  - [x] design-system-twrnc-preset: minor (0.9.0 → 0.10.0) — PureBlack API removal + peer dep
  - [x] design-system-tailwind-preset: minor (0.11.0 → 0.12.0) — design-tokens ^10.0.0 peer coordination
  - [x] design-system-react: minor (0.37.0 → 0.38.0) — Popover fix + peer dep coordination
  - [x] design-system-react-native: minor (0.41.0 → 0.42.0) — expo-image + peer dep coordination
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Multiple coordinated breaking releases (design-tokens major, PureBlack API removal, RN `expo-image` and image callback contract) require consumer migration; the diff itself is mostly versioning and docs.
> 
> **Overview**
> **Release 62.0.0** bumps the monorepo and publishes coordinated package versions with updated changelogs, migration guide links, and peer dependency ranges in `package.json` / `yarn.lock`.
> 
> **@metamask/design-tokens@10.0.0** (major) documents removal of PureBlack scaffolding (`pureBlackDarkTheme`, `resolveDarkTheme()`, `[data-pure-black]` CSS). Downstream packages align on `@metamask/design-tokens@^10.0.0`: shared drops PureBlack types, twrnc preset removes `isPureBlack` / `usePureBlack`, and React / React Native presets get matching peer bumps.
> 
> **@metamask/design-system-react-native@0.42.0** changelog records **breaking** raster rendering in `ImageOrSvg` (avatars / `BadgeNetwork`) via `expo-image` (`>=3.0.0` peer), with `contentFit` instead of `resizeMode` and different image event payloads; **MIGRATION.md** adds the 0.41.0 → 0.42.0 section.
> 
> **@metamask/design-system-react@0.38.0** notes a **Popover** default surface/arrow fix to `BackgroundElevated2` plus peer coordination—no new React API beyond 0.37.0 in this release slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38128786d69b2a48c5601d137f0ff304db64340a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->