### PR TITLE
fix: align Storybook sample copy with content guidelines

### DIFF
--- a/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react-native/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -185,7 +185,7 @@ export const ActionButtonLayout: Story = {
 export const OnClose: Story = {
   args: {
     title: 'onClose demo',
-    children: 'Click the close icon to trigger onClose.',
+    children: 'Use the close icon to trigger onClose.',
     onClose: () => undefined,
     actionButtonLabel: undefined,
     actionButtonOnPress: undefined,

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.stories.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.stories.tsx
@@ -162,7 +162,7 @@ export const ActionButtonLayout: Story = {
 export const OnClose: Story = {
   args: {
     title: 'onClose demo',
-    children: 'Click the close icon to trigger onClose.',
+    children: 'Use the close icon to trigger onClose.',
     onClose: () => undefined,
     closeButtonProps: {
       testID: 'banner-base-close-button',

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
@@ -143,11 +143,11 @@ describe('BannerBase', () => {
       <BannerBase
         onClose={() => undefined}
         testID="banner-base"
-        title="Added to Watchlist"
+        title="Added to watchlist"
       />,
     );
 
-    const titleParent = getByText('Added to Watchlist').parent;
+    const titleParent = getByText('Added to watchlist').parent;
     if (!titleParent) {
       throw new Error('Expected title content parent');
     }
@@ -432,11 +432,11 @@ describe('BannerBase', () => {
         description="Supporting details"
         onClose={() => undefined}
         testID="banner-base"
-        title="Added to Watchlist"
+        title="Added to watchlist"
       />,
     );
 
-    const titleParent = getByText('Added to Watchlist').parent;
+    const titleParent = getByText('Added to watchlist').parent;
     if (!titleParent) {
       throw new Error('Expected title content parent');
     }

--- a/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react-native/src/components/BannerBase/BannerBase.test.tsx
@@ -219,13 +219,11 @@ describe('BannerBase', () => {
       <BannerBase
         onClose={() => undefined}
         testID="banner-base"
-        title="Your deposit of 20.50 USDC into Account 1 is been confirmed."
+        title="USDC deposited into Account 1"
       />,
     );
 
-    const titleParent = getByText(
-      'Your deposit of 20.50 USDC into Account 1 is been confirmed.',
-    ).parent;
+    const titleParent = getByText('USDC deposited into Account 1').parent;
     if (!titleParent) {
       throw new Error('Expected title content parent');
     }

--- a/packages/design-system-react-native/src/components/BottomSheetHeader/BottomSheetHeader.stories.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetHeader/BottomSheetHeader.stories.tsx
@@ -35,7 +35,7 @@ type Story = StoryObj<BottomSheetHeaderProps>;
 
 export const Default: Story = {
   args: {
-    children: 'BottomSheetHeader Title',
+    children: 'Sheet title',
   },
 };
 

--- a/packages/design-system-react-native/src/components/BottomSheetHeader/BottomSheetHeader.test.tsx
+++ b/packages/design-system-react-native/src/components/BottomSheetHeader/BottomSheetHeader.test.tsx
@@ -7,7 +7,7 @@ describe('BottomSheetHeader', () => {
   describe('rendering', () => {
     it('renders correctly with default props', () => {
       const { getByTestId } = render(
-        <BottomSheetHeader testID="header">Header Title</BottomSheetHeader>,
+        <BottomSheetHeader testID="header">Header title</BottomSheetHeader>,
       );
       expect(getByTestId('header')).toBeOnTheScreen();
     });
@@ -38,7 +38,7 @@ describe('BottomSheetHeader', () => {
           onBack={() => null}
           backButtonProps={{ testID: 'back-button' }}
         >
-          Header Title
+          Header title
         </BottomSheetHeader>,
       );
       expect(getByTestId('back-button')).toBeOnTheScreen();
@@ -51,7 +51,7 @@ describe('BottomSheetHeader', () => {
           onBack={onBack}
           backButtonProps={{ testID: 'back-button' }}
         >
-          Header Title
+          Header title
         </BottomSheetHeader>,
       );
 
@@ -62,7 +62,7 @@ describe('BottomSheetHeader', () => {
     it('does not render back button when onBack is not provided', () => {
       const { queryByTestId } = render(
         <BottomSheetHeader backButtonProps={{ testID: 'back-button' }}>
-          Header Title
+          Header title
         </BottomSheetHeader>,
       );
       expect(queryByTestId('back-button')).toBeNull();
@@ -76,7 +76,7 @@ describe('BottomSheetHeader', () => {
           onClose={() => null}
           closeButtonProps={{ testID: 'close-button' }}
         >
-          Header Title
+          Header title
         </BottomSheetHeader>,
       );
       expect(getByTestId('close-button')).toBeOnTheScreen();
@@ -89,7 +89,7 @@ describe('BottomSheetHeader', () => {
           onClose={onClose}
           closeButtonProps={{ testID: 'close-button' }}
         >
-          Header Title
+          Header title
         </BottomSheetHeader>,
       );
 
@@ -100,7 +100,7 @@ describe('BottomSheetHeader', () => {
     it('does not render close button when onClose is not provided', () => {
       const { queryByTestId } = render(
         <BottomSheetHeader closeButtonProps={{ testID: 'close-button' }}>
-          Header Title
+          Header title
         </BottomSheetHeader>,
       );
       expect(queryByTestId('close-button')).toBeNull();
@@ -125,7 +125,7 @@ describe('BottomSheetHeader', () => {
             accessibilityLabel: 'Close modal',
           }}
         >
-          Header Title
+          Header title
         </BottomSheetHeader>,
       );
 

--- a/packages/design-system-react-native/src/components/Button/Button.stories.tsx
+++ b/packages/design-system-react-native/src/components/Button/Button.stories.tsx
@@ -144,7 +144,7 @@ export const IsLoading: Story = {
               endIconName={IconName.ArrowRight}
               variant={ButtonVariant[variantKey as keyof typeof ButtonVariant]}
               isLoading
-              loadingText="With Loading Text"
+              loadingText="Loading..."
             >
               {variantKey}
             </ButtonStory>

--- a/packages/design-system-react-native/src/components/Button/Button.stories.tsx
+++ b/packages/design-system-react-native/src/components/Button/Button.stories.tsx
@@ -73,7 +73,7 @@ const ButtonStory: React.FC<ButtonProps> = ({ isInverse, ...props }) => {
 export const Default: Story = {
   args: {
     variant: ButtonVariant.Primary,
-    children: 'Sample Button Text',
+    children: 'Sample button text',
     size: ButtonSize.Lg,
     isLoading: false,
     loadingText: 'Loading',
@@ -164,7 +164,7 @@ export const WithStartAccessory: Story = {
           startIconName={IconName.ArrowLeft}
           variant={ButtonVariant[variantKey as keyof typeof ButtonVariant]}
         >
-          With Start Accessory
+          With start accessory
         </ButtonStory>
       ))}
     </View>
@@ -180,7 +180,7 @@ export const WithEndAccessory: Story = {
           endIconName={IconName.ArrowRight}
           variant={ButtonVariant[variantKey as keyof typeof ButtonVariant]}
         >
-          With End Accessory
+          With end accessory
         </ButtonStory>
       ))}
     </View>
@@ -197,7 +197,7 @@ export const WithStartAndEndAccessory: Story = {
           endIconName={IconName.ArrowRight}
           variant={ButtonVariant[variantKey as keyof typeof ButtonVariant]}
         >
-          With Start and End Accessory
+          With Start and end accessory
         </ButtonStory>
       ))}
     </View>

--- a/packages/design-system-react-native/src/components/Button/README.md
+++ b/packages/design-system-react-native/src/components/Button/README.md
@@ -143,7 +143,7 @@ Whether to show the button with inverted colors for use on colored backgrounds (
 
 ```tsx
 <Button variant={ButtonVariant.Primary} isInverse onPress={() => {}}>
-  Inverse Button
+  Inverse button
 </Button>
 ```
 
@@ -171,7 +171,7 @@ Whether the button should take up the full width of its container.
 
 ```tsx
 <Button variant={ButtonVariant.Primary} isFullWidth onPress={() => {}}>
-  Full Width Button
+  Full width button
 </Button>
 ```
 
@@ -185,7 +185,7 @@ Whether the button is in a loading state, showing a spinner.
 
 ```tsx
 <Button variant={ButtonVariant.Primary} isLoading onPress={() => {}}>
-  Loading Button
+  Loading button
 </Button>
 ```
 

--- a/packages/design-system-react-native/src/components/Button/README.md
+++ b/packages/design-system-react-native/src/components/Button/README.md
@@ -201,7 +201,7 @@ Text to display when the button is in loading state.
 <Button
   variant={ButtonVariant.Primary}
   isLoading
-  loadingText="Please wait..."
+  loadingText="Loading..."
   onPress={() => {}}
 >
   Submit

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.stories.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.stories.tsx
@@ -96,7 +96,7 @@ export const IsLoading: Story = {
   render: () => (
     <View style={{ gap: 16 }}>
       <ButtonPrimary isLoading>ButtonPrimary</ButtonPrimary>
-      <ButtonPrimary isLoading loadingText="With Loading Text">
+      <ButtonPrimary isLoading loadingText="Loading...">
         ButtonPrimary
       </ButtonPrimary>
     </View>

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.stories.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/ButtonPrimary.stories.tsx
@@ -66,7 +66,7 @@ const ButtonPrimaryStory: React.FC<ButtonPrimaryProps> = ({
 
 export const Default: Story = {
   args: {
-    children: 'Sample ButtonPrimary Text',
+    children: 'Sample ButtonPrimary text',
     size: ButtonSize.Lg,
     isLoading: false,
     loadingText: 'Loading',
@@ -105,21 +105,21 @@ export const IsLoading: Story = {
 
 export const WithStartAccessory: Story = {
   args: {
-    children: 'Start Accessory',
+    children: 'Start accessory',
     startIconName: IconName.Add,
   },
 };
 
 export const WithEndAccessory: Story = {
   args: {
-    children: 'End Accessory',
+    children: 'End accessory',
     endIconName: IconName.Add,
   },
 };
 
 export const WithStartAndEndAccessory: Story = {
   args: {
-    children: 'Start and End Accessory',
+    children: 'Start and end accessory',
     startIconName: IconName.Add,
     endIconName: IconName.AddSquare,
   },

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.stories.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.stories.tsx
@@ -66,7 +66,7 @@ const ButtonSecondaryStory: React.FC<ButtonSecondaryProps> = ({
 
 export const Default: Story = {
   args: {
-    children: 'Sample ButtonSecondary Text',
+    children: 'Sample ButtonSecondary text',
     size: ButtonSize.Lg,
     isLoading: false,
     loadingText: 'Loading',
@@ -105,21 +105,21 @@ export const IsLoading: Story = {
 
 export const WithStartAccessory: Story = {
   args: {
-    children: 'Start Accessory',
+    children: 'Start accessory',
     startIconName: IconName.Add,
   },
 };
 
 export const WithEndAccessory: Story = {
   args: {
-    children: 'End Accessory',
+    children: 'End accessory',
     endIconName: IconName.AddSquare,
   },
 };
 
 export const WithStartAndEndAccessory: Story = {
   args: {
-    children: 'Start and End Accessory',
+    children: 'Start and end accessory',
     startIconName: IconName.Add,
     endIconName: IconName.AddSquare,
   },

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.stories.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/ButtonSecondary.stories.tsx
@@ -96,7 +96,7 @@ export const IsLoading: Story = {
   render: () => (
     <View style={{ gap: 16 }}>
       <ButtonSecondary isLoading>ButtonSecondary</ButtonSecondary>
-      <ButtonSecondary isLoading loadingText="With Loading Text">
+      <ButtonSecondary isLoading loadingText="Loading...">
         ButtonSecondary
       </ButtonSecondary>
     </View>

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.stories.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.stories.tsx
@@ -66,7 +66,7 @@ const ButtonTertiaryStory: React.FC<ButtonTertiaryProps> = ({
 
 export const Default: Story = {
   args: {
-    children: 'Sample ButtonTertiary Text',
+    children: 'Sample ButtonTertiary text',
     size: ButtonSize.Lg,
     isLoading: false,
     loadingText: 'Loading',
@@ -105,21 +105,21 @@ export const IsLoading: Story = {
 
 export const WithStartAccessory: Story = {
   args: {
-    children: 'Start Acccessory',
+    children: 'Start accessory',
     startIconName: IconName.Add,
   },
 };
 
 export const WithEndAccessory: Story = {
   args: {
-    children: 'End Accessory',
+    children: 'End accessory',
     endIconName: IconName.AddSquare,
   },
 };
 
 export const WithStartAndEndAccessory: Story = {
   args: {
-    children: 'Start and End Accessory',
+    children: 'Start and end accessory',
     startIconName: IconName.Add,
     endIconName: IconName.AddSquare,
   },

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.stories.tsx
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/ButtonTertiary.stories.tsx
@@ -96,7 +96,7 @@ export const IsLoading: Story = {
   render: () => (
     <View style={{ gap: 16 }}>
       <ButtonTertiary isLoading>ButtonTertiary</ButtonTertiary>
-      <ButtonTertiary isLoading loadingText="With Loading Text">
+      <ButtonTertiary isLoading loadingText="Loading...">
         ButtonTertiary
       </ButtonTertiary>
     </View>

--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.stories.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.stories.tsx
@@ -319,7 +319,7 @@ export const IsLoading: Story = {
       <ButtonBase {...args} isLoading>
         ButtonBase
       </ButtonBase>
-      <ButtonBase {...args} isLoading loadingText="With Loading Text">
+      <ButtonBase {...args} isLoading loadingText="Loading...">
         ButtonBase
       </ButtonBase>
     </Box>

--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.test.tsx
@@ -376,7 +376,7 @@ describe('ButtonBase', () => {
     });
 
     it('renders loadingText in the spinner', () => {
-      const text = 'Please wait…';
+      const text = 'Loading...';
 
       const { getByText } = render(
         <ButtonBase isLoading loadingText={text}>
@@ -698,7 +698,7 @@ describe('ButtonBase', () => {
 
     it('marks loading state and prefers loadingText as label when provided', () => {
       const { getByTestId } = render(
-        <ButtonBase testID="btn" isLoading loadingText="Please wait">
+        <ButtonBase testID="btn" isLoading loadingText="Loading...">
           Loading Button
         </ButtonBase>,
       );
@@ -710,9 +710,9 @@ describe('ButtonBase', () => {
           busy: true,
         }),
       );
-      expect(btn.props.accessibilityLabel).toBe('Please wait');
+      expect(btn.props.accessibilityLabel).toBe('Loading...');
       expect(btn.props.accessibilityHint).toBe(
-        'Button is currently loading, please wait',
+        'Button is currently loading',
       );
       expect(btn).toBeDisabled();
     });
@@ -742,7 +742,7 @@ describe('ButtonBase', () => {
 
       expect(btn.props.accessibilityLabel).toBe('Button');
       expect(btn.props.accessibilityHint).toBe(
-        'Button is currently loading, please wait',
+        'Button is currently loading',
       );
       expect(btn.props.accessibilityState).toStrictEqual(
         expect.objectContaining({

--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.test.tsx
@@ -685,7 +685,7 @@ describe('ButtonBase', () => {
     it('marks disabled state when isDisabled', () => {
       const { getByTestId } = render(
         <ButtonBase testID="btn" isDisabled>
-          Disabled Button
+          Disabled button
         </ButtonBase>,
       );
       const btn = getByTestId('btn');
@@ -699,7 +699,7 @@ describe('ButtonBase', () => {
     it('marks loading state and prefers loadingText as label when provided', () => {
       const { getByTestId } = render(
         <ButtonBase testID="btn" isLoading loadingText="Loading...">
-          Loading Button
+          Loading button
         </ButtonBase>,
       );
       const btn = getByTestId('btn');

--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.test.tsx
@@ -711,9 +711,7 @@ describe('ButtonBase', () => {
         }),
       );
       expect(btn.props.accessibilityLabel).toBe('Loading...');
-      expect(btn.props.accessibilityHint).toBe(
-        'Button is currently loading',
-      );
+      expect(btn.props.accessibilityHint).toBe('Button is currently loading');
       expect(btn).toBeDisabled();
     });
 
@@ -741,9 +739,7 @@ describe('ButtonBase', () => {
       const btn = getByTestId('btn');
 
       expect(btn.props.accessibilityLabel).toBe('Button');
-      expect(btn.props.accessibilityHint).toBe(
-        'Button is currently loading',
-      );
+      expect(btn.props.accessibilityHint).toBe('Button is currently loading');
       expect(btn.props.accessibilityState).toStrictEqual(
         expect.objectContaining({
           disabled: true,

--- a/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.tsx
+++ b/packages/design-system-react-native/src/components/ButtonBase/ButtonBase.tsx
@@ -89,7 +89,7 @@ export const ButtonBase = ({
     }
 
     if (isLoading) {
-      return 'Button is currently loading, please wait';
+      return 'Button is currently loading';
     }
 
     return undefined;

--- a/packages/design-system-react-native/src/components/ButtonBase/README.md
+++ b/packages/design-system-react-native/src/components/ButtonBase/README.md
@@ -74,7 +74,7 @@ Whether the button is disabled.
 
 ```tsx
 <ButtonBase isDisabled onPress={() => {}}>
-  Disabled Button
+  Disabled button
 </ButtonBase>
 ```
 

--- a/packages/design-system-react-native/src/components/ButtonHero/ButtonHero.stories.tsx
+++ b/packages/design-system-react-native/src/components/ButtonHero/ButtonHero.stories.tsx
@@ -60,7 +60,7 @@ type Story = StoryObj<typeof ButtonHero>;
 
 export const Default: Story = {
   args: {
-    children: 'Primary Action',
+    children: 'Primary action',
   },
 };
 
@@ -82,28 +82,28 @@ export const Size: Story = {
 
 export const IsFullWidth: Story = {
   args: {
-    children: 'Full Width',
+    children: 'Full width',
     isFullWidth: true,
   },
 };
 
 export const StartIconName: Story = {
   args: {
-    children: 'Start Icon',
+    children: 'Start icon',
     startIconName: IconName.AddSquare,
   },
 };
 
 export const EndIconName: Story = {
   args: {
-    children: 'End Icon',
+    children: 'End icon',
     endIconName: IconName.AddSquare,
   },
 };
 
 export const IsDisabled: Story = {
   args: {
-    children: 'Disabled Button',
+    children: 'Disabled button',
     isDisabled: true,
   },
 };

--- a/packages/design-system-react-native/src/components/ButtonHero/ButtonHero.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonHero/ButtonHero.test.tsx
@@ -109,12 +109,12 @@ describe('ButtonHero', () => {
 
   it('displays loading text when provided', () => {
     const { getByText } = render(
-      <ButtonHero isLoading loadingText="Please wait...">
+      <ButtonHero isLoading loadingText="Loading...">
         Submit
       </ButtonHero>,
     );
 
-    expect(getByText('Please wait...')).toBeDefined();
+    expect(getByText('Loading...')).toBeDefined();
   });
 
   it('uses light theme primary background color', () => {

--- a/packages/design-system-react-native/src/components/ButtonHero/ButtonHero.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonHero/ButtonHero.test.tsx
@@ -79,7 +79,7 @@ describe('ButtonHero', () => {
     const handlePress = jest.fn();
     const { getByRole } = render(
       <ButtonHero isDisabled onPress={handlePress}>
-        Disabled Button
+        Disabled button
       </ButtonHero>,
     );
 
@@ -94,7 +94,7 @@ describe('ButtonHero', () => {
         loadingText="Loading..."
         loadingWrapperProps={{ testID: 'spinner-container' }}
       >
-        Loading Button
+        Loading button
       </ButtonHero>,
     );
 
@@ -213,7 +213,7 @@ describe('ButtonHero', () => {
   it('supports isFullWidth prop', () => {
     const { getByRole } = render(
       <ButtonHero isFullWidth testID="full-width-btn">
-        Full Width
+        Full width
       </ButtonHero>,
     );
 
@@ -227,7 +227,7 @@ describe('ButtonHero', () => {
         startIconName={IconName.Add}
         startIconProps={{ testID: 'start-icon' }}
       >
-        With Start Icon
+        With start icon
       </ButtonHero>,
     );
 
@@ -240,7 +240,7 @@ describe('ButtonHero', () => {
         endIconName={IconName.ArrowRight}
         endIconProps={{ testID: 'end-icon' }}
       >
-        With End Icon
+        With end icon
       </ButtonHero>,
     );
 

--- a/packages/design-system-react-native/src/components/ButtonHero/README.md
+++ b/packages/design-system-react-native/src/components/ButtonHero/README.md
@@ -28,7 +28,7 @@ import { ButtonHero } from '@metamask/design-system-react-native';
 | `React.ReactNode` | Yes      | `undefined` |
 
 ```tsx
-<ButtonHero>Primary Action</ButtonHero>
+<ButtonHero>Primary action</ButtonHero>
 ```
 
 ### `size`
@@ -62,7 +62,7 @@ ButtonHero can be set to take up the full width of its container.
 | `boolean` | No       | `false` |
 
 ```tsx
-<ButtonHero isFullWidth>Full Width Button</ButtonHero>
+<ButtonHero isFullWidth>Full width button</ButtonHero>
 ```
 
 ### `startIconName`
@@ -76,7 +76,7 @@ ButtonHero can display an icon at the start of the button.
 ```tsx
 import { ButtonHero, IconName } from '@metamask/design-system-react-native';
 
-<ButtonHero startIconName={IconName.AddSquare}>Start Icon</ButtonHero>;
+<ButtonHero startIconName={IconName.AddSquare}>Start icon</ButtonHero>;
 ```
 
 ### `endIconName`
@@ -90,7 +90,7 @@ ButtonHero can display an icon at the end of the button.
 ```tsx
 import { ButtonHero, IconName } from '@metamask/design-system-react-native';
 
-<ButtonHero endIconName={IconName.ArrowRight}>End Icon</ButtonHero>;
+<ButtonHero endIconName={IconName.ArrowRight}>End icon</ButtonHero>;
 ```
 
 ### `isDisabled`
@@ -102,7 +102,7 @@ Whether the button is disabled.
 | `boolean` | No       | `false` |
 
 ```tsx
-<ButtonHero isDisabled>Disabled Button</ButtonHero>
+<ButtonHero isDisabled>Disabled button</ButtonHero>
 ```
 
 ### `isLoading`
@@ -115,7 +115,7 @@ Whether the button is in a loading state.
 
 ```tsx
 <ButtonHero isLoading loadingText="Loading...">
-  Loading Button
+  Loading button
 </ButtonHero>
 ```
 

--- a/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.stories.tsx
+++ b/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.stories.tsx
@@ -74,7 +74,7 @@ export const Severity: Story = {
         Success Button
       </ButtonSemantic>
       <ButtonSemantic {...args} severity={ButtonSemanticSeverity.Danger}>
-        Danger Button
+        Danger button
       </ButtonSemantic>
     </Box>
   ),

--- a/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.stories.tsx
+++ b/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.stories.tsx
@@ -71,7 +71,7 @@ export const Severity: Story = {
   render: (args) => (
     <Box gap={4}>
       <ButtonSemantic {...args} severity={ButtonSemanticSeverity.Success}>
-        Success Button
+        Success button
       </ButtonSemantic>
       <ButtonSemantic {...args} severity={ButtonSemanticSeverity.Danger}>
         Danger button

--- a/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.test.tsx
@@ -32,11 +32,11 @@ describe('ButtonSemantic', () => {
           severity={ButtonSemanticSeverity.Danger}
           onPress={mockOnPress}
         >
-          Danger Button
+          Danger button
         </ButtonSemantic>,
       );
 
-      expect(getByText('Danger Button')).toBeDefined();
+      expect(getByText('Danger button')).toBeDefined();
     });
 
     it.each([
@@ -94,11 +94,11 @@ describe('ButtonSemantic', () => {
           onPress={mockOnPress}
           isDisabled
         >
-          Disabled Button
+          Disabled button
         </ButtonSemantic>,
       );
 
-      fireEvent.press(getByText('Disabled Button'));
+      fireEvent.press(getByText('Disabled button'));
 
       expect(mockOnPress).not.toHaveBeenCalled();
     });
@@ -141,11 +141,11 @@ describe('ButtonSemantic', () => {
           onPress={mockOnPress}
           isDisabled
         >
-          Disabled Button
+          Disabled button
         </ButtonSemantic>,
       );
 
-      expect(getByText('Disabled Button')).toBeDefined();
+      expect(getByText('Disabled button')).toBeDefined();
     });
   });
 

--- a/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.test.tsx
+++ b/packages/design-system-react-native/src/components/ButtonSemantic/ButtonSemantic.test.tsx
@@ -19,11 +19,11 @@ describe('ButtonSemantic', () => {
           severity={ButtonSemanticSeverity.Success}
           onPress={mockOnPress}
         >
-          Success Button
+          Success button
         </ButtonSemantic>,
       );
 
-      expect(getByText('Success Button')).toBeDefined();
+      expect(getByText('Success button')).toBeDefined();
     });
 
     it('renders with Danger severity', () => {

--- a/packages/design-system-react-native/src/components/HeaderBase/HeaderBase.stories.tsx
+++ b/packages/design-system-react-native/src/components/HeaderBase/HeaderBase.stories.tsx
@@ -38,14 +38,14 @@ export default HeaderBaseMeta;
 
 export const Default = {
   args: {
-    children: 'Header Title',
+    children: 'Header title',
   },
 };
 
 export const TwClassName = {
   render: () => (
     <HeaderBase twClassName="bg-info-default px-4">
-      Header with Custom Styles
+      Header with custom styles
     </HeaderBase>
   ),
 };
@@ -58,7 +58,7 @@ export const StartButtonIconProps = {
         onPress: () => console.log('Back pressed'),
       }}
     >
-      With Start Button
+      With start button
     </HeaderBase>
   ),
 };
@@ -73,7 +73,7 @@ export const EndButtonIconProps = {
         },
       ]}
     >
-      With End Button
+      With end button
     </HeaderBase>
   ),
 };
@@ -96,7 +96,7 @@ export const MultipleEndButtonIconProps = {
         },
       ]}
     >
-      Multiple End Buttons
+      Multiple end buttons
     </HeaderBase>
   ),
 };
@@ -112,7 +112,7 @@ export const StartAccessory = {
         />
       }
     >
-      With Start Accessory
+      With start accessory
     </HeaderBase>
   ),
 };
@@ -128,7 +128,7 @@ export const EndAccessory = {
         />
       }
     >
-      With End Accessory
+      With end accessory
     </HeaderBase>
   ),
 };
@@ -151,7 +151,7 @@ export const BothAccessories = {
         />
       }
     >
-      Both Accessories
+      Both accessories
     </HeaderBase>
   ),
 };
@@ -165,7 +165,7 @@ export const Children = {
       }}
     >
       <Box twClassName="items-center">
-        <Text variant={TextVariant.HeadingSm}>Custom Title</Text>
+        <Text variant={TextVariant.HeadingSm}>Custom title</Text>
         <Text variant={TextVariant.BodySm}>Subtitle text</Text>
       </Box>
     </HeaderBase>

--- a/packages/design-system-react-native/src/components/HeaderBase/README.md
+++ b/packages/design-system-react-native/src/components/HeaderBase/README.md
@@ -5,7 +5,7 @@ HeaderBase is a reusable header component with optional start/end accessories an
 ```tsx
 import { HeaderBase } from '@metamask/design-system-react-native';
 
-<HeaderBase>Page Title</HeaderBase>;
+<HeaderBase>Page title</HeaderBase>;
 ```
 
 ## Props
@@ -22,12 +22,12 @@ The title of the header. Pass a string for automatic Text rendering with the cor
 
 ```tsx
 // String title (auto-renders as Text with correct variant)
-<HeaderBase>Page Title</HeaderBase>
+<HeaderBase>Page title</HeaderBase>
 
 // Custom ReactNode title
 <HeaderBase>
   <Box twClassName="items-center">
-    <Text variant={TextVariant.HeadingSm}>Custom Title</Text>
+    <Text variant={TextVariant.HeadingSm}>Custom title</Text>
     <Text variant={TextVariant.BodySm}>Subtitle</Text>
   </Box>
 </HeaderBase>
@@ -51,7 +51,7 @@ Content displayed before the title. Takes priority over `startButtonIconProps` i
     />
   }
 >
-  Page Title
+  Page title
 </HeaderBase>
 ```
 
@@ -73,7 +73,7 @@ Content displayed after the title. Takes priority over `endButtonIconProps` if b
     />
   }
 >
-  Page Title
+  Page title
 </HeaderBase>
 ```
 
@@ -92,7 +92,7 @@ ButtonIcon props to render a ButtonIcon as the start accessory. Only used if `st
     onPress: handleBack,
   }}
 >
-  Page Title
+  Page title
 </HeaderBase>
 ```
 
@@ -112,7 +112,7 @@ Array of ButtonIcon props to render multiple ButtonIcons as end accessories. Ren
     { iconName: IconName.Close, onPress: handleClose },
   ]}
 >
-  Page Title
+  Page title
 </HeaderBase>
 ```
 
@@ -125,7 +125,7 @@ Adds the device's safe area top inset as margin to ensure the header is visible 
 | `boolean` | No       | `false` |
 
 ```tsx
-<HeaderBase includesTopInset>Page Title</HeaderBase>
+<HeaderBase includesTopInset>Page title</HeaderBase>
 ```
 
 ### `twClassName`
@@ -161,7 +161,7 @@ Props passed to the `Text` element when `children` is a string. This is the pref
 | `Omit<Partial<TextProps>, 'children'>` | No       | `undefined` |
 
 ```tsx
-<HeaderBase textProps={{ testID: 'my-header-title' }}>Page Title</HeaderBase>
+<HeaderBase textProps={{ testID: 'my-header-title' }}>Page title</HeaderBase>
 ```
 
 ## Migration from MetaMask Mobile Component Library

--- a/packages/design-system-react-native/src/components/HeaderRoot/README.md
+++ b/packages/design-system-react-native/src/components/HeaderRoot/README.md
@@ -11,7 +11,7 @@ HeaderRoot is a header with a left section and an end section(`endAccessory` or 
 import { HeaderRoot, IconName } from '@metamask/design-system-react-native';
 
 <HeaderRoot
-  title="Screen Title"
+  title="Screen title"
   endButtonIconProps={[{ iconName: IconName.Close, onPress: handleClose }]}
 />;
 ```

--- a/packages/design-system-react-native/src/components/HeaderStandard/HeaderStandard.stories.tsx
+++ b/packages/design-system-react-native/src/components/HeaderStandard/HeaderStandard.stories.tsx
@@ -30,14 +30,14 @@ type Story = StoryObj<HeaderStandardProps>;
 
 export const Default: Story = {
   args: {
-    title: 'Header Title',
+    title: 'Header title',
   },
 };
 
 export const Subtitle: Story = {
   args: {
     title: 'Settings',
-    subtitle: 'Account Settings',
+    subtitle: 'Account settings',
     onBack: () => null,
   },
 };
@@ -51,7 +51,7 @@ export const OnBack: Story = {
 
 export const OnClose: Story = {
   args: {
-    title: 'Modal Title',
+    title: 'Modal title',
     onClose: () => null,
   },
 };
@@ -82,7 +82,7 @@ export const Children: Story = {
   render: () => (
     <HeaderStandard onClose={() => null}>
       <Box twClassName="items-center">
-        <Text variant={TextVariant.HeadingSm}>Custom Title</Text>
+        <Text variant={TextVariant.HeadingSm}>Custom title</Text>
         <Text variant={TextVariant.BodySm}>Subtitle text</Text>
       </Box>
     </HeaderStandard>

--- a/packages/design-system-react-native/src/components/HeaderStandard/HeaderStandard.test.tsx
+++ b/packages/design-system-react-native/src/components/HeaderStandard/HeaderStandard.test.tsx
@@ -24,15 +24,15 @@ describe('HeaderStandard', () => {
 
   describe('title and subtitle', () => {
     it('renders with title', () => {
-      const { getByText } = render(<HeaderStandard title="Test Title" />);
+      const { getByText } = render(<HeaderStandard title="Test title" />);
 
-      expect(getByText('Test Title')).toBeOnTheScreen();
+      expect(getByText('Test title')).toBeOnTheScreen();
     });
 
     it('renders title with testID when provided via titleProps', () => {
       const { getByTestId } = render(
         <HeaderStandard
-          title="Test Title"
+          title="Test title"
           titleProps={{ testID: TITLE_TEST_ID }}
         />,
       );
@@ -42,7 +42,7 @@ describe('HeaderStandard', () => {
 
     it('renders container with testID when provided', () => {
       const { getByTestId } = render(
-        <HeaderStandard title="Test Title" testID={CONTAINER_TEST_ID} />,
+        <HeaderStandard title="Test title" testID={CONTAINER_TEST_ID} />,
       );
 
       expect(getByTestId(CONTAINER_TEST_ID)).toBeOnTheScreen();
@@ -50,45 +50,45 @@ describe('HeaderStandard', () => {
 
     it('renders custom children instead of title', () => {
       const { getByText, queryByText } = render(
-        <HeaderStandard title="Ignored Title">
-          <Text>Custom Content</Text>
+        <HeaderStandard title="Ignored title">
+          <Text>Custom content</Text>
         </HeaderStandard>,
       );
 
-      expect(getByText('Custom Content')).toBeOnTheScreen();
-      expect(queryByText('Ignored Title')).not.toBeOnTheScreen();
+      expect(getByText('Custom content')).toBeOnTheScreen();
+      expect(queryByText('Ignored title')).not.toBeOnTheScreen();
     });
 
     it('renders children when both title and children provided', () => {
       const { getByText, queryByText } = render(
-        <HeaderStandard title="Title Text">
-          <Text>Children Text</Text>
+        <HeaderStandard title="Title text">
+          <Text>Children text</Text>
         </HeaderStandard>,
       );
 
-      expect(getByText('Children Text')).toBeOnTheScreen();
-      expect(queryByText('Title Text')).not.toBeOnTheScreen();
+      expect(getByText('Children text')).toBeOnTheScreen();
+      expect(queryByText('Title text')).not.toBeOnTheScreen();
     });
 
     it('renders subtitle when provided', () => {
       const { getByText } = render(
-        <HeaderStandard title="Test Title" subtitle="Test Subtitle" />,
+        <HeaderStandard title="Test title" subtitle="Test subtitle" />,
       );
 
-      expect(getByText('Test Subtitle')).toBeOnTheScreen();
+      expect(getByText('Test subtitle')).toBeOnTheScreen();
     });
 
     it('does not render subtitle when not provided', () => {
-      const { queryByText } = render(<HeaderStandard title="Test Title" />);
+      const { queryByText } = render(<HeaderStandard title="Test title" />);
 
-      expect(queryByText('Test Subtitle')).not.toBeOnTheScreen();
+      expect(queryByText('Test subtitle')).not.toBeOnTheScreen();
     });
 
     it('renders subtitle with testID when provided via subtitleProps', () => {
       const { getByTestId } = render(
         <HeaderStandard
-          title="Test Title"
-          subtitle="Test Subtitle"
+          title="Test title"
+          subtitle="Test subtitle"
           subtitleProps={{ testID: 'subtitle-test-id' }}
         />,
       );
@@ -98,38 +98,38 @@ describe('HeaderStandard', () => {
 
     it('renders both title and subtitle together', () => {
       const { getByText } = render(
-        <HeaderStandard title="Main Title" subtitle="Supporting Text" />,
+        <HeaderStandard title="Main title" subtitle="Supporting text" />,
       );
 
-      expect(getByText('Main Title')).toBeOnTheScreen();
-      expect(getByText('Supporting Text')).toBeOnTheScreen();
+      expect(getByText('Main title')).toBeOnTheScreen();
+      expect(getByText('Supporting text')).toBeOnTheScreen();
     });
 
     it('renders title when passed as React node', () => {
       const TITLE_NODE_TEST_ID = 'custom-title-node';
       const { getByTestId, getByText } = render(
         <HeaderStandard
-          title={<Text testID={TITLE_NODE_TEST_ID}>Custom Title Node</Text>}
+          title={<Text testID={TITLE_NODE_TEST_ID}>Custom title node</Text>}
         />,
       );
 
       expect(getByTestId(TITLE_NODE_TEST_ID)).toBeOnTheScreen();
-      expect(getByText('Custom Title Node')).toBeOnTheScreen();
+      expect(getByText('Custom title node')).toBeOnTheScreen();
     });
 
     it('renders subtitle when passed as React node', () => {
       const SUBTITLE_NODE_TEST_ID = 'custom-subtitle-node';
       const { getByTestId, getByText } = render(
         <HeaderStandard
-          title="Page Title"
+          title="Page title"
           subtitle={
-            <Text testID={SUBTITLE_NODE_TEST_ID}>Custom Subtitle Node</Text>
+            <Text testID={SUBTITLE_NODE_TEST_ID}>Custom subtitle node</Text>
           }
         />,
       );
 
       expect(getByTestId(SUBTITLE_NODE_TEST_ID)).toBeOnTheScreen();
-      expect(getByText('Custom Subtitle Node')).toBeOnTheScreen();
+      expect(getByText('Custom subtitle node')).toBeOnTheScreen();
     });
 
     it('renders both title and subtitle as React nodes', () => {
@@ -137,8 +137,8 @@ describe('HeaderStandard', () => {
       const SUBTITLE_NODE_TEST_ID = 'subtitle-node';
       const { getByTestId } = render(
         <HeaderStandard
-          title={<Text testID={TITLE_NODE_TEST_ID}>Node Title</Text>}
-          subtitle={<Text testID={SUBTITLE_NODE_TEST_ID}>Node Subtitle</Text>}
+          title={<Text testID={TITLE_NODE_TEST_ID}>Node title</Text>}
+          subtitle={<Text testID={SUBTITLE_NODE_TEST_ID}>Node subtitle</Text>}
         />,
       );
 
@@ -158,7 +158,7 @@ describe('HeaderStandard', () => {
     it('does not render subtitle row when subtitle is an empty string', () => {
       const { getByTestId, queryByTestId } = render(
         <HeaderStandard
-          title="Only Title"
+          title="Only title"
           titleProps={{ testID: TITLE_TEST_ID }}
           subtitle=""
           subtitleProps={{ testID: SUBTITLE_ROW_TEST_ID }}

--- a/packages/design-system-react-native/src/components/HeaderStandard/README.md
+++ b/packages/design-system-react-native/src/components/HeaderStandard/README.md
@@ -5,7 +5,7 @@ HeaderStandard is a header component with a centered title and optional back and
 ```tsx
 import { HeaderStandard } from '@metamask/design-system-react-native';
 
-<HeaderStandard title="Page Title" onBack={handleBack} onClose={handleClose} />;
+<HeaderStandard title="Page title" onBack={handleBack} onClose={handleClose} />;
 ```
 
 ## Props
@@ -164,12 +164,12 @@ Tailwind classes merged onto the root [HeaderBase](../HeaderBase/README.md) cont
 <HeaderStandard title="Settings" onBack={() => navigation.goBack()} />
 
 <HeaderStandard
-  title="Modal Title"
+  title="Modal title"
   onClose={() => setModalVisible(false)}
 />
 
 <HeaderStandard
-  title="Page Title"
+  title="Page title"
   subtitle="Subtitle text"
   onBack={handleBack}
   onClose={handleClose}

--- a/packages/design-system-react-native/src/components/HeaderStandardAnimated/HeaderStandardAnimated.stories.tsx
+++ b/packages/design-system-react-native/src/components/HeaderStandardAnimated/HeaderStandardAnimated.stories.tsx
@@ -123,7 +123,7 @@ export const OnBack: Story = {
 
 export const OnClose: Story = {
   args: {
-    title: 'Modal Title',
+    title: 'Modal title',
     onClose: () => undefined,
   },
   render: (args) => <ScrollDemo {...args} />,

--- a/packages/design-system-react-native/src/components/Input/Input.stories.tsx
+++ b/packages/design-system-react-native/src/components/Input/Input.stories.tsx
@@ -51,7 +51,7 @@ type Story = StoryObj<InputProps>;
 export const Default: Story = {
   args: {
     value: '',
-    placeholder: 'Sample Placeholder',
+    placeholder: 'Sample placeholder',
   },
   render: (args) => <ControlledInput {...args} />,
 };

--- a/packages/design-system-react-native/src/components/Label/Label.stories.tsx
+++ b/packages/design-system-react-native/src/components/Label/Label.stories.tsx
@@ -28,6 +28,6 @@ type Story = StoryObj<LabelProps>;
 
 export const Default: Story = {
   args: {
-    children: 'Sample Label Text',
+    children: 'Sample label text',
   },
 };

--- a/packages/design-system-react-native/src/components/Label/Label.test.tsx
+++ b/packages/design-system-react-native/src/components/Label/Label.test.tsx
@@ -6,13 +6,13 @@ import { Label } from './Label';
 describe('Label', () => {
   it('renders correctly', () => {
     const { getByTestId } = render(
-      <Label testID="label">Sample Label Text</Label>,
+      <Label testID="label">Sample label text</Label>,
     );
     expect(getByTestId('label')).toBeDefined();
   });
 
   it('renders children content', () => {
-    const { getByText } = render(<Label>Sample Label Text</Label>);
-    expect(getByText('Sample Label Text')).toBeDefined();
+    const { getByText } = render(<Label>Sample label text</Label>);
+    expect(getByText('Sample label text')).toBeDefined();
   });
 });

--- a/packages/design-system-react-native/src/components/Label/README.md
+++ b/packages/design-system-react-native/src/components/Label/README.md
@@ -5,7 +5,7 @@ Label is used to describe the purpose of a form field. It renders a standardized
 ```tsx
 import { Label } from '@metamask/design-system-react-native';
 
-<Label>Email Address</Label>;
+<Label>Email address</Label>;
 ```
 
 ## Props
@@ -36,8 +36,8 @@ Optional enum to select between typography variants. The Label defaults to `Text
 import { Label } from '@metamask/design-system-react-native';
 import { TextVariant } from '@metamask/design-system-react-native';
 
-<Label variant={TextVariant.BodySm}>Small Label</Label>
-<Label>Default Label (BodyMd)</Label>
+<Label variant={TextVariant.BodySm}>Small label</Label>
+<Label>Default label (BodyMd)</Label>
 ```
 
 ### `twClassName`
@@ -58,7 +58,7 @@ import { Label } from '@metamask/design-system-react-native';
 <Label twClassName="mb-2">Label with margin</Label>
 
 // Override default styles
-<Label twClassName="text-error-default">Required Field</Label>
+<Label twClassName="text-error-default">Required field</Label>
 ```
 
 ### `style`
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
 });
 
 export const StyleExample = () => (
-  <Label style={styles.custom}>Styled Label</Label>
+  <Label style={styles.custom}>Styled label</Label>
 );
 ```
 

--- a/packages/design-system-react-native/src/components/RadioButton/RadioButton.constants.ts
+++ b/packages/design-system-react-native/src/components/RadioButton/RadioButton.constants.ts
@@ -2,7 +2,7 @@ import type { RadioButtonProps } from './RadioButton.types';
 
 // Sample props for stories and tests
 export const SAMPLE_RADIOBUTTON_PROPS: RadioButtonProps = {
-  label: 'Sample RadioButton Label',
+  label: 'Sample radio button label',
   isChecked: false,
   isDisabled: false,
   isReadOnly: false,

--- a/packages/design-system-react-native/src/components/RadioButton/RadioButton.stories.tsx
+++ b/packages/design-system-react-native/src/components/RadioButton/RadioButton.stories.tsx
@@ -62,7 +62,7 @@ export const IsReadOnly: Story = {
   render: () => (
     <View style={{ gap: 16 }}>
       <RadioButtonStory label="Editable" />
-      <RadioButtonStory isReadOnly isChecked label="Read Only" />
+      <RadioButtonStory isReadOnly isChecked label="Read only" />
     </View>
   ),
 };

--- a/packages/design-system-react-native/src/components/SensitiveText/README.md
+++ b/packages/design-system-react-native/src/components/SensitiveText/README.md
@@ -65,7 +65,7 @@ The text content to display or hide.
 | `ReactNode` | Yes      | `undefined` |
 
 ```tsx
-<SensitiveText isHidden>Sensitive Information</SensitiveText>
+<SensitiveText isHidden>Sensitive information</SensitiveText>
 ```
 
 ### `twClassName`

--- a/packages/design-system-react-native/src/components/SensitiveText/SensitiveText.stories.tsx
+++ b/packages/design-system-react-native/src/components/SensitiveText/SensitiveText.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = {
     length: SensitiveTextLength.Short,
     variant: TextVariant.BodyMd,
     color: TextColor.TextDefault,
-    children: 'Sensitive Information',
+    children: 'Sensitive information',
   },
 };
 
@@ -36,10 +36,10 @@ export const IsHidden: Story = {
   render: () => (
     <>
       <SensitiveText variant={TextVariant.BodyMd}>
-        Visible: Sensitive Information
+        Visible: Sensitive information
       </SensitiveText>
       <SensitiveText variant={TextVariant.BodyMd} isHidden>
-        Hidden: Sensitive Information
+        Hidden: Sensitive information
       </SensitiveText>
     </>
   ),

--- a/packages/design-system-react-native/src/components/SensitiveText/SensitiveText.test.tsx
+++ b/packages/design-system-react-native/src/components/SensitiveText/SensitiveText.test.tsx
@@ -11,7 +11,7 @@ describe('SensitiveText', () => {
   it('renders correctly', () => {
     const { getByTestId } = render(
       <SensitiveText testID="sensitive-text">
-        Sensitive Information
+        Sensitive information
       </SensitiveText>,
     );
     expect(getByTestId('sensitive-text')).toBeDefined();
@@ -26,16 +26,16 @@ describe('SensitiveText', () => {
 
   it('displays the text when isHidden is false', () => {
     const { getByText } = render(
-      <SensitiveText>Sensitive Information</SensitiveText>,
+      <SensitiveText>Sensitive information</SensitiveText>,
     );
-    expect(getByText('Sensitive Information')).toBeDefined();
+    expect(getByText('Sensitive information')).toBeDefined();
   });
 
   it('hides the text when isHidden is true', () => {
     const { queryByText, getByText } = render(
-      <SensitiveText isHidden>Sensitive Information</SensitiveText>,
+      <SensitiveText isHidden>Sensitive information</SensitiveText>,
     );
-    expect(queryByText('Sensitive Information')).toBeNull();
+    expect(queryByText('Sensitive information')).toBeNull();
     expect(getByText('••••••')).toBeDefined();
   });
 
@@ -98,10 +98,10 @@ describe('SensitiveText', () => {
     const tw = renderHook(() => useTailwind()).result.current;
     const { getByText } = render(
       <SensitiveText color={TextColor.TextDefault}>
-        Sensitive Information
+        Sensitive information
       </SensitiveText>,
     );
-    const textElement = getByText('Sensitive Information');
+    const textElement = getByText('Sensitive information');
     const styles = [textElement.props.style].flat();
     const color = styles.find(
       (s: Record<string, unknown>) => s?.color !== undefined,

--- a/packages/design-system-react-native/src/components/TabEmptyState/README.md
+++ b/packages/design-system-react-native/src/components/TabEmptyState/README.md
@@ -7,7 +7,7 @@ import { TabEmptyState } from '@metamask/design-system-react-native';
 
 <TabEmptyState
   description="No items found"
-  actionButtonText="Add Item"
+  actionButtonText="Add item"
   onAction={() => console.log('pressed')}
 />;
 ```
@@ -69,7 +69,7 @@ Optional label for the action button. The button is only rendered when both `act
 
 ```tsx
 <TabEmptyState
-  actionButtonText="Try Again"
+  actionButtonText="Try again"
   onAction={() => console.log('pressed')}
 />
 ```
@@ -84,7 +84,7 @@ Optional props to pass to the action `Button` component. Use this for a separate
 
 ```tsx
 <TabEmptyState
-  actionButtonText="Add Item"
+  actionButtonText="Add item"
   onAction={() => {}}
   actionButtonProps={{ testID: 'action-button' }}
 />

--- a/packages/design-system-react-native/src/components/TabEmptyState/TabEmptyState.stories.tsx
+++ b/packages/design-system-react-native/src/components/TabEmptyState/TabEmptyState.stories.tsx
@@ -39,7 +39,7 @@ export const Default: Story = {
   args: {
     icon: <Icon name={IconName.Add} size={IconSize.Xl} />,
     description: 'No perpetual positions found',
-    actionButtonText: 'Start Trading',
+    actionButtonText: 'Start trading',
   },
 };
 
@@ -65,7 +65,7 @@ export const OnAction: Story = {
     <TabEmptyState
       {...args}
       description="No results found"
-      actionButtonText="Try Again"
+      actionButtonText="Try again"
       onAction={() => {
         console.log('Action pressed');
       }}

--- a/packages/design-system-react-native/src/components/TabEmptyState/TabEmptyState.test.tsx
+++ b/packages/design-system-react-native/src/components/TabEmptyState/TabEmptyState.test.tsx
@@ -18,14 +18,14 @@ describe('TabEmptyState', () => {
       <TabEmptyState
         testID="tab-empty-state"
         description="No items found"
-        actionButtonText="Add Item"
+        actionButtonText="Add item"
         onAction={mockOnAction}
       />,
     );
 
     expect(getByTestId('tab-empty-state')).toBeDefined();
     expect(getByText('No items found')).toBeDefined();
-    expect(getByText('Add Item')).toBeDefined();
+    expect(getByText('Add item')).toBeDefined();
   });
 
   it('renders description when provided', () => {
@@ -50,24 +50,24 @@ describe('TabEmptyState', () => {
 
   it('renders action button when both actionButtonText and onAction are provided', () => {
     const { getByText } = render(
-      <TabEmptyState actionButtonText="Add Item" onAction={mockOnAction} />,
+      <TabEmptyState actionButtonText="Add item" onAction={mockOnAction} />,
     );
 
-    expect(getByText('Add Item')).toBeDefined();
+    expect(getByText('Add item')).toBeDefined();
   });
 
   it('does not render action button when only actionButtonText is provided', () => {
     const { queryByText } = render(
-      <TabEmptyState actionButtonText="Add Item" />,
+      <TabEmptyState actionButtonText="Add item" />,
     );
 
-    expect(queryByText('Add Item')).toBeNull();
+    expect(queryByText('Add item')).toBeNull();
   });
 
   it('does not render action button when only onAction is provided', () => {
     const { queryByText } = render(<TabEmptyState onAction={mockOnAction} />);
 
-    expect(queryByText('Add Item')).toBeNull();
+    expect(queryByText('Add item')).toBeNull();
   });
 
   it('renders custom children', () => {
@@ -82,10 +82,10 @@ describe('TabEmptyState', () => {
 
   it('calls onAction when action button is pressed', () => {
     const { getByText } = render(
-      <TabEmptyState actionButtonText="Add Item" onAction={mockOnAction} />,
+      <TabEmptyState actionButtonText="Add item" onAction={mockOnAction} />,
     );
 
-    fireEvent.press(getByText('Add Item'));
+    fireEvent.press(getByText('Add item'));
     expect(mockOnAction).toHaveBeenCalledTimes(1);
   });
 
@@ -118,7 +118,7 @@ describe('TabEmptyState', () => {
   it('passes actionButtonProps to action Button component', () => {
     const { getByTestId } = render(
       <TabEmptyState
-        actionButtonText="Add Item"
+        actionButtonText="Add item"
         onAction={mockOnAction}
         actionButtonProps={{ testID: 'custom-button' }}
       />,

--- a/packages/design-system-react-native/src/components/TextButton/TextButton.figma.tsx
+++ b/packages/design-system-react-native/src/components/TextButton/TextButton.figma.tsx
@@ -27,7 +27,7 @@ figma.connect(
     },
     example: ({ size, ...props }) => (
       <TextButton {...props} variant={size} onPress={() => undefined}>
-        Text Button
+        Text button
       </TextButton>
     ),
   },

--- a/packages/design-system-react-native/src/components/TextButton/TextButton.stories.tsx
+++ b/packages/design-system-react-native/src/components/TextButton/TextButton.stories.tsx
@@ -31,7 +31,7 @@ type Story = StoryObj<TextButtonProps>;
 
 export const Default: Story = {
   args: {
-    children: 'Sample TextButton',
+    children: 'Sample text button',
     onPress: () => undefined,
     suppressHighlighting: true,
   },
@@ -60,7 +60,7 @@ export const InlineWithText: Story = {
   render: () => (
     <Text>
       Pre TextButton text{' '}
-      <TextButton onPress={() => undefined}>Text Button</TextButton> Post
+      <TextButton onPress={() => undefined}>Text button</TextButton> Post
       TextButton text
     </Text>
   ),

--- a/packages/design-system-react-native/src/components/Toast/README.md
+++ b/packages/design-system-react-native/src/components/Toast/README.md
@@ -16,7 +16,7 @@ const Demo = () => {
           });
         }}
       >
-        Show Toast
+        Show toast
       </Button>
       <Toaster />
     </>
@@ -42,7 +42,7 @@ const Demo = () => {
           });
         }}
       >
-        Show Toast
+        Show toast
       </Button>
       <Toaster />
     </>

--- a/packages/design-system-react-native/src/components/Toast/Toast.figma.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toast.figma.tsx
@@ -60,7 +60,7 @@ figma.connect(
               });
             }}
           >
-            Show Toast
+            Show toast
           </Button>
         </>
       );

--- a/packages/design-system-react-native/src/components/Toast/Toast.stories.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toast.stories.tsx
@@ -81,7 +81,7 @@ export const Default: Story = {
             });
           }}
         >
-          Show Toast
+          Show toast
         </Button>
         <Toaster />
       </>
@@ -95,7 +95,7 @@ export const Default: Story = {
 
 export const Title: Story = {
   args: {
-    title: 'Added to Watchlist',
+    title: 'Added to watchlist',
   },
 };
 
@@ -145,7 +145,7 @@ export const ActionButtonOnPress: Story = {
           actionButtonLayout={BannerBaseActionButtonLayout.End}
           actionButtonOnPress={() => undefined}
           severity={ToastSeverity.Success}
-          title="Added to Watchlist"
+          title="Added to watchlist"
         />
       </Box>
       <Box twClassName="gap-2">
@@ -192,7 +192,7 @@ export const Spacing: Story = {
           <Toast
             onClose={() => undefined}
             severity={ToastSeverity.Success}
-            title="Added to Watchlist"
+            title="Added to watchlist"
           />
           <Toast
             onClose={() => undefined}
@@ -253,7 +253,7 @@ export const Spacing: Story = {
             actionButtonOnPress={() => undefined}
             description="You can remove it anytime."
             severity={ToastSeverity.Success}
-            title="Added to Watchlist"
+            title="Added to watchlist"
           />
           <Toast
             actionButtonLabel="Undo"
@@ -262,7 +262,7 @@ export const Spacing: Story = {
             description="Your token has been saved for easy access. You may remove this anytime."
             onClose={() => undefined}
             severity={ToastSeverity.Success}
-            title="Added to Watchlist"
+            title="Added to watchlist"
           />
         </Box>
       </Box>
@@ -293,7 +293,7 @@ export const IncorrectUsage: Story = {
           description="You can remove it anytime."
           onClose={() => undefined}
           severity={ToastSeverity.Success}
-          title="Added to Watchlist"
+          title="Added to watchlist"
         />
       </Box>
       <Box twClassName="gap-4">
@@ -317,7 +317,7 @@ export const IncorrectUsage: Story = {
           description="Your token has been saved for easy access. You may remove this anytime."
           onClose={() => undefined}
           severity={ToastSeverity.Success}
-          title="Added to Watchlist"
+          title="Added to watchlist"
         />
       </Box>
     </Box>

--- a/packages/design-system-react-native/src/components/Toast/Toast.stories.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toast.stories.tsx
@@ -197,7 +197,7 @@ export const Spacing: Story = {
           <Toast
             onClose={() => undefined}
             severity={ToastSeverity.Success}
-            title="Your deposit of 20.50 USDC into Account 1 is been confirmed."
+            title="USDC deposited into Account 1"
           />
         </Box>
         <Box twClassName="gap-4">

--- a/packages/design-system-react-native/src/components/Toast/Toaster.test.tsx
+++ b/packages/design-system-react-native/src/components/Toast/Toaster.test.tsx
@@ -242,12 +242,12 @@ describe('Toaster', () => {
     const onActionPress = jest.fn();
     render(<Toaster ref={toasterRef} />);
     await showToastAndWait(toasterRef, {
-      actionButtonLabel: 'Click here',
+      actionButtonLabel: 'View details',
       hasNoTimeout: true,
       actionButtonOnPress: onActionPress,
       title: 'With action',
     });
-    const actionButton = screen.getByText('Click here');
+    const actionButton = screen.getByText('View details');
     expect(actionButton).toBeDefined();
 
     await act(async () => {

--- a/packages/design-system-react-native/src/components/temp-components/TextOrChildren/TextOrChildren.test.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/TextOrChildren/TextOrChildren.test.tsx
@@ -15,11 +15,11 @@ describe('TextOrChildren', () => {
   it('hides string children when textProps.isHidden is true', () => {
     const { getByText, queryByText } = render(
       <TextOrChildren textProps={{ isHidden: true }}>
-        Sensitive Information
+        Sensitive information
       </TextOrChildren>,
     );
 
-    expect(queryByText('Sensitive Information')).toBeNull();
+    expect(queryByText('Sensitive information')).toBeNull();
     expect(getByText('••••••')).toBeDefined();
   });
 
@@ -28,7 +28,7 @@ describe('TextOrChildren', () => {
       <TextOrChildren
         textProps={{ isHidden: true, length: SensitiveTextLength.Medium }}
       >
-        Sensitive Information
+        Sensitive information
       </TextOrChildren>,
     );
 

--- a/packages/design-system-react/src/components/AvatarFavicon/AvatarFavicon.test.tsx
+++ b/packages/design-system-react/src/components/AvatarFavicon/AvatarFavicon.test.tsx
@@ -91,7 +91,7 @@ describe('AvatarFavicon', () => {
           imageProps={{ 'data-testid': 'img2' }}
         />,
       );
-      expect(screen.getByTestId('img2')).toHaveAttribute('alt', 'Dapp logo');
+      expect(screen.getByTestId('img2')).toHaveAttribute('alt', 'Site logo');
     });
 
     it('does not render fallbackText initially', () => {
@@ -155,7 +155,7 @@ describe('AvatarFavicon', () => {
         />,
       );
       const img = screen.getByTestId('img-no-name') as HTMLImageElement;
-      expect(img.alt).toBe('Dapp logo');
+      expect(img.alt).toBe('Site logo');
     });
   });
 

--- a/packages/design-system-react/src/components/AvatarFavicon/AvatarFavicon.tsx
+++ b/packages/design-system-react/src/components/AvatarFavicon/AvatarFavicon.tsx
@@ -24,7 +24,7 @@ export const AvatarFavicon = forwardRef<HTMLDivElement, AvatarFaviconProps>(
   ) => {
     const [finalFallbackText, setFinalFallbackText] = useState<string>('');
     const backupFallbackText = fallbackText || name?.[0] || '?';
-    const altText = name || 'Dapp logo'; // TBC: Add localization for default text
+    const altText = name || 'Site logo'; // TBC: Add localization for default text
 
     const onErrorHandler = (e: React.SyntheticEvent<HTMLImageElement>) => {
       setFinalFallbackText(backupFallbackText);

--- a/packages/design-system-react/src/components/AvatarFavicon/README.mdx
+++ b/packages/design-system-react/src/components/AvatarFavicon/README.mdx
@@ -22,7 +22,7 @@ import { AvatarFavicon } from '@metamask/design-system-react';
 
 ### `name`
 
-The `name` prop is optional and serves two purposes: used as alt text for the dapp logo and first letter is used as fallback display text when `fallbackText` is not provided.
+The `name` prop is optional and serves two purposes: used as alt text for the site logo and first letter is used as fallback display text when `fallbackText` is not provided.
 
 <table>
   <thead>

--- a/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
+++ b/packages/design-system-react/src/components/BannerAlert/BannerAlert.stories.tsx
@@ -191,7 +191,7 @@ export const ActionButtonLayout: Story = {
 export const OnClose: Story = {
   args: {
     title: 'onClose demo',
-    children: 'Click the close icon to trigger onClose.',
+    children: 'Use the close icon to trigger onClose.',
     actionButtonLabel: undefined,
     actionButtonOnClick: undefined,
   },

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.stories.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.stories.tsx
@@ -168,7 +168,7 @@ export const ActionButtonLayout: Story = {
 export const OnClose: Story = {
   args: {
     title: 'onClose demo',
-    children: 'Click the close icon to trigger onClose.',
+    children: 'Use the close icon to trigger onClose.',
     onClose: () => undefined,
     closeButtonProps: {
       'data-testid': 'banner-base-close-button',

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
@@ -167,7 +167,7 @@ describe('BannerBase', () => {
       <BannerBase
         data-testid="banner-base"
         onClose={() => undefined}
-        title="Added to Watchlist"
+        title="Added to watchlist"
         closeButtonProps={{ 'data-testid': closeButtonTestId }}
       />,
     );
@@ -411,7 +411,7 @@ describe('BannerBase', () => {
         data-testid="banner-base"
         description="Supporting details"
         onClose={() => undefined}
-        title="Added to Watchlist"
+        title="Added to watchlist"
       />,
     );
 

--- a/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
+++ b/packages/design-system-react/src/components/BannerBase/BannerBase.test.tsx
@@ -250,7 +250,7 @@ describe('BannerBase', () => {
       <BannerBase
         data-testid="banner-base"
         onClose={() => undefined}
-        title="Your deposit of 20.50 USDC into Account 1 is been confirmed."
+        title="USDC deposited into Account 1"
       />,
     );
 

--- a/packages/design-system-react/src/components/Button/Button.stories.tsx
+++ b/packages/design-system-react/src/components/Button/Button.stories.tsx
@@ -140,12 +140,12 @@ export const IsDanger: Story = {
   render: () => (
     <div className="space-y-4">
       <div className="flex gap-2">
-        <Button isDanger>Primary Danger</Button>
+        <Button isDanger>Primary danger</Button>
         <Button variant={ButtonVariant.Secondary} isDanger>
-          Secondary Danger
+          Secondary danger
         </Button>
         <Button variant={ButtonVariant.Tertiary} isDanger>
-          Tertiary Danger
+          Tertiary danger
         </Button>
       </div>
     </div>
@@ -156,23 +156,23 @@ export const IsInverse: Story = {
   render: () => (
     <div className="space-y-4 bg-primary-default p-4">
       <div className="flex gap-2">
-        <Button isInverse>Primary Inverse</Button>
+        <Button isInverse>Primary inverse</Button>
         <Button variant={ButtonVariant.Secondary} isInverse>
-          Secondary Inverse
+          Secondary inverse
         </Button>
         <Button variant={ButtonVariant.Tertiary} isInverse>
-          Tertiary Inverse
+          Tertiary inverse
         </Button>
       </div>
       <div className="flex gap-2">
         <Button isDanger isInverse>
-          Primary Danger Inverse
+          Primary danger inverse
         </Button>
         <Button variant={ButtonVariant.Secondary} isDanger isInverse>
-          Secondary Danger Inverse
+          Secondary danger inverse
         </Button>
         <Button variant={ButtonVariant.Tertiary} isDanger isInverse>
-          Tertiary Danger Inverse
+          Tertiary danger inverse
         </Button>
       </div>
     </div>
@@ -181,14 +181,14 @@ export const IsInverse: Story = {
 
 export const StartIconName: Story = {
   args: {
-    children: 'With Start Icon',
+    children: 'With start icon',
     startIconName: IconName.AddSquare,
   },
 };
 
 export const EndIconName: Story = {
   args: {
-    children: 'With End Icon',
+    children: 'With end icon',
     endIconName: IconName.AddSquare,
   },
 };
@@ -238,12 +238,12 @@ export const IsDisabled: Story = {
 export const IsFullWidth: Story = {
   render: () => (
     <div className="space-y-4">
-      <Button isFullWidth>Full Width Primary</Button>
+      <Button isFullWidth>Full width primary</Button>
       <Button variant={ButtonVariant.Secondary} isFullWidth>
-        Full Width Secondary
+        Full width secondary
       </Button>
       <Button variant={ButtonVariant.Tertiary} isFullWidth>
-        Full Width Tertiary
+        Full width tertiary
       </Button>
     </div>
   ),

--- a/packages/design-system-react/src/components/Button/Button.test.tsx
+++ b/packages/design-system-react/src/components/Button/Button.test.tsx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 describe('Button', () => {
   describe('Variants', () => {
     it('renders primary button by default', () => {
-      render(<Button>Primary Button</Button>);
+      render(<Button>Primary button</Button>);
 
       const button = screen.getByRole('button');
       expect(button).toHaveClass(
@@ -20,7 +20,7 @@ describe('Button', () => {
 
     it('renders secondary button when variant is Secondary', () => {
       render(
-        <Button variant={ButtonVariant.Secondary}>Secondary Button</Button>,
+        <Button variant={ButtonVariant.Secondary}>Secondary button</Button>,
       );
 
       const button = screen.getByRole('button');
@@ -56,7 +56,7 @@ describe('Button', () => {
   describe('Common Features', () => {
     it('applies danger styles correctly for each variant', () => {
       const { rerender } = render(
-        <Button isDanger>Primary Danger Button</Button>,
+        <Button isDanger>Primary danger button</Button>,
       );
 
       let button = screen.getByRole('button');
@@ -64,7 +64,7 @@ describe('Button', () => {
 
       rerender(
         <Button variant={ButtonVariant.Secondary} isDanger>
-          Secondary Danger Button
+          Secondary danger button
         </Button>,
       );
       button = screen.getByRole('button');
@@ -77,7 +77,7 @@ describe('Button', () => {
 
       rerender(
         <Button variant={ButtonVariant.Tertiary} isDanger>
-          Tertiary Danger Button
+          Tertiary danger button
         </Button>,
       );
       button = screen.getByRole('button');
@@ -86,7 +86,7 @@ describe('Button', () => {
 
     it('applies inverse styles correctly for Primary and Secondary variants', () => {
       const { rerender } = render(
-        <Button isInverse>Primary Inverse Button</Button>,
+        <Button isInverse>Primary inverse button</Button>,
       );
 
       let button = screen.getByRole('button');
@@ -94,7 +94,7 @@ describe('Button', () => {
 
       rerender(
         <Button variant={ButtonVariant.Secondary} isInverse>
-          Secondary Inverse Button
+          Secondary inverse button
         </Button>,
       );
       button = screen.getByRole('button');
@@ -216,7 +216,7 @@ describe('Button', () => {
 
     it('applies full width correctly for all variants', () => {
       const { rerender } = render(
-        <Button isFullWidth>Primary Full Width</Button>,
+        <Button isFullWidth>Primary full width</Button>,
       );
 
       let button = screen.getByRole('button');
@@ -224,7 +224,7 @@ describe('Button', () => {
 
       rerender(
         <Button variant={ButtonVariant.Secondary} isFullWidth>
-          Secondary Full Width
+          Secondary full width
         </Button>,
       );
       button = screen.getByRole('button');
@@ -232,7 +232,7 @@ describe('Button', () => {
 
       rerender(
         <Button variant={ButtonVariant.Tertiary} isFullWidth>
-          Tertiary Full Width
+          Tertiary full width
         </Button>,
       );
       button = screen.getByRole('button');
@@ -243,7 +243,7 @@ describe('Button', () => {
   describe('Focus Styling', () => {
     describe('Primary Button Focus', () => {
       it('applies correct focus outline for non-inverse primary button', () => {
-        render(<Button>Primary Button</Button>);
+        render(<Button>Primary button</Button>);
         const button = screen.getByRole('button');
         expect(button).toHaveClass(
           'focus-visible:ring-0',
@@ -255,7 +255,7 @@ describe('Button', () => {
       });
 
       it('applies correct focus outline for inverse primary button', () => {
-        render(<Button isInverse>Primary Inverse Button</Button>);
+        render(<Button isInverse>Primary inverse button</Button>);
         const button = screen.getByRole('button');
         expect(button).toHaveClass(
           'focus-visible:ring-0',
@@ -267,7 +267,7 @@ describe('Button', () => {
       });
 
       it('applies correct focus outline for danger primary button', () => {
-        render(<Button isDanger>Primary Danger Button</Button>);
+        render(<Button isDanger>Primary danger button</Button>);
         const button = screen.getByRole('button');
         expect(button).toHaveClass(
           'focus-visible:ring-0',
@@ -282,7 +282,7 @@ describe('Button', () => {
     describe('Secondary Button Focus', () => {
       it('applies correct focus outline for non-inverse secondary button', () => {
         render(
-          <Button variant={ButtonVariant.Secondary}>Secondary Button</Button>,
+          <Button variant={ButtonVariant.Secondary}>Secondary button</Button>,
         );
         const button = screen.getByRole('button');
         expect(button).toHaveClass(
@@ -297,7 +297,7 @@ describe('Button', () => {
       it('applies correct focus outline for inverse secondary button', () => {
         render(
           <Button variant={ButtonVariant.Secondary} isInverse>
-            Secondary Inverse Button
+            Secondary inverse button
           </Button>,
         );
         const button = screen.getByRole('button');
@@ -313,7 +313,7 @@ describe('Button', () => {
       it('applies correct focus outline for danger secondary button', () => {
         render(
           <Button variant={ButtonVariant.Secondary} isDanger>
-            Secondary Danger Button
+            Secondary danger button
           </Button>,
         );
         const button = screen.getByRole('button');
@@ -345,7 +345,7 @@ describe('Button', () => {
       it('applies correct focus outline for inverse tertiary button', () => {
         render(
           <Button variant={ButtonVariant.Tertiary} isInverse>
-            Tertiary Inverse Button
+            Tertiary inverse button
           </Button>,
         );
         const button = screen.getByRole('button');
@@ -361,7 +361,7 @@ describe('Button', () => {
       it('applies correct focus outline for danger tertiary button', () => {
         render(
           <Button variant={ButtonVariant.Tertiary} isDanger>
-            Tertiary Danger Button
+            Tertiary danger button
           </Button>,
         );
         const button = screen.getByRole('button');

--- a/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.stories.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.stories.tsx
@@ -105,13 +105,13 @@ type Story = StoryObj<typeof ButtonPrimary>;
 
 export const Default: Story = {
   args: {
-    children: 'Primary Button',
+    children: 'Primary button',
   },
 };
 
 export const IsDanger: Story = {
   args: {
-    children: 'Danger Button',
+    children: 'Danger button',
     isDanger: true,
   },
 };
@@ -120,10 +120,10 @@ export const IsInverse: Story = {
   render: (args) => (
     <div className="flex gap-2 rounded bg-primary-default p-4">
       <ButtonPrimary {...args} isInverse>
-        Inverse Button
+        Inverse button
       </ButtonPrimary>
       <ButtonPrimary {...args} isInverse isDanger>
-        Inverse Danger Button
+        Inverse Danger button
       </ButtonPrimary>
     </div>
   ),
@@ -147,28 +147,28 @@ export const Size: Story = {
 
 export const IsFullWidth: Story = {
   args: {
-    children: 'Full Width Button',
+    children: 'Full width button',
     isFullWidth: true,
   },
 };
 
 export const StartIconName: Story = {
   args: {
-    children: 'With Start Icon',
+    children: 'With start icon',
     startIconName: IconName.AddSquare,
   },
 };
 
 export const EndIconName: Story = {
   args: {
-    children: 'With End Icon',
+    children: 'With end icon',
     endIconName: IconName.AddSquare,
   },
 };
 
 export const IsLoading: Story = {
   args: {
-    children: 'Loading Button',
+    children: 'Loading button',
     isLoading: true,
     loadingText: 'Loading...',
   },
@@ -176,7 +176,7 @@ export const IsLoading: Story = {
 
 export const IsDisabled: Story = {
   args: {
-    children: 'Disabled Button',
+    children: 'Disabled button',
     isDisabled: true,
   },
 };

--- a/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.stories.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.stories.tsx
@@ -123,7 +123,7 @@ export const IsInverse: Story = {
         Inverse button
       </ButtonPrimary>
       <ButtonPrimary {...args} isInverse isDanger>
-        Inverse Danger button
+        Inverse danger button
       </ButtonPrimary>
     </div>
   ),

--- a/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
@@ -6,7 +6,7 @@ import { ButtonPrimary } from './ButtonPrimary';
 
 describe('ButtonPrimary', () => {
   it('renders with primary button styles by default', () => {
-    render(<ButtonPrimary>Primary Button</ButtonPrimary>);
+    render(<ButtonPrimary>Primary button</ButtonPrimary>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass(
@@ -18,7 +18,7 @@ describe('ButtonPrimary', () => {
   });
 
   it('renders with danger styles when isDanger is true', () => {
-    render(<ButtonPrimary isDanger>Danger Button</ButtonPrimary>);
+    render(<ButtonPrimary isDanger>Danger button</ButtonPrimary>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass(
@@ -30,7 +30,7 @@ describe('ButtonPrimary', () => {
   });
 
   it('renders with inverse styles when isInverse is true', () => {
-    render(<ButtonPrimary isInverse>Inverse Button</ButtonPrimary>);
+    render(<ButtonPrimary isInverse>Inverse button</ButtonPrimary>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass(
@@ -50,7 +50,7 @@ describe('ButtonPrimary', () => {
   it('renders with inverse danger styles when both isInverse and isDanger are true', () => {
     render(
       <ButtonPrimary isInverse isDanger>
-        Inverse Danger Button
+        Inverse Danger button
       </ButtonPrimary>,
     );
 
@@ -64,7 +64,7 @@ describe('ButtonPrimary', () => {
   });
 
   it('applies disabled styles while preserving variant-specific classes', () => {
-    render(<ButtonPrimary isDisabled>Disabled Button</ButtonPrimary>);
+    render(<ButtonPrimary isDisabled>Disabled button</ButtonPrimary>);
 
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
@@ -79,7 +79,7 @@ describe('ButtonPrimary', () => {
   it('applies loading styles while preserving variant-specific classes', () => {
     render(
       <ButtonPrimary isLoading loadingText="Loading...">
-        Loading Button
+        Loading button
       </ButtonPrimary>,
     );
 
@@ -157,7 +157,7 @@ describe('ButtonPrimary', () => {
   });
 
   it('applies full width class correctly', () => {
-    render(<ButtonPrimary isFullWidth>Full Width</ButtonPrimary>);
+    render(<ButtonPrimary isFullWidth>Full width</ButtonPrimary>);
     expect(screen.getByRole('button')).toHaveClass('w-full');
   });
 
@@ -175,7 +175,7 @@ describe('ButtonPrimary', () => {
 
   describe('loading state', () => {
     it('applies correct loading styles and removes hover/active states', () => {
-      render(<ButtonPrimary isLoading>Loading Button</ButtonPrimary>);
+      render(<ButtonPrimary isLoading>Loading button</ButtonPrimary>);
 
       const button = screen.getByRole('button');
 
@@ -194,7 +194,7 @@ describe('ButtonPrimary', () => {
     it('applies correct loading styles for danger variant', () => {
       render(
         <ButtonPrimary isLoading isDanger>
-          Loading Button
+          Loading button
         </ButtonPrimary>,
       );
 
@@ -206,7 +206,7 @@ describe('ButtonPrimary', () => {
     it('applies correct loading styles for inverse variant', () => {
       render(
         <ButtonPrimary isLoading isInverse>
-          Loading Button
+          Loading button
         </ButtonPrimary>,
       );
 
@@ -218,7 +218,7 @@ describe('ButtonPrimary', () => {
     it('applies correct loading styles for inverse danger variant', () => {
       render(
         <ButtonPrimary isLoading isInverse isDanger>
-          Loading Button
+          Loading button
         </ButtonPrimary>,
       );
 

--- a/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
@@ -144,12 +144,12 @@ describe('ButtonPrimary', () => {
 
   it('renders loading text when provided', () => {
     render(
-      <ButtonPrimary isLoading loadingText="Please wait...">
+      <ButtonPrimary isLoading loadingText="Loading...">
         Submit
       </ButtonPrimary>,
     );
 
-    expect(screen.getAllByText('Please wait...')).toHaveLength(2);
+    expect(screen.getAllByText('Loading...')).toHaveLength(2);
     const widthPlaceholder = screen
       .getByRole('button')
       .querySelector('span.invisible');

--- a/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonPrimary/ButtonPrimary.test.tsx
@@ -50,7 +50,7 @@ describe('ButtonPrimary', () => {
   it('renders with inverse danger styles when both isInverse and isDanger are true', () => {
     render(
       <ButtonPrimary isInverse isDanger>
-        Inverse Danger button
+        Inverse danger button
       </ButtonPrimary>,
     );
 

--- a/packages/design-system-react/src/components/Button/variants/ButtonPrimary/README.mdx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonPrimary/README.mdx
@@ -10,7 +10,7 @@ Consumers should use `Button` with `variant={ButtonVariant.Primary}` instead of 
 ```tsx
 import { Button, ButtonVariant } from '@metamask/design-system-react';
 
-<Button variant={ButtonVariant.Primary}>Primary Button</Button>;
+<Button variant={ButtonVariant.Primary}>Primary button</Button>;
 ```
 
 <Canvas of={ButtonPrimaryStories.Default} />

--- a/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.stories.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.stories.tsx
@@ -105,13 +105,13 @@ type Story = StoryObj<typeof ButtonSecondary>;
 
 export const Default: Story = {
   args: {
-    children: 'Secondary Button',
+    children: 'Secondary button',
   },
 };
 
 export const IsDanger: Story = {
   args: {
-    children: 'Danger Button',
+    children: 'Danger button',
     isDanger: true,
   },
 };
@@ -120,10 +120,10 @@ export const IsInverse: Story = {
   render: (args) => (
     <div className="flex gap-2 rounded bg-primary-default p-4">
       <ButtonSecondary {...args} isInverse>
-        Inverse Button
+        Inverse button
       </ButtonSecondary>
       <ButtonSecondary {...args} isInverse isDanger>
-        Inverse Danger Button
+        Inverse Danger button
       </ButtonSecondary>
     </div>
   ),
@@ -147,28 +147,28 @@ export const Size: Story = {
 
 export const IsFullWidth: Story = {
   args: {
-    children: 'Full Width Button',
+    children: 'Full width button',
     isFullWidth: true,
   },
 };
 
 export const StartIconName: Story = {
   args: {
-    children: 'With Start Icon',
+    children: 'With start icon',
     startIconName: IconName.AddSquare,
   },
 };
 
 export const EndIconName: Story = {
   args: {
-    children: 'With End Icon',
+    children: 'With end icon',
     endIconName: IconName.AddSquare,
   },
 };
 
 export const IsLoading: Story = {
   args: {
-    children: 'Loading Button',
+    children: 'Loading button',
     isLoading: true,
     loadingText: 'Loading...',
   },
@@ -176,7 +176,7 @@ export const IsLoading: Story = {
 
 export const IsDisabled: Story = {
   args: {
-    children: 'Disabled Button',
+    children: 'Disabled button',
     isDisabled: true,
   },
 };

--- a/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.stories.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.stories.tsx
@@ -123,7 +123,7 @@ export const IsInverse: Story = {
         Inverse button
       </ButtonSecondary>
       <ButtonSecondary {...args} isInverse isDanger>
-        Inverse Danger button
+        Inverse danger button
       </ButtonSecondary>
     </div>
   ),

--- a/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
@@ -127,12 +127,12 @@ describe('ButtonSecondary', () => {
 
   it('renders loading text when provided', () => {
     render(
-      <ButtonSecondary isLoading loadingText="Please wait...">
+      <ButtonSecondary isLoading loadingText="Loading...">
         Submit
       </ButtonSecondary>,
     );
 
-    expect(screen.getAllByText('Please wait...')).toHaveLength(2); // Both visible and screen reader text
+    expect(screen.getAllByText('Loading...')).toHaveLength(2); // Both visible and screen reader text
     const widthPlaceholder = screen
       .getByRole('button')
       .querySelector('span.invisible');

--- a/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
@@ -6,7 +6,7 @@ import { ButtonSecondary } from './ButtonSecondary';
 
 describe('ButtonSecondary', () => {
   it('renders with secondary button styles by default', () => {
-    render(<ButtonSecondary>Secondary Button</ButtonSecondary>);
+    render(<ButtonSecondary>Secondary button</ButtonSecondary>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass(
@@ -18,7 +18,7 @@ describe('ButtonSecondary', () => {
   });
 
   it('renders with danger styles when isDanger is true', () => {
-    render(<ButtonSecondary isDanger>Danger Button</ButtonSecondary>);
+    render(<ButtonSecondary isDanger>Danger button</ButtonSecondary>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass(
@@ -30,7 +30,7 @@ describe('ButtonSecondary', () => {
   });
 
   it('renders with inverse styles when isInverse is true', () => {
-    render(<ButtonSecondary isInverse>Inverse Button</ButtonSecondary>);
+    render(<ButtonSecondary isInverse>Inverse button</ButtonSecondary>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass(
@@ -44,7 +44,7 @@ describe('ButtonSecondary', () => {
   it('renders with inverse danger styles when both isInverse and isDanger are true', () => {
     render(
       <ButtonSecondary isInverse isDanger>
-        Inverse Danger Button
+        Inverse Danger button
       </ButtonSecondary>,
     );
 
@@ -53,7 +53,7 @@ describe('ButtonSecondary', () => {
   });
 
   it('applies disabled styles while preserving variant-specific classes', () => {
-    render(<ButtonSecondary isDisabled>Disabled Button</ButtonSecondary>);
+    render(<ButtonSecondary isDisabled>Disabled button</ButtonSecondary>);
 
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
@@ -140,7 +140,7 @@ describe('ButtonSecondary', () => {
   });
 
   it('applies full width class correctly', () => {
-    render(<ButtonSecondary isFullWidth>Full Width</ButtonSecondary>);
+    render(<ButtonSecondary isFullWidth>Full width</ButtonSecondary>);
     expect(screen.getByRole('button')).toHaveClass('w-full');
   });
 
@@ -158,7 +158,7 @@ describe('ButtonSecondary', () => {
 
   describe('loading state', () => {
     it('applies correct loading styles and removes hover/active states', () => {
-      render(<ButtonSecondary isLoading>Loading Button</ButtonSecondary>);
+      render(<ButtonSecondary isLoading>Loading button</ButtonSecondary>);
 
       const button = screen.getByRole('button');
 
@@ -177,7 +177,7 @@ describe('ButtonSecondary', () => {
     it('applies correct loading styles for danger variant', () => {
       render(
         <ButtonSecondary isLoading isDanger>
-          Loading Button
+          Loading button
         </ButtonSecondary>,
       );
 
@@ -189,7 +189,7 @@ describe('ButtonSecondary', () => {
     it('applies correct loading styles for inverse variant', () => {
       render(
         <ButtonSecondary isLoading isInverse>
-          Loading Button
+          Loading button
         </ButtonSecondary>,
       );
 
@@ -201,7 +201,7 @@ describe('ButtonSecondary', () => {
     it('applies correct loading styles for inverse danger variant', () => {
       render(
         <ButtonSecondary isLoading isInverse isDanger>
-          Loading Button
+          Loading button
         </ButtonSecondary>,
       );
 

--- a/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonSecondary/ButtonSecondary.test.tsx
@@ -44,7 +44,7 @@ describe('ButtonSecondary', () => {
   it('renders with inverse danger styles when both isInverse and isDanger are true', () => {
     render(
       <ButtonSecondary isInverse isDanger>
-        Inverse Danger button
+        Inverse danger button
       </ButtonSecondary>,
     );
 

--- a/packages/design-system-react/src/components/Button/variants/ButtonSecondary/README.mdx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonSecondary/README.mdx
@@ -10,7 +10,7 @@ Consumers should use `Button` with `variant={ButtonVariant.Secondary}` instead o
 ```tsx
 import { Button, ButtonVariant } from '@metamask/design-system-react';
 
-<Button variant={ButtonVariant.Secondary}>Secondary Button</Button>;
+<Button variant={ButtonVariant.Secondary}>Secondary button</Button>;
 ```
 
 <Canvas of={ButtonSecondaryStories.Default} />

--- a/packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.stories.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.stories.tsx
@@ -97,7 +97,7 @@ type Story = StoryObj<typeof ButtonTertiary>;
 
 export const Default: Story = {
   args: {
-    children: 'Button Tertiary',
+    children: 'Button tertiary',
   },
 };
 
@@ -139,21 +139,21 @@ export const IsInverse: Story = {
 
 export const IsFullWidth: Story = {
   args: {
-    children: 'Full Width',
+    children: 'Full width',
     isFullWidth: true,
   },
 };
 
 export const StartIconName: Story = {
   args: {
-    children: 'With Start Icon',
+    children: 'With start icon',
     startIconName: IconName.AddSquare,
   },
 };
 
 export const EndIconName: Story = {
   args: {
-    children: 'With End Icon',
+    children: 'With end icon',
     endIconName: IconName.AddSquare,
   },
 };
@@ -168,7 +168,7 @@ export const IsLoading: Story = {
 
 export const IsDisabled: Story = {
   args: {
-    children: 'Disabled Button Tertiary',
+    children: 'Disabled button tertiary',
     isDisabled: true,
   },
 };

--- a/packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.test.tsx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonTertiary/ButtonTertiary.test.tsx
@@ -6,14 +6,14 @@ import { ButtonTertiary } from './ButtonTertiary';
 
 describe('ButtonTertiary', () => {
   it('renders with button tertiary styles by default', () => {
-    render(<ButtonTertiary>Button Tertiary</ButtonTertiary>);
+    render(<ButtonTertiary>Button tertiary</ButtonTertiary>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass('bg-transparent', 'text-default');
   });
 
   it('renders with danger styles when isDanger is true', () => {
-    render(<ButtonTertiary isDanger>Danger Button Tertiary</ButtonTertiary>);
+    render(<ButtonTertiary isDanger>Danger button Tertiary</ButtonTertiary>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass('bg-transparent', 'text-error-default');
@@ -27,7 +27,7 @@ describe('ButtonTertiary', () => {
 
   it('applies disabled styles while preserving variant-specific classes', () => {
     render(
-      <ButtonTertiary isDisabled>Disabled Button Tertiary</ButtonTertiary>,
+      <ButtonTertiary isDisabled>Disabled button tertiary</ButtonTertiary>,
     );
 
     const button = screen.getByRole('button');
@@ -97,7 +97,7 @@ describe('ButtonTertiary', () => {
   });
 
   it('applies full width class correctly', () => {
-    render(<ButtonTertiary isFullWidth>Full Width</ButtonTertiary>);
+    render(<ButtonTertiary isFullWidth>Full width</ButtonTertiary>);
     expect(screen.getByRole('button')).toHaveClass('w-full');
   });
 
@@ -114,7 +114,7 @@ describe('ButtonTertiary', () => {
     });
 
     it('does not apply interactive styles when disabled', () => {
-      render(<ButtonTertiary isDisabled>Disabled Button</ButtonTertiary>);
+      render(<ButtonTertiary isDisabled>Disabled button</ButtonTertiary>);
 
       const button = screen.getByRole('button');
       expect(button).not.toHaveClass('hover:bg-hover');
@@ -122,7 +122,7 @@ describe('ButtonTertiary', () => {
     });
 
     it('does not apply interactive styles when loading', () => {
-      render(<ButtonTertiary isLoading>Loading Button</ButtonTertiary>);
+      render(<ButtonTertiary isLoading>Loading button</ButtonTertiary>);
 
       const button = screen.getByRole('button');
       expect(button).not.toHaveClass('hover:bg-hover');
@@ -240,7 +240,7 @@ describe('ButtonTertiary', () => {
   describe('loading states', () => {
     it('applies correct loading styles for all variants', () => {
       const { rerender } = render(
-        <ButtonTertiary isLoading>Loading Button</ButtonTertiary>,
+        <ButtonTertiary isLoading>Loading button</ButtonTertiary>,
       );
 
       // Default loading
@@ -252,7 +252,7 @@ describe('ButtonTertiary', () => {
       // Danger loading
       rerender(
         <ButtonTertiary isLoading isDanger>
-          Loading Button
+          Loading button
         </ButtonTertiary>,
       );
       button = screen.getByRole('button');
@@ -265,7 +265,7 @@ describe('ButtonTertiary', () => {
       // Inverse loading
       rerender(
         <ButtonTertiary isLoading isInverse>
-          Loading Button
+          Loading button
         </ButtonTertiary>,
       );
       button = screen.getByRole('button');
@@ -274,7 +274,7 @@ describe('ButtonTertiary', () => {
       // Inverse danger loading
       rerender(
         <ButtonTertiary isLoading isInverse isDanger>
-          Loading Button
+          Loading button
         </ButtonTertiary>,
       );
       button = screen.getByRole('button');

--- a/packages/design-system-react/src/components/Button/variants/ButtonTertiary/README.mdx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonTertiary/README.mdx
@@ -10,7 +10,7 @@ Consumers should use `Button` with `variant={ButtonVariant.Tertiary}` instead of
 ```tsx
 import { Button, ButtonVariant } from '@metamask/design-system-react';
 
-<Button variant={ButtonVariant.Tertiary}>Button Tertiary</Button>;
+<Button variant={ButtonVariant.Tertiary}>Button tertiary</Button>;
 ```
 
 <Canvas of={ButtonTertiaryStories.Default} />

--- a/packages/design-system-react/src/components/ButtonBase/ButtonBase.stories.tsx
+++ b/packages/design-system-react/src/components/ButtonBase/ButtonBase.stories.tsx
@@ -123,7 +123,7 @@ type Story = StoryObj<typeof ButtonBase>;
 
 export const Default: Story = {
   args: {
-    children: 'Button Base',
+    children: 'Button base',
   },
 };
 
@@ -304,35 +304,35 @@ export const Spacing: Story = {
 
 export const IsFullWidth: Story = {
   args: {
-    children: 'Full Width Button',
+    children: 'Full width button',
     isFullWidth: true,
   },
 };
 
 export const StartIconName: Story = {
   args: {
-    children: 'With Start Icon',
+    children: 'With start icon',
     startIconName: IconName.AddSquare,
   },
 };
 
 export const EndIconName: Story = {
   args: {
-    children: 'With End Icon',
+    children: 'With end icon',
     endIconName: IconName.AddSquare,
   },
 };
 
 export const StartAccessory: Story = {
   args: {
-    children: 'With Start Accessory',
+    children: 'With start accessory',
     startAccessory: '→',
   },
 };
 
 export const EndAccessory: Story = {
   args: {
-    children: 'With End Accessory',
+    children: 'With end accessory',
     endAccessory: '←',
   },
 };
@@ -475,7 +475,7 @@ export const AccessibilityLoadingStates: Story = {
   render: (args) => (
     <div className="flex flex-col gap-4 p-4">
       <div className="space-y-2">
-        <Text variant={TextVariant.HeadingSm}>Loading State Announcements</Text>
+        <Text variant={TextVariant.HeadingSm}>Loading state announcements</Text>
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           Screen readers will announce loading states to users
         </Text>
@@ -499,10 +499,10 @@ export const AccessibilityLoadingStates: Story = {
         </Text>
         <div className="flex gap-2">
           <ButtonBase {...args} isDisabled>
-            Disabled Button
+            Disabled button
           </ButtonBase>
           <ButtonBase {...args} isLoading>
-            Loading Button
+            Loading button
           </ButtonBase>
         </div>
       </div>
@@ -550,7 +550,7 @@ export const AccessibilityKeyboardNavigation: Story = {
 
 export const IsDisabled: Story = {
   args: {
-    children: 'Disabled Button',
+    children: 'Disabled button',
     isDisabled: true,
   },
 };

--- a/packages/design-system-react/src/components/ButtonBase/ButtonBase.test.tsx
+++ b/packages/design-system-react/src/components/ButtonBase/ButtonBase.test.tsx
@@ -56,14 +56,14 @@ describe('ButtonBase', () => {
     render(
       <ButtonBase
         isLoading
-        loadingText="Please wait..."
+        loadingText="Loading..."
         loadingIconProps={{ 'data-testid': 'loading-spinner' }}
       >
         Submit
       </ButtonBase>,
     );
     expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
-    const loadingTexts = screen.getAllByText('Please wait...');
+    const loadingTexts = screen.getAllByText('Loading...');
     expect(loadingTexts).toHaveLength(2);
     const widthPlaceholder = screen
       .getByRole('button')
@@ -437,7 +437,7 @@ describe('ButtonBase', () => {
       render(
         <ButtonBase
           isLoading
-          loadingText="Please wait"
+          loadingText="Loading..."
           loadingIconProps={{ 'data-testid': 'loading-spinner' }}
         >
           Submit

--- a/packages/design-system-react/src/components/ButtonBase/ButtonBase.test.tsx
+++ b/packages/design-system-react/src/components/ButtonBase/ButtonBase.test.tsx
@@ -131,14 +131,14 @@ describe('ButtonBase', () => {
   });
 
   it('applies disabled state', () => {
-    render(<ButtonBase isDisabled>Disabled Button</ButtonBase>);
+    render(<ButtonBase isDisabled>Disabled button</ButtonBase>);
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
     expect(button).toHaveClass('opacity-50', 'cursor-not-allowed');
   });
 
   it('applies full width class when isFullWidth is true', () => {
-    render(<ButtonBase isFullWidth>Full Width Button</ButtonBase>);
+    render(<ButtonBase isFullWidth>Full width button</ButtonBase>);
     expect(screen.getByRole('button')).toHaveClass('w-full');
   });
 
@@ -183,7 +183,7 @@ describe('ButtonBase', () => {
   });
 
   it('disables the button when isLoading is true', () => {
-    render(<ButtonBase isLoading>Loading Button</ButtonBase>);
+    render(<ButtonBase isLoading>Loading button</ButtonBase>);
 
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
@@ -192,7 +192,7 @@ describe('ButtonBase', () => {
 
   it('applies disabled styles for both isDisabled and isLoading states', () => {
     const { rerender } = render(
-      <ButtonBase isDisabled>Disabled Button</ButtonBase>,
+      <ButtonBase isDisabled>Disabled button</ButtonBase>,
     );
 
     let button = screen.getByRole('button');
@@ -205,7 +205,7 @@ describe('ButtonBase', () => {
         loadingText="Loading"
         loadingTextProps={{ className: 'custom-text-class' }}
       >
-        Loading Button
+        Loading button
       </ButtonBase>,
     );
     button = screen.getByRole('button');
@@ -347,13 +347,13 @@ describe('ButtonBase', () => {
     });
 
     it('applies aria-disabled when isDisabled is true', () => {
-      render(<ButtonBase isDisabled>Disabled Button</ButtonBase>);
+      render(<ButtonBase isDisabled>Disabled button</ButtonBase>);
       const button = screen.getByRole('button');
       expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('applies aria-busy when isLoading is true', () => {
-      render(<ButtonBase isLoading>Loading Button</ButtonBase>);
+      render(<ButtonBase isLoading>Loading button</ButtonBase>);
       const button = screen.getByRole('button');
       expect(button).toHaveAttribute('aria-busy', 'true');
     });
@@ -452,7 +452,7 @@ describe('ButtonBase', () => {
 
     it('sets proper tabindex for disabled buttons', () => {
       const { rerender } = render(
-        <ButtonBase isDisabled>Disabled Button</ButtonBase>,
+        <ButtonBase isDisabled>Disabled button</ButtonBase>,
       );
       let button = screen.getByRole('button');
       expect(button).toHaveAttribute('tabindex', '-1');

--- a/packages/design-system-react/src/components/ButtonBase/README.mdx
+++ b/packages/design-system-react/src/components/ButtonBase/README.mdx
@@ -9,7 +9,7 @@ ButtonBase is a labeled element that a user can click or tap to initiate an acti
 ```tsx
 import { ButtonBase } from '@metamask/design-system-react';
 
-<ButtonBase onClick={() => {}}>Button Base</ButtonBase>;
+<ButtonBase onClick={() => {}}>Button base</ButtonBase>;
 ```
 
 <Canvas of={ButtonBaseStories.Default} />

--- a/packages/design-system-react/src/components/ButtonHero/ButtonHero.stories.tsx
+++ b/packages/design-system-react/src/components/ButtonHero/ButtonHero.stories.tsx
@@ -70,7 +70,7 @@ type Story = StoryObj<typeof ButtonHero>;
 
 export const Default: Story = {
   args: {
-    children: 'Primary Action',
+    children: 'Primary action',
   },
 };
 
@@ -92,28 +92,28 @@ export const Size: Story = {
 
 export const IsFullWidth: Story = {
   args: {
-    children: 'Full Width',
+    children: 'Full width',
     isFullWidth: true,
   },
 };
 
 export const StartIconName: Story = {
   args: {
-    children: 'Start Icon',
+    children: 'Start icon',
     startIconName: IconName.AddSquare,
   },
 };
 
 export const EndIconName: Story = {
   args: {
-    children: 'End Icon',
+    children: 'End icon',
     endIconName: IconName.AddSquare,
   },
 };
 
 export const Disabled: Story = {
   args: {
-    children: 'Disabled Button',
+    children: 'Disabled button',
     isDisabled: true,
   },
 };

--- a/packages/design-system-react/src/components/ButtonHero/ButtonHero.test.tsx
+++ b/packages/design-system-react/src/components/ButtonHero/ButtonHero.test.tsx
@@ -39,7 +39,7 @@ describe('ButtonHero Component', () => {
     const handleClick = jest.fn();
     render(
       <ButtonHero isDisabled onClick={handleClick}>
-        Disabled Button
+        Disabled button
       </ButtonHero>,
     );
 
@@ -51,7 +51,7 @@ describe('ButtonHero Component', () => {
   it('applies loading styles while preserving hero-specific classes', () => {
     render(
       <ButtonHero isLoading loadingText="Loading...">
-        Loading Button
+        Loading button
       </ButtonHero>,
     );
 

--- a/packages/design-system-react/src/components/ButtonHero/ButtonHero.test.tsx
+++ b/packages/design-system-react/src/components/ButtonHero/ButtonHero.test.tsx
@@ -64,12 +64,12 @@ describe('ButtonHero Component', () => {
 
   it('displays loading text when loading', () => {
     render(
-      <ButtonHero isLoading loadingText="Please wait...">
+      <ButtonHero isLoading loadingText="Loading...">
         Submit
       </ButtonHero>,
     );
 
-    expect(screen.getAllByText('Please wait...')).toHaveLength(2);
+    expect(screen.getAllByText('Loading...')).toHaveLength(2);
     const widthPlaceholder = screen
       .getByRole('button')
       .querySelector('span.invisible');

--- a/packages/design-system-react/src/components/ModalBody/ModalBody.stories.tsx
+++ b/packages/design-system-react/src/components/ModalBody/ModalBody.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<ModalBodyProps> = {
     },
   },
   args: {
-    children: 'Modal Body',
+    children: 'Modal body',
   },
   render: (args) => (
     <ModalBody {...args}>

--- a/packages/design-system-react/src/components/SensitiveText/SensitiveText.stories.tsx
+++ b/packages/design-system-react/src/components/SensitiveText/SensitiveText.stories.tsx
@@ -52,7 +52,7 @@ const meta: Meta<SensitiveTextProps> = {
     length: SensitiveTextLength.Short,
     variant: TextVariant.BodyMd,
     color: TextColor.TextDefault,
-    children: 'Sensitive Information',
+    children: 'Sensitive information',
   },
 };
 

--- a/packages/design-system-react/src/components/SensitiveText/SensitiveText.test.tsx
+++ b/packages/design-system-react/src/components/SensitiveText/SensitiveText.test.tsx
@@ -7,16 +7,16 @@ import { SensitiveText } from './SensitiveText';
 describe('SensitiveText', () => {
   describe('isHidden', () => {
     it('renders the children when false', () => {
-      render(<SensitiveText>Sensitive Information</SensitiveText>);
+      render(<SensitiveText>Sensitive information</SensitiveText>);
 
-      expect(screen.getByText('Sensitive Information')).toBeInTheDocument();
+      expect(screen.getByText('Sensitive information')).toBeInTheDocument();
     });
 
     it('replaces children with bullets when true', () => {
-      render(<SensitiveText isHidden>Sensitive Information</SensitiveText>);
+      render(<SensitiveText isHidden>Sensitive information</SensitiveText>);
 
       expect(
-        screen.queryByText('Sensitive Information'),
+        screen.queryByText('Sensitive information'),
       ).not.toBeInTheDocument();
       expect(screen.getByText('••••••')).toBeInTheDocument();
     });

--- a/packages/design-system-react/src/components/TextButton/README.mdx
+++ b/packages/design-system-react/src/components/TextButton/README.mdx
@@ -9,7 +9,7 @@ TextButton is used for text-only button actions or hyperlink without padding or 
 ```tsx
 import { TextButton } from '@metamask/design-system-react';
 
-<TextButton onClick={() => {}}>Text Button</TextButton>;
+<TextButton onClick={() => {}}>Text button</TextButton>;
 ```
 
 <Canvas of={TextButtonStories.Default} />

--- a/packages/design-system-react/src/components/TextButton/TextButton.figma.tsx
+++ b/packages/design-system-react/src/components/TextButton/TextButton.figma.tsx
@@ -54,7 +54,7 @@ figma.connect(
         endIconName={endIconName}
         {...props}
       >
-        Text Button
+        Text button
       </TextButton>
     ),
   },

--- a/packages/design-system-react/src/components/TextButton/TextButton.stories.tsx
+++ b/packages/design-system-react/src/components/TextButton/TextButton.stories.tsx
@@ -59,7 +59,7 @@ type Story = StoryObj<typeof TextButton>;
 
 export const Default: Story = {
   args: {
-    children: 'Text Button',
+    children: 'Text button',
   },
 };
 
@@ -111,7 +111,7 @@ export const IsInverse: Story = {
   render: (args) => (
     <div className="rounded bg-primary-default p-4">
       <TextButton {...args} isInverse>
-        Inverse Button
+        Inverse button
       </TextButton>
     </div>
   ),
@@ -119,21 +119,21 @@ export const IsInverse: Story = {
 
 export const StartIconName: Story = {
   args: {
-    children: 'With Start Icon',
+    children: 'With start icon',
     startIconName: IconName.AddSquare,
   },
 };
 
 export const EndIconName: Story = {
   args: {
-    children: 'With End Icon',
+    children: 'With end icon',
     endIconName: IconName.AddSquare,
   },
 };
 
 export const IsDisabled: Story = {
   args: {
-    children: 'Disabled Button',
+    children: 'Disabled button',
     isDisabled: true,
   },
 };

--- a/packages/design-system-react/src/components/TextButton/TextButton.test.tsx
+++ b/packages/design-system-react/src/components/TextButton/TextButton.test.tsx
@@ -9,7 +9,7 @@ import { TextButton } from './TextButton';
 
 describe('TextButton', () => {
   it('renders with text button styles by default', () => {
-    render(<TextButton>Text Button</TextButton>);
+    render(<TextButton>Text button</TextButton>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass(
@@ -22,7 +22,7 @@ describe('TextButton', () => {
   });
 
   it('renders with inverse styles when isInverse is true', () => {
-    render(<TextButton isInverse>Inverse Button</TextButton>);
+    render(<TextButton isInverse>Inverse button</TextButton>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass('text-primary-inverse');
@@ -42,7 +42,7 @@ describe('TextButton', () => {
   });
 
   it('applies disabled styles while preserving variant-specific classes', () => {
-    render(<TextButton isDisabled>Disabled Button</TextButton>);
+    render(<TextButton isDisabled>Disabled button</TextButton>);
 
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
@@ -90,13 +90,13 @@ describe('TextButton', () => {
       <Text variant={TextVariant.BodyLg}>
         Text with{' '}
         <TextButton textProps={{ className: 'font-inherit' }}>
-          Text Button
+          Text button
         </TextButton>{' '}
         inside
       </Text>,
     );
 
-    const text = screen.getByText('Text Button');
+    const text = screen.getByText('Text button');
     expect(text).toHaveClass('font-inherit');
   });
 });

--- a/packages/design-system-react/src/components/Toast/README.mdx
+++ b/packages/design-system-react/src/components/Toast/README.mdx
@@ -22,7 +22,7 @@ const Demo = () => {
           });
         }}
       >
-        Show Toast
+        Show toast
       </Button>
       <Toaster />
     </>
@@ -50,7 +50,7 @@ const Demo = () => {
           });
         }}
       >
-        Show Toast
+        Show toast
       </Button>
       <Toaster />
     </>
@@ -76,7 +76,7 @@ Use `title` for the primary message. Use `titleProps` to access the title `Text`
 import { toast } from '@metamask/design-system-react';
 
 toast({
-  title: 'Added to Watchlist',
+  title: 'Added to watchlist',
 });
 ```
 
@@ -151,7 +151,7 @@ import {
 
 // Right (trailing)
 toast({
-  title: 'Added to Watchlist',
+  title: 'Added to watchlist',
   actionButtonLabel: 'Undo',
   actionButtonLayout: BannerBaseActionButtonLayout.End,
   actionButtonOnClick: () => {

--- a/packages/design-system-react/src/components/Toast/Toast.stories.tsx
+++ b/packages/design-system-react/src/components/Toast/Toast.stories.tsx
@@ -70,7 +70,7 @@ export const Default: Story = {
             });
           }}
         >
-          Show Toast
+          Show toast
         </Button>
         <Toaster />
       </>
@@ -84,7 +84,7 @@ export const Default: Story = {
 
 export const Title: Story = {
   args: {
-    title: 'Added to Watchlist',
+    title: 'Added to watchlist',
   },
 };
 
@@ -134,7 +134,7 @@ export const ActionButton: Story = {
           actionButtonLayout={BannerBaseActionButtonLayout.End}
           actionButtonOnClick={() => undefined}
           severity={ToastSeverity.Success}
-          title="Added to Watchlist"
+          title="Added to watchlist"
         />
       </Box>
       <Box className="flex flex-col gap-2">
@@ -177,7 +177,7 @@ export const Spacing: Story = {
         <Toast
           onClose={() => undefined}
           severity={ToastSeverity.Success}
-          title="Added to Watchlist"
+          title="Added to watchlist"
         />
         <Toast
           onClose={() => undefined}
@@ -232,7 +232,7 @@ export const Spacing: Story = {
           actionButtonOnClick={() => undefined}
           description="You can remove it anytime."
           severity={ToastSeverity.Success}
-          title="Added to Watchlist"
+          title="Added to watchlist"
         />
         <Toast
           actionButtonLabel="Undo"
@@ -241,7 +241,7 @@ export const Spacing: Story = {
           description="Your token has been saved for easy access. You may remove this anytime."
           onClose={() => undefined}
           severity={ToastSeverity.Success}
-          title="Added to Watchlist"
+          title="Added to watchlist"
         />
       </Box>
     </Box>
@@ -271,7 +271,7 @@ export const IncorrectUsage: Story = {
           description="You can remove it anytime."
           onClose={() => undefined}
           severity={ToastSeverity.Success}
-          title="Added to Watchlist"
+          title="Added to watchlist"
         />
       </Box>
       <Box className="flex flex-col gap-4">
@@ -295,7 +295,7 @@ export const IncorrectUsage: Story = {
           description="Your token has been saved for easy access. You may remove this anytime."
           onClose={() => undefined}
           severity={ToastSeverity.Success}
-          title="Added to Watchlist"
+          title="Added to watchlist"
         />
       </Box>
     </Box>

--- a/packages/design-system-react/src/components/Toast/Toast.stories.tsx
+++ b/packages/design-system-react/src/components/Toast/Toast.stories.tsx
@@ -182,7 +182,7 @@ export const Spacing: Story = {
         <Toast
           onClose={() => undefined}
           severity={ToastSeverity.Success}
-          title="Your deposit of 20.50 USDC into Account 1 is been confirmed."
+          title="USDC deposited into Account 1"
         />
       </Box>
       <Box className="flex flex-col gap-4">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Applies the MetaMask Content Design Style Guide to sample and default user-facing strings in this design system. The Cursor rule itself landed on `main` in #1462; this PR is **copy fixes only** (stories, tests, README/MDX examples, and a few component defaults).

Changes include:

- Sentence case for sample product copy (for example `Start Trading` → `Start trading`, `Account Settings` → `Account settings`, `Added to Watchlist` → `Added to watchlist`)
- Sentence case for button, header, banner, and toast sample strings in stories, READMEs, and tests (for example `Primary Button` → `Primary button`, `Screen Title` → `Screen title`)
- Replacing `"please"` loading copy with `"Loading..."`
- Replacing toast `"Click here"` with `"View details"`
- Changing the `AvatarFavicon` fallback alt from `"Dapp logo"` to `"Site logo"`
- Changing the React Native `ButtonBase` loading accessibility hint from `"Button is currently loading, please wait"` to `"Button is currently loading"`

**Changelog (consumer-facing):**

- `@metamask/design-system-react`: `AvatarFavicon` default image alt is now `"Site logo"` when `name` is omitted
- `@metamask/design-system-react-native`: `ButtonBase` default loading `accessibilityHint` no longer includes `"please wait"`

**Review evidence:** File-level comments on changed `.stories.tsx` files include before/after Storybook screenshots (images pinned to commit `aaf9f719`).

## **Related issues**

- Content guidelines rule: #1462
- Source rule PR: https://github.com/MetaMask/metamask-mobile/pull/35256

## **Manual testing steps**

1. Open the PR Storybook preview (React and React Native) and spot-check updated stories (`TabEmptyState`, `HeaderStandard`, `Toast`, `Button` variants).
2. Compare against file-level PR comments for before/after screenshots on changed story files.
3. Run package tests if desired: `yarn workspace @metamask/design-system-react run test` and `yarn workspace @metamask/design-system-react-native run test`.

## **Screenshots/Recordings**

Before/after screenshots are attached as file-level review comments on changed `.stories.tsx` files (not committed to this branch).

### **Before**

See pinned images and [main Storybook](https://metamask.github.io/metamask-design-system) links in PR file comments.

### **After**

See pinned images and PR preview links in PR file comments.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9807269-b3c7-4d67-abd1-07d44480aba0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9807269-b3c7-4d67-abd1-07d44480aba0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

