### PR TITLE
feat: add numeric aliases for Tailwind's radius scale

### DIFF
--- a/.cursor/rules/component-creation.md
+++ b/.cursor/rules/component-creation.md
@@ -147,7 +147,7 @@ export type { MyComponentProps } from './MyComponent.types';
 
 - ✅ Replace template div/View with Box primitive
 - ✅ Use Text component (not raw span/Text)
-- ✅ Use design token const objects (BoxBackgroundColor, BoxBorderRadius, TextVariant)
+- ✅ Use design token const objects (BoxBackgroundColor, TextVariant) and radius token classes (`rounded-8`)
 - ✅ Forward refs using `forwardRef`
 - ✅ Set displayName: `MyComponent.displayName = 'MyComponent';`
 
@@ -159,7 +159,7 @@ export const MyComponent = forwardRef<RefType, MyComponentProps>(
     <Box
       ref={ref}
       backgroundColor={BoxBackgroundColor.BackgroundDefault}
-      borderRadius={BoxBorderRadius.Md}
+      className="rounded-6"
       {...props}
     >
       <Text variant={TextVariant.BodyMd}>{children}</Text>

--- a/.cursor/rules/styling.md
+++ b/.cursor/rules/styling.md
@@ -20,10 +20,9 @@ Component styling using design tokens, Tailwind CSS (web), and TWRNC (React Nati
 
 // ✅ Correct
 <Box
-  borderRadius={BoxBorderRadius.Lg}
   backgroundColor={BoxBackgroundColor.BackgroundAlternative}
   p={4}
-  className="flex-1" // No flex-1 prop exists, so className is fine
+  className="rounded-8 flex-1" // No radius or flex-1 prop exists, so className is fine
 >
   <Text variant={TextVariant.BodyMd}>Content</Text>
 </Box>
@@ -39,10 +38,9 @@ Component styling using design tokens, Tailwind CSS (web), and TWRNC (React Nati
 
 // ✅ Correct
 <Box
-  borderRadius={BoxBorderRadius.Lg}
   backgroundColor={BoxBackgroundColor.BackgroundAlternative}
   p={4}
-  twClassName="flex-1" // No flex-1 prop exists, so twClassName is fine
+  twClassName="rounded-8 flex-1" // No radius or flex-1 prop exists, so twClassName is fine
 >
   <Text variant={TextVariant.BodyMd}>Content</Text>
 </Box>
@@ -50,9 +48,9 @@ Component styling using design tokens, Tailwind CSS (web), and TWRNC (React Nati
 
 ### Design Tokens Only
 
-- **ALWAYS** use design token generated classes (bg-default, text-error-default)
+- **ALWAYS** use design token generated classes (bg-default, text-error-default, rounded-8)
 - **NEVER** use default Tailwind colors (bg-blue-500, text-gray-700)
-- **NEVER** use arbitrary values (bg-[#4459ff], p-[16px]) unless critical
+- **NEVER** use arbitrary values (bg-[#4459ff], p-[16px], rounded-[10px]) unless critical
 - **ALWAYS** use Text component for typography, never Tailwind text classes
 
 **React Web:**
@@ -92,6 +90,33 @@ Component styling using design tokens, Tailwind CSS (web), and TWRNC (React Nati
   </Text>
 </Box>
 ```
+
+### Corner Radius
+
+- **ALWAYS** use the numeric radius names. Tailwind's `rounded-sm`/`md`/`lg`/
+  `xl`/`2xl`/`3xl` still resolve to the same values, but a numeric name states
+  its own value and does not change meaning between Tailwind versions.
+
+| Class          | Tailwind equivalent | Value  |
+| -------------- | ------------------- | ------ |
+| `rounded-none` | `rounded-none`      | 0      |
+| `rounded-2`    | `rounded-sm`        | 2px    |
+| `rounded-4`    | `rounded`           | 4px    |
+| `rounded-6`    | `rounded-md`        | 6px    |
+| `rounded-8`    | `rounded-lg`        | 8px    |
+| `rounded-12`   | `rounded-xl`        | 12px   |
+| `rounded-16`   | `rounded-2xl`       | 16px   |
+| `rounded-24`   | `rounded-3xl`       | 24px   |
+| `rounded-full` | `rounded-full`      | 9999px |
+
+Corner-specific variants work as usual: `rounded-t-24`, `rounded-tl-2`.
+
+- **ALWAYS** use `rounded-full` for circles and capsules. A radius larger than
+  half the shortest side rounds the shape fully.
+- **ONLY** compute a radius (`size / 2`) when the diameter is dynamic and lives
+  in the same expression.
+- For styles that cannot use classes, import the values instead of hardcoding
+  them: `import { borderRadius } from '@metamask/design-tokens'`.
 
 ### Platform-Specific Props
 
@@ -351,6 +376,7 @@ After styling changes, verify:
 - [ ] Component props used where available
 - [ ] className/twClassName only when no equivalent prop exists
 - [ ] No default Tailwind colors (bg-blue-500, text-gray-700)
+- [ ] No default Tailwind radius classes (rounded-lg, rounded-full) — use radius tokens
 - [ ] No arbitrary values (unless documented as necessary)
 - [ ] No inline styles mixed with Tailwind classes
 - [ ] Platform-specific prop used (className for web, twClassName for native)

--- a/packages/design-system-react-native/src/border-radius.test.ts
+++ b/packages/design-system-react-native/src/border-radius.test.ts
@@ -1,0 +1,51 @@
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { borderRadius } from '@metamask/design-tokens';
+import { renderHook } from '@testing-library/react-native';
+
+// Each numeric alias and the Tailwind name that carries the same value.
+const ALIASED_NAMES: [string, string][] = [
+  ['2', 'sm'],
+  ['4', ''],
+  ['6', 'md'],
+  ['8', 'lg'],
+  ['12', 'xl'],
+  ['16', '2xl'],
+  ['24', '3xl'],
+];
+
+describe('Border radius utilities', () => {
+  let tw: ReturnType<typeof useTailwind>;
+
+  beforeEach(() => {
+    tw = renderHook(() => useTailwind()).result.current;
+  });
+
+  it.each(Object.entries(borderRadius))(
+    'resolves rounded-%s to %ipx',
+    (token, value) => {
+      expect(tw.style(`rounded-${token}`)).toStrictEqual({
+        borderRadius: value,
+      });
+    },
+  );
+
+  it.each(ALIASED_NAMES)(
+    'rounded-%s resolves to the same value as the Tailwind name it aliases',
+    (alias, tailwindName) => {
+      const tailwindClass = tailwindName
+        ? `rounded-${tailwindName}`
+        : 'rounded';
+
+      expect(tw.style(`rounded-${alias}`)).toStrictEqual(
+        tw.style(tailwindClass),
+      );
+    },
+  );
+
+  it('supports corner-specific variants', () => {
+    expect(tw.style('rounded-t-24')).toStrictEqual({
+      borderTopLeftRadius: 24,
+      borderTopRightRadius: 24,
+    });
+  });
+});

--- a/packages/design-system-react/src/utils/tw-merge.test.ts
+++ b/packages/design-system-react/src/utils/tw-merge.test.ts
@@ -48,6 +48,31 @@ describe('twMerge utility', () => {
     });
   });
 
+  // Classes are passed as separate arguments rather than one string so the
+  // Tailwind classname-order autofixer cannot reorder them and invert the
+  // expected winner.
+  describe('border radius conflicts', () => {
+    it.each([
+      ['rounded-8', 'rounded-12'],
+      ['rounded-8', 'rounded-full'],
+      ['rounded-full', 'rounded-none'],
+      ['rounded-24', 'rounded-2'],
+      ['rounded-t-24', 'rounded-t-12'],
+      ['rounded-tl-2', 'rounded-tl-8'],
+      // Aliases and Tailwind's own names have to resolve against each other.
+      ['rounded-lg', 'rounded-16'],
+      ['rounded-16', 'rounded-lg'],
+    ])('%s is overridden by a later %s', (base, override) => {
+      expect(twMerge(base, override)).toBe(override);
+    });
+
+    it('keeps a corner override alongside an all-corner radius', () => {
+      expect(twMerge('rounded-8', 'rounded-t-12')).toBe(
+        'rounded-8 rounded-t-12',
+      );
+    });
+  });
+
   describe('complex class combinations', () => {
     it('should handle multiple property conflicts simultaneously', () => {
       const result = twMerge('text-l-heading-lg font-bold text-alternative');

--- a/packages/design-system-react/src/utils/tw-merge.ts
+++ b/packages/design-system-react/src/utils/tw-merge.ts
@@ -31,12 +31,41 @@ const variantClassGroups = [
   'l-amount-display-lg',
 ];
 
+// Numeric radius aliases from `@metamask/design-tokens`. Inlined to avoid a
+// workspace dependency cycle (design-tokens → design-system-react).
+const borderRadiusScale = ['2', '4', '6', '8', '12', '16', '24'];
+
+// Tailwind Merge keys border radius by corner, so every corner group needs the
+// aliases. Without them `rounded-8 rounded-12` keeps both classes, and so does
+// `rounded-lg rounded-12`, since Merge cannot tell the two vocabularies name
+// the same property.
+const borderRadiusClassGroups = Object.fromEntries(
+  [
+    'rounded',
+    'rounded-s',
+    'rounded-e',
+    'rounded-t',
+    'rounded-r',
+    'rounded-b',
+    'rounded-l',
+    'rounded-ss',
+    'rounded-se',
+    'rounded-ee',
+    'rounded-es',
+    'rounded-tl',
+    'rounded-tr',
+    'rounded-br',
+    'rounded-bl',
+  ].map((group) => [group, [{ [group]: borderRadiusScale }]]),
+);
+
 /**
  * Custom Tailwind Merge configuration to handle our design system's typography classes.
  * This extends the default Tailwind Merge behavior to properly handle conflicts between:
  * 1. Custom text color classes (text-default, text-alternative, text-muted)
  * 2. Typography variant classes for font sizes (e.g., s-body-md, l-heading-lg)
  * 3. Standard and custom font weight classes
+ * 4. Radius token classes (e.g., rounded-8, rounded-full)
  *
  * Without this configuration, Tailwind Merge wouldn't know these classes are meant
  * to override each other, potentially leading to multiple conflicting classes
@@ -45,6 +74,7 @@ const variantClassGroups = [
 export const twMerge = extendTailwindMerge({
   extend: {
     classGroups: {
+      ...borderRadiusClassGroups,
       'text-color': ['text-default', 'text-alternative', 'text-muted'],
       'font-size': [
         {

--- a/packages/design-system-tailwind-preset/README.md
+++ b/packages/design-system-tailwind-preset/README.md
@@ -31,13 +31,30 @@ module.exports = {
 ```
 
 ```html
-<div class="bg-default text-default">
+<div class="bg-default text-default rounded-8">
   <h1 class="font-s-heading-lg sm:font-l-heading-lg">Welcome to MetaMask</h1>
   <p class="font-s-body-md sm:font-l-body">
     Enjoy our consistent design across projects!
   </p>
 </div>
 ```
+
+### Corner radius
+
+The preset adds numeric aliases for Tailwind's radius scale. No values change:
+`rounded-8` and `rounded-lg` are both 8px, and Tailwind's own names keep
+working.
+
+`rounded-none`, `rounded-2`, `rounded-4`, `rounded-6`, `rounded-8`,
+`rounded-12`, `rounded-16`, `rounded-24`, `rounded-full`.
+
+Prefer the numeric names. They state their value, and they mean the same thing
+across Tailwind versions — `rounded-sm` is 2px in v3 and 4px in v4.
+
+Corner-specific variants work as usual: `rounded-t-24`, `rounded-tl-2`.
+
+Use `rounded-full` for circles and capsules — a radius larger than half the
+shortest side rounds the shape fully.
 
 ## Customization
 

--- a/packages/design-system-tailwind-preset/scripts/testUtils.ts
+++ b/packages/design-system-tailwind-preset/scripts/testUtils.ts
@@ -27,6 +27,7 @@ export const getDesignTokenVariables = async (
     'dark-theme-colors.css',
     'typography.css',
     'shadow.css',
+    'border-radius.css',
   ];
 
   // Initialize a Set to store all variables

--- a/packages/design-system-tailwind-preset/src/border-radius.test.ts
+++ b/packages/design-system-tailwind-preset/src/border-radius.test.ts
@@ -1,0 +1,62 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
+import {
+  getDesignTokenVariables,
+  collectCssVariables,
+} from '../scripts/testUtils';
+
+import { borderRadius } from './border-radius';
+
+// `none` and `full` are supplied by Tailwind rather than aliased here, so their
+// variables are expected to go unused by this preset.
+const NOT_ALIASED = ['--radius-none', '--radius-full'];
+
+const toPx = (value: string) =>
+  value.endsWith('rem') ? parseFloat(value) * 16 : parseFloat(value);
+
+describe('Border radius', () => {
+  const usedVariables = collectCssVariables(borderRadius);
+
+  it('should use only radius CSS variables that exist in @metamask/design-tokens', async () => {
+    const designTokens = await getDesignTokenVariables(['--radius']);
+
+    const missingVariables = usedVariables.filter(
+      (varName) => !designTokens.has(varName),
+    );
+
+    expect(missingVariables).toHaveLength(0);
+  });
+
+  it('should not have unused radius CSS variables in @metamask/design-tokens', async () => {
+    const designTokens = await getDesignTokenVariables(['--radius']);
+    const usedSet = new Set([...usedVariables, ...NOT_ALIASED]);
+
+    const unusedVariables = Array.from(designTokens).filter(
+      (varName) => !usedSet.has(varName),
+    );
+
+    expect(unusedVariables).toHaveLength(0);
+  });
+
+  it('aliases the numeric steps only', () => {
+    expect(Object.keys(borderRadius)).toStrictEqual([
+      '2',
+      '4',
+      '6',
+      '8',
+      '12',
+      '16',
+      '24',
+    ]);
+  });
+
+  it('introduces no value Tailwind does not already ship', () => {
+    const tailwindValues = Object.values(defaultTheme.borderRadius ?? {}).map(
+      (value) => toPx(value as string),
+    );
+
+    Object.keys(borderRadius).forEach((token) => {
+      expect(tailwindValues).toContain(Number(token));
+    });
+  });
+});

--- a/packages/design-system-tailwind-preset/src/border-radius.ts
+++ b/packages/design-system-tailwind-preset/src/border-radius.ts
@@ -1,0 +1,20 @@
+/**
+ * Numeric aliases for Tailwind's radius scale.
+ *
+ * No new values are introduced: `rounded-8` and `rounded-lg` are both 8px.
+ * The aliases exist because a numeric name states its own value and means the
+ * same thing across Tailwind versions, whereas `rounded-sm` is 2px in v3 and
+ * 4px in v4.
+ *
+ * `rounded-none` and `rounded-full` are deliberately absent — Tailwind already
+ * spells those well, so they stay as they are.
+ */
+export const borderRadius = {
+  2: 'var(--radius-2)',
+  4: 'var(--radius-4)',
+  6: 'var(--radius-6)',
+  8: 'var(--radius-8)',
+  12: 'var(--radius-12)',
+  16: 'var(--radius-16)',
+  24: 'var(--radius-24)',
+};

--- a/packages/design-system-tailwind-preset/src/index.test.ts
+++ b/packages/design-system-tailwind-preset/src/index.test.ts
@@ -1,3 +1,6 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
+import { borderRadius } from './border-radius';
 import { colors } from './colors';
 import { shadows } from './shadows';
 
@@ -90,6 +93,25 @@ describe('Tailwind Preset', () => {
     expect(tailwindConfig.theme?.extend?.boxShadow).toStrictEqual(
       expect.objectContaining(shadows),
     );
+  });
+
+  /**
+   * Border radius
+   */
+
+  it('borderRadius extends the default Tailwind scale rather than replacing it', () => {
+    expect(tailwindConfig.theme?.extend?.borderRadius).toStrictEqual(
+      borderRadius,
+    );
+    expect(tailwindConfig.theme).not.toHaveProperty('borderRadius');
+  });
+
+  it('leaves the default Tailwind radius names untouched', () => {
+    const defaultNames = Object.keys(defaultTheme.borderRadius ?? {});
+
+    expect(
+      Object.keys(borderRadius).filter((token) => defaultNames.includes(token)),
+    ).toStrictEqual([]);
   });
 
   /**

--- a/packages/design-system-tailwind-preset/src/index.ts
+++ b/packages/design-system-tailwind-preset/src/index.ts
@@ -1,5 +1,6 @@
 import type { Config } from 'tailwindcss';
 
+import { borderRadius } from './border-radius';
 import { colors } from './colors';
 import { shadows, shadowPlugin } from './shadows';
 import { typography } from './typography';
@@ -8,6 +9,7 @@ const tailwindConfig: Config = {
   content: [],
   theme: {
     extend: {
+      borderRadius,
       colors: {
         ...colors,
       },

--- a/packages/design-system-twrnc-preset/README.md
+++ b/packages/design-system-twrnc-preset/README.md
@@ -58,6 +58,34 @@ function MyComponent() {
 }
 ```
 
+### Corner radius
+
+The preset adds numeric aliases for Tailwind's radius scale. No values change:
+`rounded-8` and `rounded-lg` are both 8px, and Tailwind's own names keep
+working.
+
+`rounded-none`, `rounded-2`, `rounded-4`, `rounded-6`, `rounded-8`,
+`rounded-12`, `rounded-16`, `rounded-24`, `rounded-full`.
+
+Prefer the numeric names. They state their value, and they mean the same thing
+across Tailwind versions — `rounded-sm` is 2px in v3 and 4px in v4.
+
+Corner-specific variants work as usual: `rounded-t-24`, `rounded-tl-2`.
+
+Use `rounded-full` for circles and capsules — a radius larger than half the
+shortest side rounds the shape fully.
+
+`StyleSheet` styles cannot use classes, so import the values rather than
+hardcoding them:
+
+```tsx
+import { borderRadius } from '@metamask/design-tokens';
+
+const styles = StyleSheet.create({
+  card: { borderRadius: borderRadius[8] },
+});
+```
+
 ### Tailwind Config for IntelliSense
 
 To get Tailwind IntelliSense and ESLint plugin support, use the config generator:

--- a/packages/design-system-twrnc-preset/src/border-radius.ts
+++ b/packages/design-system-twrnc-preset/src/border-radius.ts
@@ -1,0 +1,18 @@
+import { borderRadius } from '@metamask/design-tokens';
+
+/**
+ * Numeric aliases for Tailwind's radius scale, for twrnc.
+ *
+ * No new values are introduced: `rounded-8` and `rounded-lg` are both 8px.
+ * The aliases exist because a numeric name states its own value and means the
+ * same thing across Tailwind versions, whereas `rounded-sm` is 2px in v3 and
+ * 4px in v4.
+ *
+ * `rounded-none` and `rounded-full` are deliberately absent — Tailwind already
+ * spells those well, so they stay as they are.
+ */
+export const borderRadiusTailwindConfig = Object.fromEntries(
+  Object.entries(borderRadius)
+    .filter(([token]) => !Number.isNaN(Number(token)))
+    .map(([token, value]) => [token, `${value}px`]),
+);

--- a/packages/design-system-twrnc-preset/src/tailwind.config.ts
+++ b/packages/design-system-twrnc-preset/src/tailwind.config.ts
@@ -1,6 +1,7 @@
 import { brandColor } from '@metamask/design-tokens';
 import type { TwConfig } from 'twrnc';
 
+import { borderRadiusTailwindConfig } from './border-radius';
 import { getThemeColors } from './colors';
 import type { Theme } from './Theme.types';
 import { typographyTailwindConfig } from './typography';
@@ -105,6 +106,13 @@ export const generateTailwindConfig = (theme: Theme): TwConfig => {
       },
       lineHeight: {
         ...typographyTailwindConfig.lineHeight,
+      },
+      extend: {
+        // Added alongside the default Tailwind radius scale so consumers can
+        // adopt radius tokens without a coordinated rename.
+        borderRadius: {
+          ...borderRadiusTailwindConfig,
+        },
       },
     },
   };

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -63,6 +63,42 @@ const createStyles = (theme) =>
   });
 ```
 
+### Corner radius
+
+These are Tailwind's radius values — no steps are added or changed. What the
+design system adds is a naming convention: each step is named after its value.
+Radii do not change between themes, so they are exported on their own rather
+than through `lightTheme` / `darkTheme`.
+
+| Token               | Tailwind class | CSS variable    | Value  |
+| ------------------- | -------------- | --------------- | ------ |
+| `borderRadius.none` | `rounded-none` | `--radius-none` | 0      |
+| `borderRadius[2]`   | `rounded-2`    | `--radius-2`    | 2px    |
+| `borderRadius[4]`   | `rounded-4`    | `--radius-4`    | 4px    |
+| `borderRadius[6]`   | `rounded-6`    | `--radius-6`    | 6px    |
+| `borderRadius[8]`   | `rounded-8`    | `--radius-8`    | 8px    |
+| `borderRadius[12]`  | `rounded-12`   | `--radius-12`   | 12px   |
+| `borderRadius[16]`  | `rounded-16`   | `--radius-16`   | 16px   |
+| `borderRadius[24]`  | `rounded-24`   | `--radius-24`   | 24px   |
+| `borderRadius.full` | `rounded-full` | `--radius-full` | 9999px |
+
+Both presets add the numeric class names as aliases, so `rounded-8` and
+`rounded-lg` are the same 8px and Tailwind's own names keep working. Prefer the
+numeric ones: they state their value, and they mean the same thing across
+Tailwind versions, where `rounded-sm` is 2px in v3 and 4px in v4.
+
+Use `borderRadius.full` for circles and capsules: a radius larger than half the
+shortest side rounds the shape fully.
+
+```js
+import { borderRadius } from '@metamask/design-tokens';
+
+StyleSheet.create({
+  card: { borderRadius: borderRadius[8] },
+  avatar: { borderRadius: borderRadius.full },
+});
+```
+
 ## Tooling
 
 To prevent color tech debt and ensure themability, accessibility, and consistency of the MetaMask brand, we recommend using [@metamask/eslint-plugin-design-tokens](https://github.com/MetaMask/eslint-plugin-design-tokens). This ESLint plugin helps enforce the usage of design tokens in your codebase.

--- a/packages/design-tokens/src/css/border-radius.css
+++ b/packages/design-tokens/src/css/border-radius.css
@@ -1,0 +1,15 @@
+/**
+ * Corner radius
+ */
+:root {
+  /* border radius */
+  --radius-none: 0px;
+  --radius-2: 2px;
+  --radius-4: 4px;
+  --radius-6: 6px;
+  --radius-8: 8px;
+  --radius-12: 12px;
+  --radius-16: 16px;
+  --radius-24: 24px;
+  --radius-full: 9999px;
+}

--- a/packages/design-tokens/src/css/index.css
+++ b/packages/design-tokens/src/css/index.css
@@ -3,3 +3,4 @@
 @import './dark-theme-colors.css';
 @import './typography.css';
 @import './shadow.css';
+@import './border-radius.css';

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -6,8 +6,10 @@ export {
   typography,
   fontFamilies,
   AnimationDuration,
+  borderRadius,
 } from './js';
 export type {
+  BorderRadiusToken,
   BrandColor,
   Theme,
   ThemeColors,

--- a/packages/design-tokens/src/js/borderRadius/borderRadius.test.ts
+++ b/packages/design-tokens/src/js/borderRadius/borderRadius.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { borderRadius } from './borderRadius';
+
+describe('borderRadius', () => {
+  it('maps every token name to its pixel value', () => {
+    expect(borderRadius).toStrictEqual({
+      none: 0,
+      2: 2,
+      4: 4,
+      6: 6,
+      8: 8,
+      12: 12,
+      16: 16,
+      24: 24,
+      full: 9999,
+    });
+  });
+
+  it('names every numeric step after its own value', () => {
+    const numericSteps = Object.entries(borderRadius).filter(
+      ([token]) => !Number.isNaN(Number(token)),
+    );
+
+    expect(numericSteps).not.toHaveLength(0);
+    numericSteps.forEach(([token, value]) => {
+      expect(Number(token)).toBe(value);
+    });
+  });
+});
+
+describe('border-radius.css', () => {
+  const css = readFileSync(
+    resolve(__dirname, '../../css/border-radius.css'),
+    'utf8',
+  );
+
+  it.each(Object.entries(borderRadius))(
+    'defines --radius-%s as %ipx',
+    (token, value) => {
+      expect(css).toContain(`--radius-${token}: ${value}px;`);
+    },
+  );
+
+  it('does not define radius variables outside the scale', () => {
+    const declared = [...css.matchAll(/--radius-([\w-]+):/gu)].map(
+      ([, token]) => token,
+    );
+
+    expect(declared.sort()).toStrictEqual(Object.keys(borderRadius).sort());
+  });
+});

--- a/packages/design-tokens/src/js/borderRadius/borderRadius.ts
+++ b/packages/design-tokens/src/js/borderRadius/borderRadius.ts
@@ -1,0 +1,25 @@
+/**
+ * Corner radius tokens in pixels.
+ *
+ * These are the values Tailwind already ships — MetaMask adds no new steps.
+ * What it adds is a naming convention: each step is named after its value, so
+ * `rounded-8` is 8px. That matters because Tailwind's own names are not stable
+ * across versions (`rounded-sm` is 2px in v3 and 4px in v4), while a numeric
+ * name means the same thing everywhere.
+ *
+ * `none` and `full` keep Tailwind's names, because those say something the
+ * numbers cannot and are already the established spelling.
+ */
+export const borderRadius = {
+  none: 0,
+  2: 2,
+  4: 4,
+  6: 6,
+  8: 8,
+  12: 12,
+  16: 16,
+  24: 24,
+  full: 9999,
+} as const;
+
+export type BorderRadiusToken = keyof typeof borderRadius;

--- a/packages/design-tokens/src/js/borderRadius/index.ts
+++ b/packages/design-tokens/src/js/borderRadius/index.ts
@@ -1,0 +1,2 @@
+export { borderRadius } from './borderRadius';
+export type { BorderRadiusToken } from './borderRadius';

--- a/packages/design-tokens/src/js/index.ts
+++ b/packages/design-tokens/src/js/index.ts
@@ -15,3 +15,7 @@ export type { ThemeTypography } from './typography';
 
 // Animations
 export { AnimationDuration } from './animations';
+
+// Border radius
+export { borderRadius } from './borderRadius';
+export type { BorderRadiusToken } from './borderRadius';

--- a/packages/design-tokens/src/tailwind/theme.css
+++ b/packages/design-tokens/src/tailwind/theme.css
@@ -1,6 +1,7 @@
 @import '../css/brand-colors.css';
 @import '../css/typography.css';
 @import '../css/shadow.css';
+@import '../css/border-radius.css';
 
 @theme {
   --font-size-*: initial;
@@ -186,6 +187,17 @@
   --shadow-sm: 0 2px 8px 0 #0000001a;
   --shadow-md: 0 2px 16px 0 #0000001a;
   --shadow-lg: 0 2px 40px 0 #0000001a;
+
+  /* Numeric aliases for Tailwind's radius scale. No new values: rounded-8 and
+  rounded-lg are both 8px. Numeric names state their own value and are stable
+  across Tailwind versions, where rounded-sm is 2px in v3 and 4px in v4. */
+  --radius-2: 2px;
+  --radius-4: 4px;
+  --radius-6: 6px;
+  --radius-8: 8px;
+  --radius-12: 12px;
+  --radius-16: 16px;
+  --radius-24: 24px;
 }
 
 /**

--- a/packages/design-tokens/stories/BorderRadius.mdx
+++ b/packages/design-tokens/stories/BorderRadius.mdx
@@ -1,0 +1,206 @@
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks';
+import * as BorderRadiusStories from './BorderRadius.stories';
+
+# Border radius
+
+MetaMask uses Tailwind's radius scale. No values are added or changed — what the
+design system adds is a naming convention: each step is named after its value,
+so `rounded-8` is 8px.
+
+Tailwind's own names still work and always will. `rounded-8` and `rounded-lg`
+are the same 8px.
+
+<Canvas of={BorderRadiusStories.DefaultStory} />
+
+## Why alias at all
+
+A numeric name states its value, so nothing can drift between the class and a
+comment next to it.
+
+More usefully, numeric names are stable across Tailwind versions. `rounded-sm`
+is 2px in Tailwind v3 and 4px in v4, so the same class silently changes meaning
+on upgrade. `rounded-8` cannot.
+
+## Scale
+
+<Canvas of={BorderRadiusStories.Scale} />
+
+<table>
+  <thead>
+    <tr>
+      <th>Preferred</th>
+      <th>Tailwind equivalent</th>
+      <th>JS</th>
+      <th>CSS</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>rounded-none</code>
+      </td>
+      <td>
+        <code>rounded-none</code>
+      </td>
+      <td>
+        <code>borderRadius.none</code>
+      </td>
+      <td>
+        <code>var(--radius-none)</code>
+      </td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <td>
+        <code>rounded-2</code>
+      </td>
+      <td>
+        <code>rounded-sm</code>
+      </td>
+      <td>
+        <code>borderRadius[2]</code>
+      </td>
+      <td>
+        <code>var(--radius-2)</code>
+      </td>
+      <td>2px</td>
+    </tr>
+    <tr>
+      <td>
+        <code>rounded-4</code>
+      </td>
+      <td>
+        <code>rounded</code>
+      </td>
+      <td>
+        <code>borderRadius[4]</code>
+      </td>
+      <td>
+        <code>var(--radius-4)</code>
+      </td>
+      <td>4px</td>
+    </tr>
+    <tr>
+      <td>
+        <code>rounded-6</code>
+      </td>
+      <td>
+        <code>rounded-md</code>
+      </td>
+      <td>
+        <code>borderRadius[6]</code>
+      </td>
+      <td>
+        <code>var(--radius-6)</code>
+      </td>
+      <td>6px</td>
+    </tr>
+    <tr>
+      <td>
+        <code>rounded-8</code>
+      </td>
+      <td>
+        <code>rounded-lg</code>
+      </td>
+      <td>
+        <code>borderRadius[8]</code>
+      </td>
+      <td>
+        <code>var(--radius-8)</code>
+      </td>
+      <td>8px</td>
+    </tr>
+    <tr>
+      <td>
+        <code>rounded-12</code>
+      </td>
+      <td>
+        <code>rounded-xl</code>
+      </td>
+      <td>
+        <code>borderRadius[12]</code>
+      </td>
+      <td>
+        <code>var(--radius-12)</code>
+      </td>
+      <td>12px</td>
+    </tr>
+    <tr>
+      <td>
+        <code>rounded-16</code>
+      </td>
+      <td>
+        <code>rounded-2xl</code>
+      </td>
+      <td>
+        <code>borderRadius[16]</code>
+      </td>
+      <td>
+        <code>var(--radius-16)</code>
+      </td>
+      <td>16px</td>
+    </tr>
+    <tr>
+      <td>
+        <code>rounded-24</code>
+      </td>
+      <td>
+        <code>rounded-3xl</code>
+      </td>
+      <td>
+        <code>borderRadius[24]</code>
+      </td>
+      <td>
+        <code>var(--radius-24)</code>
+      </td>
+      <td>24px</td>
+    </tr>
+    <tr>
+      <td>
+        <code>rounded-full</code>
+      </td>
+      <td>
+        <code>rounded-full</code>
+      </td>
+      <td>
+        <code>borderRadius.full</code>
+      </td>
+      <td>
+        <code>var(--radius-full)</code>
+      </td>
+      <td>9999px</td>
+    </tr>
+  </tbody>
+</table>
+
+`none` and `full` keep Tailwind's names: those say something the numbers cannot,
+and are already the established spelling.
+
+## Circles and capsules
+
+Use `rounded-full`. A radius larger than half the shortest side rounds the shape
+fully, so a single class covers every avatar, badge and chip regardless of size.
+
+Only compute a radius (`size / 2`) when the diameter is dynamic and lives in the
+same expression.
+
+## Corners
+
+Corner-specific variants work as they do for any Tailwind radius utility.
+
+<Canvas of={BorderRadiusStories.Corners} />
+
+## Usage outside Tailwind
+
+React Native `StyleSheet` styles and other non-Tailwind styles should import the
+values rather than hardcode them.
+
+```tsx
+import { borderRadius } from '@metamask/design-tokens';
+
+StyleSheet.create({
+  card: { borderRadius: borderRadius[8] },
+  avatar: { borderRadius: borderRadius.full },
+});
+```

--- a/packages/design-tokens/stories/BorderRadius.stories.tsx
+++ b/packages/design-tokens/stories/BorderRadius.stories.tsx
@@ -1,0 +1,76 @@
+import { Text, TextVariant } from '@metamask/design-system-react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+
+import README from './BorderRadius.mdx';
+
+type BorderRadiusSwatchProps = {
+  label: string;
+  className?: string;
+};
+
+const BorderRadiusSwatch: React.FC<BorderRadiusSwatchProps> = ({
+  label,
+  className = '',
+}) => (
+  <div className="grid gap-2 text-center">
+    <div className={`size-24 bg-primary-muted ${className}`} />
+    <Text variant={TextVariant.BodyXs}>{label}</Text>
+  </div>
+);
+
+// Class names are written out in full because Tailwind only generates
+// utilities it can find as literal strings when scanning source files.
+const SCALE = [
+  { label: 'rounded-none', className: 'rounded-none' },
+  { label: 'rounded-2', className: 'rounded-2' },
+  { label: 'rounded-4', className: 'rounded-4' },
+  { label: 'rounded-6', className: 'rounded-6' },
+  { label: 'rounded-8', className: 'rounded-8' },
+  { label: 'rounded-12', className: 'rounded-12' },
+  { label: 'rounded-16', className: 'rounded-16' },
+  { label: 'rounded-24', className: 'rounded-24' },
+  { label: 'rounded-full', className: 'rounded-full' },
+];
+
+const meta: Meta<typeof BorderRadiusSwatch> = {
+  title: 'Design Tokens/Border Radius/Border Radius',
+  component: BorderRadiusSwatch,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+};
+
+export default meta;
+
+export const DefaultStory: StoryObj<typeof BorderRadiusSwatch> = {
+  name: 'Default',
+  args: {
+    label: 'rounded-8',
+    className: 'rounded-8',
+  },
+  render: (args) => <BorderRadiusSwatch {...args} />,
+};
+
+export const Scale: StoryObj<typeof BorderRadiusSwatch> = {
+  render: () => (
+    <div className="grid grid-cols-[repeat(auto-fill,96px)] gap-8">
+      {SCALE.map(({ label, className }) => (
+        <BorderRadiusSwatch key={label} label={label} className={className} />
+      ))}
+    </div>
+  ),
+};
+
+export const Corners: StoryObj<typeof BorderRadiusSwatch> = {
+  render: () => (
+    <div className="grid grid-cols-[repeat(auto-fill,96px)] gap-8">
+      <BorderRadiusSwatch label="rounded-t-24" className="rounded-t-24" />
+      <BorderRadiusSwatch label="rounded-b-16" className="rounded-b-16" />
+      <BorderRadiusSwatch label="rounded-tl-12" className="rounded-tl-12" />
+      <BorderRadiusSwatch label="rounded-r-full" className="rounded-r-full" />
+    </div>
+  ),
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Radius is the one visual domain with no design token behind it. Colours, typography, shadows and animations all flow through `@metamask/design-tokens`; radius does not, so components fall back to Tailwind's names directly.

**We are not introducing a scale.** Tailwind's values are already the right ones — checked, and every value the design system uses is one Tailwind already ships. What this PR adds is a naming convention on top of them, plus the CSS-variable and JS surfaces that non-Tailwind callers need.

### Numeric aliases

| Preferred | Tailwind equivalent | Value |
| --- | --- | --- |
| `rounded-none` | `rounded-none` | 0 |
| `rounded-2` | `rounded-sm` | 2px |
| `rounded-4` | `rounded` | 4px |
| `rounded-6` | `rounded-md` | 6px |
| `rounded-8` | `rounded-lg` | 8px |
| `rounded-12` | `rounded-xl` | 12px |
| `rounded-16` | `rounded-2xl` | 16px |
| `rounded-24` | `rounded-3xl` | 24px |
| `rounded-full` | `rounded-full` | 9999px |

`none` and `full` keep Tailwind's spelling — those names say something the numbers cannot, and are already the established way to write them.

### Why alias rather than just use Tailwind's names

A numeric name states its value, so a class and a comment beside it cannot drift. That is not hypothetical here: `AvatarBase` carries `rounded-sm // 4px` when Tailwind renders it at 2px.

The stronger reason is version stability. **`rounded-sm` is 2px in Tailwind v3 and 4px in v4** — the same class silently changes meaning on upgrade. `rounded-8` cannot.

### Scope

- `borderRadius` exported from `@metamask/design-tokens`, plus `--radius-*` CSS variables in `styles.css` and the Tailwind v4 `@theme`. This is the part mobile's ~508 raw `borderRadius: N` literals and extension's ~145 SCSS declarations currently have nothing to point at.
- Both presets register the numeric aliases via `theme.extend`
- A Storybook page under **Design Tokens → Border Radius**
- `twMerge` taught the aliases

### Nothing breaks, nothing needs migrating

Purely additive. Tailwind's names keep working and are not scheduled for removal — aliases and originals coexist by design. A test asserts the aliases introduce no value Tailwind does not already ship.

No `CHANGELOG.md` entries here by design: changelogs are generated on `release/*` branches, and the "Validate changelog" checks pass.

### One fix worth a look

`twMerge` had to learn the aliases. Without it, `twMerge('rounded-lg', 'rounded-12')` keeps **both** classes and CSS source order picks the winner — so a consumer override is silently ignored. Merge cannot otherwise tell the two vocabularies name the same property. The class group is keyed per corner, so all fifteen corner groups need them. Covered by tests, including alias-vs-Tailwind-name conflicts in both directions.

## **Related issues**

Fixes:

## **Manual testing steps**

1. `yarn build && yarn test && yarn lint` — all green.
2. `yarn storybook` → **Design Tokens / Border Radius**. Each step renders in both themes and computed `border-radius` matches the name.
3. Confirm the aliases are aliases: on React Native, `tw.style('rounded-8')` deep-equals `tw.style('rounded-lg')`. Asserted in tests for every pair.
4. Confirm tooling resolves them: `rounded-8` passes `tailwindcss/no-custom-classname` and appears in Tailwind IntelliSense on both platforms, since both configs read the preset.

## **Screenshots/Recordings**

[Border radius scale in Storybook](https://cursor.com/agents/bc-453ce01d-ee42-42d7-9261-4ef90bfb094d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_radius_scale_storybook.png)

### **Before**

No visual change — this PR adds class names and does not alter any rendered radius. The new Storybook page is the only new UI.

### **After**

As above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

### What this PR is really asking

One question: **is the numeric alias the convention we want?** Everything downstream follows from it.

Chromatic will show three new snapshots for the Border Radius page and no changes to existing ones. `chromatic --exit-zero-on-changes` means CI stays green either way, so the new baselines still need accepting.

### Note on an earlier revision

This PR previously proposed a MetaMask-owned scale that replaced Tailwind's, including a 10px step. That turned out to be nine renames of values Tailwind already had, to add one step that was not real — at a cost of ~815 call sites across extension and mobile. Reworked to aliases only. The follow-up in [#1464](https://github.com/MetaMask/metamask-design-system/pull/1464) moves the design system's own components across; consumers never have to.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-453ce01d-ee42-42d7-9261-4ef90bfb094d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-453ce01d-ee42-42d7-9261-4ef90bfb094d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

