### PR TITLE
docs(react): fix AvatarGroup migration guide for extension

### DIFF
--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -1902,51 +1902,87 @@ import { AvatarToken, AvatarTokenSize } from '@metamask/design-system-react';
 
 ### AvatarGroup Component
 
-`AvatarGroup` is **not exported** from the extension `component-library` (see [extension `index.ts`](https://github.com/MetaMask/metamask-extension/blob/main/ui/components/component-library/index.ts)). Use this section for **MetaMask Mobile** and any app that used the standalone `AvatarGroup` molecule.
+The extension [`multichain/avatar-group`](https://github.com/MetaMask/metamask-extension/tree/main/ui/components/multichain/avatar-group) component maps to `AvatarGroup` in the design system. It is **not** part of the extension `component-library` barrel (see [extension `index.ts`](https://github.com/MetaMask/metamask-extension/blob/main/ui/components/component-library/index.ts)); consumers import it from `ui/components/multichain/avatar-group` today and should migrate to `@metamask/design-system-react`.
 
-**MMDS** requires a **required `variant`** (const object + union `AvatarGroupVariant`) and **`avatarPropsArr`** (not `avatarPropsList`). The **`max` prop** defaults to 4, **`size`** to `AvatarGroupSize.Md`. **`isReverse`** and **`overflowTextProps`** are new. Mobile’s **`spaceBetweenAvatars`**, **`includesBorder` stack override**, and the **`+N` size default of `AvatarSize.Xs`** are not part of the MMDS `AvatarGroup` public API; recreate spacing and borders with layout/`twClassName` if needed.
+**MMDS** requires a **required `variant`** (`AvatarGroupVariant`) and **`avatarPropsArr`** (typed avatar props per variant) instead of the extension’s **`avatarType` + `members`** shape. The **`max` prop** defaults to `4`, **`size`** to `AvatarGroupSize.Md` (extension defaults to `AvatarTokenSize.Xs`). **`isReverse`** and **`overflowTextProps`** are new. The extension’s **`isTagOverlay`** (overflow as inline `Text` vs overlay `AvatarBase`) and **Box `StyleUtilityProps`** are not carried forward; MMDS always renders the `+N` overflow in an `AvatarBase` badge (similar to `isTagOverlay={true}`). Use `className` / `style` for layout overrides.
 
-#### Breaking Changes (vs Mobile `AvatarGroup`)
+Refer to [General Extension Migration Guidance](#general-extension-migration-guidance) for shared Box/style-utility migration patterns.
 
-| Mobile API                                                          | MMDS API                                                                | Change Type              | Notes                                                           |
-| ------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------ | --------------------------------------------------------------- |
-| `avatarPropsList: AvatarProps[]` (discriminated by inner `variant`) | `variant` + `avatarPropsArr: Avatar*Props[]` (single variant per group) | restructured             | pick one of Account / Favicon / Network / Token for the group   |
-| `size?: AvatarSize` (default `Xs` in mobile types)                  | `size?: AvatarGroupSize` (alias of `AvatarBaseSize`, default `Md`)      | default and type changed | verify visual overlap                                           |
-| `maxStackedAvatars?`                                                | `max?`                                                                  | renamed                  | same intent (default `4`)                                       |
-| `includesBorder?`                                                   | (not on `AvatarGroup`)                                                  | removed                  | set `hasBorder` on children via props if the design requires it |
-| `spaceBetweenAvatars?`                                              | (no direct prop)                                                        | removed                  | use wrapper layout / utilities                                  |
-| (n/a)                                                               | `isReverse?`, `overflowTextProps?`                                      | new                      | stack direction and overflow label styling                      |
+#### Breaking Changes (Extension)
 
-#### Mobile variant → MMDS `AvatarGroupVariant` + item props
+| Extension API                                                                 | MMDS API                                                                | Change Type              | Notes                                                                                      |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------ |
+| `import { AvatarGroup } from '.../multichain/avatar-group'`                   | `import { AvatarGroup } from '@metamask/design-system-react'`           | import path              | drop local multichain wrapper                                                              |
+| `avatarType?: AvatarType` (`TOKEN` / `ACCOUNT` / `NETWORK`)                   | `variant: AvatarGroupVariant` (required)                                | restructured             | one variant per group; MMDS also supports `Favicon`                                        |
+| `members: { avatarValue; symbol? }[]`                                         | `avatarPropsArr: Avatar*Props[]`                                        | restructured             | map `avatarValue` → `src` or `address`; `symbol` → `name`                                  |
+| `limit` (default `4`)                                                         | `max?` (default `4`)                                                    | renamed                  | same intent                                                                                |
+| `size?: AvatarTokenSize` (default `Xs`; only honored for `TOKEN`)             | `size?: AvatarGroupSize` (default `Md`; applies to all children)        | default and scope changed | account/network stacks were hardcoded to `Xs` in the extension — set `size` explicitly     |
+| `variant?: AvatarAccountVariant` (group-level, `ACCOUNT` only)                | per-item `variant` on `AvatarAccountProps` in `avatarPropsArr`            | moved                    | e.g. `AvatarAccountVariant.Maskicon` on each account item                                    |
+| `isTagOverlay?: boolean`                                                      | (overflow always in `AvatarBase`)                                       | removed                  | separate `Text` overflow label is not supported; use `overflowTextProps` to style badge  |
+| Box `StyleUtilityProps` (`display`, `gap`, `alignItems`, …) on root          | `className` / `style` on root `div`                                     | removed as first-class   | e.g. `gap={1}` → Tailwind `gap-1` on `className`                                           |
+| (n/a)                                                                         | `isReverse?`, `overflowTextProps?`                                      | new                      | stack direction and overflow badge styling                                                 |
 
-| Mobile `Avatar` variant (on each item) | MMDS `variant` on `AvatarGroup` | `avatarPropsArr` item type                   |
-| -------------------------------------- | ------------------------------- | -------------------------------------------- |
-| `AvatarVariant.Account`                | `AvatarGroupVariant.Account`    | `AvatarAccountProps`                         |
-| `AvatarVariant.Favicon`                | `AvatarGroupVariant.Favicon`    | `AvatarFaviconProps`                         |
-| `AvatarVariant.Network`                | `AvatarGroupVariant.Network`    | `AvatarNetworkProps`                         |
-| `AvatarVariant.Token`                  | `AvatarGroupVariant.Token`      | `AvatarTokenProps`                           |
-| `AvatarVariant.Icon`                   | (no `AvatarGroup` branch)       | use separate layout or multiple `AvatarIcon` |
+#### Extension `AvatarType` → MMDS `AvatarGroupVariant` + item props
 
-#### Migration Example (Mobile)
+| Extension `avatarType`   | MMDS `variant` on `AvatarGroup` | `avatarPropsArr` item mapping                                      |
+| ------------------------ | ------------------------------- | ------------------------------------------------------------------ |
+| `AvatarType.TOKEN`       | `AvatarGroupVariant.Token`      | `{ src: member.avatarValue, name: member.symbol }`                 |
+| `AvatarType.ACCOUNT`     | `AvatarGroupVariant.Account`    | `{ address: member.avatarValue, variant: AvatarAccountVariant.* }` |
+| `AvatarType.NETWORK`     | `AvatarGroupVariant.Network`    | `{ src: member.avatarValue, name: member.symbol ?? '' }`            |
+| (no extension equivalent) | `AvatarGroupVariant.Favicon`   | `{ src, name }` per `AvatarFaviconProps`                           |
 
-##### Before (Mobile)
+#### Migration Example
+
+##### Before (Extension)
 
 ```tsx
-import AvatarGroup from '.../Avatars/AvatarGroup';
-import {
-  AvatarSize,
-  AvatarVariant,
-  AvatarAccountType,
-} from '.../Avatars/Avatar/Avatar.types';
+import { AvatarGroup } from '../../multichain/avatar-group';
+import { AvatarType } from '../../multichain/avatar-group/avatar-group.types';
+import { AvatarTokenSize } from '@metamask/design-system-react';
 
 <AvatarGroup
-  size={AvatarSize.Md}
-  maxStackedAvatars={3}
-  avatarPropsList={addresses.map((accountAddress) => ({
-    variant: AvatarVariant.Account,
-    accountAddress,
-    type: AvatarAccountType.JazzIcon,
+  limit={3}
+  size={AvatarTokenSize.Xs}
+  avatarType={AvatarType.TOKEN}
+  members={tokens.map((token) => ({
+    avatarValue: token.iconUrl,
+    symbol: token.symbol,
   }))}
+/>;
+```
+
+##### After (Design System)
+
+```tsx
+import {
+  AvatarGroup,
+  AvatarGroupVariant,
+  AvatarGroupSize,
+} from '@metamask/design-system-react';
+
+<AvatarGroup
+  variant={AvatarGroupVariant.Token}
+  max={3}
+  size={AvatarGroupSize.Xs}
+  avatarPropsArr={tokens.map((token) => ({
+    src: token.iconUrl,
+    name: token.symbol,
+  }))}
+/>;
+```
+
+##### Before (Extension — accounts)
+
+```tsx
+import { AvatarGroup } from '../../multichain/avatar-group';
+import { AvatarType } from '../../multichain/avatar-group/avatar-group.types';
+import { AvatarAccountVariant } from '@metamask/design-system-react';
+
+<AvatarGroup
+  limit={3}
+  avatarType={AvatarType.ACCOUNT}
+  variant={AvatarAccountVariant.Jazzicon}
+  members={addresses.map((address) => ({ avatarValue: address }))}
 />;
 ```
 
@@ -1962,8 +1998,8 @@ import {
 
 <AvatarGroup
   variant={AvatarGroupVariant.Account}
-  size={AvatarGroupSize.Md}
   max={3}
+  size={AvatarGroupSize.Xs}
   avatarPropsArr={addresses.map((address) => ({
     address,
     variant: AvatarAccountVariant.Jazzicon,

--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -1904,32 +1904,42 @@ import { AvatarToken, AvatarTokenSize } from '@metamask/design-system-react';
 
 The extension [`multichain/avatar-group`](https://github.com/MetaMask/metamask-extension/tree/main/ui/components/multichain/avatar-group) component maps to `AvatarGroup` in the design system. It is **not** part of the extension `component-library` barrel (see [extension `index.ts`](https://github.com/MetaMask/metamask-extension/blob/main/ui/components/component-library/index.ts)); consumers import it from `ui/components/multichain/avatar-group` today and should migrate to `@metamask/design-system-react`.
 
-**MMDS** requires a **required `variant`** (`AvatarGroupVariant`) and **`avatarPropsArr`** (typed avatar props per variant) instead of the extension’s **`avatarType` + `members`** shape. The **`max` prop** defaults to `4`, **`size`** to `AvatarGroupSize.Md` (extension defaults to `AvatarTokenSize.Xs`). **`isReverse`** and **`overflowTextProps`** are new. The extension’s **`isTagOverlay`** (overflow as inline `Text` vs overlay `AvatarBase`) and **Box `StyleUtilityProps`** are not carried forward; MMDS always renders the `+N` overflow in an `AvatarBase` badge (similar to `isTagOverlay={true}`). Use `className` / `style` for layout overrides.
+**MMDS** requires a **required `variant`** (`AvatarGroupVariant`) and **`avatarPropsArr`** (typed avatar props per variant) instead of the extension’s **`avatarType` + `members`** shape. The **`max` prop** defaults to `4`, **`size`** to `AvatarGroupSize.Md` (extension defaults to `AvatarTokenSize.Xs`). **`isReverse`** controls stack direction (see [Stack order](#stack-order-isreverse)); **`overflowTextProps`** customizes the overflow badge. The extension’s **`isTagOverlay`** (overflow as inline `Text` vs overlay `AvatarBase`) and **Box `StyleUtilityProps`** are not carried forward; MMDS always renders the `+N` overflow in an `AvatarBase` badge (similar to `isTagOverlay={true}`). MMDS also applies **`hasBorder`** on stacked avatars by default. Use `className` / `style` for layout overrides. Preserve `data-testid` on the root if your E2E selectors depend on it (`data-testid="avatar-group"` is forwarded via standard div props).
 
 Refer to [General Extension Migration Guidance](#general-extension-migration-guidance) for shared Box/style-utility migration patterns.
 
 #### Breaking Changes (Extension)
 
-| Extension API                                                                 | MMDS API                                                                | Change Type              | Notes                                                                                      |
-| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------ |
-| `import { AvatarGroup } from '.../multichain/avatar-group'`                   | `import { AvatarGroup } from '@metamask/design-system-react'`           | import path              | drop local multichain wrapper                                                              |
-| `avatarType?: AvatarType` (`TOKEN` / `ACCOUNT` / `NETWORK`)                   | `variant: AvatarGroupVariant` (required)                                | restructured             | one variant per group; MMDS also supports `Favicon`                                        |
-| `members: { avatarValue; symbol? }[]`                                         | `avatarPropsArr: Avatar*Props[]`                                        | restructured             | map `avatarValue` → `src` or `address`; `symbol` → `name`                                  |
-| `limit` (default `4`)                                                         | `max?` (default `4`)                                                    | renamed                  | same intent                                                                                |
-| `size?: AvatarTokenSize` (default `Xs`; only honored for `TOKEN`)             | `size?: AvatarGroupSize` (default `Md`; applies to all children)        | default and scope changed | account/network stacks were hardcoded to `Xs` in the extension — set `size` explicitly     |
-| `variant?: AvatarAccountVariant` (group-level, `ACCOUNT` only)                | per-item `variant` on `AvatarAccountProps` in `avatarPropsArr`            | moved                    | e.g. `AvatarAccountVariant.Maskicon` on each account item                                    |
-| `isTagOverlay?: boolean`                                                      | (overflow always in `AvatarBase`)                                       | removed                  | separate `Text` overflow label is not supported; use `overflowTextProps` to style badge  |
-| Box `StyleUtilityProps` (`display`, `gap`, `alignItems`, …) on root          | `className` / `style` on root `div`                                     | removed as first-class   | e.g. `gap={1}` → Tailwind `gap-1` on `className`                                           |
-| (n/a)                                                                         | `isReverse?`, `overflowTextProps?`                                      | new                      | stack direction and overflow badge styling                                                 |
+| Extension API                                                       | MMDS API                                                         | Change Type               | Notes                                                                                                  |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `import { AvatarGroup } from '.../multichain/avatar-group'`         | `import { AvatarGroup } from '@metamask/design-system-react'`    | import path               | drop local multichain wrapper                                                                          |
+| `avatarType?: AvatarType` (`TOKEN` / `ACCOUNT` / `NETWORK`)         | `variant: AvatarGroupVariant` (required)                         | restructured              | one variant per group; MMDS also supports `Favicon`                                                    |
+| `members: { avatarValue; symbol? }[]`                               | `avatarPropsArr: Avatar*Props[]`                                 | restructured              | map `avatarValue` → `src` or `address`; `symbol` → `name`                                              |
+| `limit` (default `4`)                                               | `max?` (default `4`)                                             | renamed                   | same intent                                                                                            |
+| `size?: AvatarTokenSize` (default `Xs`; only honored for `TOKEN`)   | `size?: AvatarGroupSize` (default `Md`; applies to all children) | default and scope changed | account/network stacks were hardcoded to `Xs` in the extension — set `size` explicitly                 |
+| `variant?: AvatarAccountVariant` (group-level, `ACCOUNT` only)      | per-item `variant` on `AvatarAccountProps` in `avatarPropsArr`   | moved                     | e.g. `AvatarAccountVariant.Maskicon` on each account item                                              |
+| `isTagOverlay?: boolean`                                            | (overflow always in `AvatarBase`)                                | removed                   | separate `Text` overflow label is not supported; use `overflowTextProps` to style badge                |
+| Box `StyleUtilityProps` (`display`, `gap`, `alignItems`, …) on root | `className` / `style` on root `div`                              | removed as first-class    | e.g. `gap={1}` → Tailwind `gap-1` on `className`                                                       |
+| `members.slice(0, limit).reverse()` before render (always reversed) | `isReverse?` (default `false`; forward order)                    | behavior changed          | pass `isReverse={true}` for pixel parity with the extension wrapper; forward order is the MMDS default |
+
+#### Stack order (`isReverse`)
+
+The extension wrapper **always reverses** visible members before rendering:
+
+```ts
+const visibleMembers = members.slice(0, limit).reverse();
+```
+
+MMDS renders `avatarPropsArr` in forward order by default (`isReverse={false}`). When migrating TOKEN or NETWORK stacks, pass **`isReverse={true}`** if you need the same left-to-right stacking as the deprecated wrapper. New MMDS call sites (for example `defi-protocol-cell-v2.tsx` in the extension) use forward order intentionally.
 
 #### Extension `AvatarType` → MMDS `AvatarGroupVariant` + item props
 
-| Extension `avatarType`   | MMDS `variant` on `AvatarGroup` | `avatarPropsArr` item mapping                                      |
-| ------------------------ | ------------------------------- | ------------------------------------------------------------------ |
-| `AvatarType.TOKEN`       | `AvatarGroupVariant.Token`      | `{ src: member.avatarValue, name: member.symbol }`                 |
-| `AvatarType.ACCOUNT`     | `AvatarGroupVariant.Account`    | `{ address: member.avatarValue, variant: AvatarAccountVariant.* }` |
-| `AvatarType.NETWORK`     | `AvatarGroupVariant.Network`    | `{ src: member.avatarValue, name: member.symbol ?? '' }`            |
-| (no extension equivalent) | `AvatarGroupVariant.Favicon`   | `{ src, name }` per `AvatarFaviconProps`                           |
+| Extension `avatarType`    | MMDS `variant` on `AvatarGroup` | `avatarPropsArr` item mapping                                      |
+| ------------------------- | ------------------------------- | ------------------------------------------------------------------ |
+| `AvatarType.TOKEN`        | `AvatarGroupVariant.Token`      | `{ src: member.avatarValue, name: member.symbol }`                 |
+| `AvatarType.ACCOUNT`      | `AvatarGroupVariant.Account`    | `{ address: member.avatarValue, variant: AvatarAccountVariant.* }` |
+| `AvatarType.NETWORK`      | `AvatarGroupVariant.Network`    | `{ src: member.avatarValue, name: member.symbol ?? '' }`           |
+| (no extension equivalent) | `AvatarGroupVariant.Favicon`    | `{ src, name }` per `AvatarFaviconProps`                           |
 
 #### Migration Example
 

--- a/packages/design-system-react/src/components/AvatarGroup/README.mdx
+++ b/packages/design-system-react/src/components/AvatarGroup/README.mdx
@@ -243,7 +243,7 @@ The `style` prop should primarily be used for dynamic inline styles that cannot 
 
 <Controls of={AvatarGroupStories.Default} />
 
-Migrating from the extension `multichain/avatar-group`? See the [AvatarGroup migration guide](https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#avatargroup-component) for `variant` + `avatarPropsArr`, renames from `limit` / `members`, and overflow styling differences.
+Migrating from the extension `multichain/avatar-group`? See the [AvatarGroup migration guide](https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#avatargroup-component) for `variant` + `avatarPropsArr`, renames from `limit` / `members`, stack order (`isReverse`), and overflow styling differences.
 
 ## References
 

--- a/packages/design-system-react/src/components/AvatarGroup/README.mdx
+++ b/packages/design-system-react/src/components/AvatarGroup/README.mdx
@@ -243,7 +243,7 @@ The `style` prop should primarily be used for dynamic inline styles that cannot 
 
 <Controls of={AvatarGroupStories.Default} />
 
-Migrating from the mobile `AvatarGroup`? See the [AvatarGroup migration guide](https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#avatargroup-component) for `variant` + `avatarPropsArr`, renames from `maxStackedAvatars`, and spacing differences.
+Migrating from the extension `multichain/avatar-group`? See the [AvatarGroup migration guide](https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#avatargroup-component) for `variant` + `avatarPropsArr`, renames from `limit` / `members`, and overflow styling differences.
 
 ## References
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The `AvatarGroup` section in `packages/design-system-react/MIGRATION.md` incorrectly documented migration from the MetaMask Mobile `AvatarGroup` API. Extension consumers migrating off the deprecated `ui/components/multichain/avatar-group` wrapper (see [metamask-extension#45733](https://github.com/MetaMask/metamask-extension/pull/45733)) need guidance for the extension-specific props (`avatarType`, `members`, `limit`, `isTagOverlay`, etc.).

This PR rewrites the migration guide to:

- Point at the extension [`multichain/avatar-group`](https://github.com/MetaMask/metamask-extension/tree/main/ui/components/multichain/avatar-group) source
- Document prop mappings from extension → MMDS (`avatarType` → `variant`, `members` → `avatarPropsArr`, `limit` → `max`, etc.)
- Include token and account migration examples
- Document stack order / `isReverse` (extension always reverses `members.slice(0, limit)`; MMDS defaults to forward order) — addresses [metamask-extension#45768 review](https://github.com/MetaMask/metamask-extension/pull/45768#issuecomment-5420690110)
- Note `hasBorder` default and preserving `data-testid` for E2E selectors
- Update `AvatarGroup` README.mdx to reference the extension migration path

## **Related issues**

Fixes: N/A (supports metamask-extension#45733 deprecation `@see` link and metamask-extension#45768 consumer migration)

## **Manual testing steps**

1. Open `packages/design-system-react/MIGRATION.md#avatargroup-component`
2. Verify the guide references the extension multichain component (not mobile)
3. Confirm prop mapping tables and before/after examples match the extension API
4. Confirm the Stack order (`isReverse`) section documents the extension `.reverse()` behavior

## **Screenshots/Recordings**

N/A — documentation-only change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33830207-410d-43a3-9079-b4370b958d19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33830207-410d-43a3-9079-b4370b958d19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

