### PR TITLE
docs: add Content guidelines sections to component READMEs

### DIFF
--- a/.cursor/rules/content-guidelines.mdc
+++ b/.cursor/rules/content-guidelines.mdc
@@ -1,5 +1,5 @@
 ---
-description: MetaMask content design rules for user-facing strings — capitalization, punctuation, tone, terminology, and per-component patterns
+description: MetaMask content design rules for user-facing strings — capitalization, punctuation, voice, tone, and terminology. Component-specific copy rules live in each component's README (read via Storybook MCP).
 globs:
   - packages/design-system-react/src/**/*.{stories.tsx,constants.ts,tsx,ts,mdx}
   - packages/design-system-react-native/src/**/*.{stories.tsx,constants.ts,tsx,ts,md}
@@ -15,6 +15,8 @@ alwaysApply: false
 **Applies to** user-facing sample copy in stories, constants, README/MDX examples, default `loadingText` / alt / accessibility strings, and tests that assert those strings.
 
 **Does not apply to** Storybook meta `title` / story `name` (sidebar labels), TypeScript identifiers, JSDoc that describes APIs, `CHANGELOG.md`, or historical examples in `MIGRATION.md`.
+
+**Component-specific copy rules** (prop-level guidance for `title`, `description`, button labels, etc.) live in each component's `README.md` / `README.mdx`. Read them via Storybook MCP before writing or reviewing copy for a specific component.
 
 ---
 
@@ -115,135 +117,6 @@ Do not use colons in labels or headings. Use sparingly in body copy.
 
 ---
 
-## Per-component rules
-
-Use these patterns for sample copy in this repo. Prop names match `@metamask/design-system-react` and `@metamask/design-system-react-native`.
-
-### Buttons (`Button`, `ButtonPrimary`, `ButtonSecondary`, `ButtonTertiary`, `ButtonHero`, `ButtonBase`, `ButtonSemantic`, `TextButton`, `ButtonFilter`, `FilterButton`, `MainActionButton`)
-
-- Sentence case, 1–3 words, imperative verb first
-- No punctuation
-- `loadingText` uses ellipsis: `"Turning on..."` — never `"Please wait..."`
-
-```
-✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
-❌ "Turn On Notifications"  ❌ "Submit."  ❌ "Click to continue"
-```
-
-### Form labels (`Label`)
-
-- Sentence case
-- No colon, no period
-
-```
-✅ "Email address"
-❌ "Email Address"
-```
-
-### Placeholders (`TextField`, `TextFieldSearch`, `TextArea`, `Input`, `FormTextField`)
-
-- Sentence case
-- Imperative verb starters: "Enter", "Search"
-- Ellipsis only for genuinely open-ended input; prefer specificity
-
-```
-✅ "Search tokens, sites, URLs"
-✅ "Enter amount"
-❌ "Enter Amount..."
-```
-
-### Help text / error text (`HelpText`)
-
-- Sentence case
-- Full sentences end with a period; short phrases do not
-- Errors: say what happened, then what to do. No "Error:" prefix.
-
-```
-✅ "Incorrect password. Try again."
-❌ "Error: You entered an invalid password."
-```
-
-### Banners (`BannerAlert`, `BannerBase`)
-
-- `title`: sentence case, no period
-- `description`: sentence case, period if complete sentence
-- `actionButtonLabel`: sentence case, no period
-
-### Toast
-
-- Sentence case throughout
-- Label segments combine into one sentence ending with a period: `"Added"` + bold `"Mainnet"` + `" network."`
-- `description`: full sentence, period
-- `actionButtonLabel`: sentence case, no period, no exclamation point, never "Click here"
-
-### Modals (`Modal`, `ModalHeader`, `ModalBody`, `ModalFooter`) — React web
-
-- Header title: sentence case, no period
-- Body: sentence case, period if complete sentence
-- Footer button labels: sentence case, no period
-
-### Bottom sheets (`BottomSheet`, `BottomSheetHeader`, `BottomSheetFooter`) — React Native
-
-- `title` / header children: sentence case, no period
-- Footer button labels: sentence case, no period
-
-### Screen headers (`HeaderBase`, `HeaderStandard`, `HeaderStandardAnimated`, `HeaderRoot`, `HeaderSearch`, `HeaderSubpage`)
-
-- Sentence case — this includes multi-word screen titles
-- No period
-
-```
-✅ "Account settings"
-❌ "Account Settings"
-```
-
-### Section headers (`SectionHeader`)
-
-- Sentence case
-- No period
-
-```
-✅ "Your positions"  ✅ "Tokens"
-❌ "Your Positions"
-```
-
-### Tags (`Tag`)
-
-- Sentence case at source — do not pre-uppercase the string if the component applies `textTransform`
-- No period
-
-### List items (`ActionListItem`, `ListItem`)
-
-- `label`: sentence case, no period
-- `description`: sentence case, no period
-
-### Key-value rows (`KeyValueRow`, `KeyValueSelect`, `KeyValueColumn`)
-
-- Field labels: sentence case, no period
-- Tooltip title: sentence case, no period
-- Tooltip content: full sentence, period
-
-### Checkboxes / radio buttons (`Checkbox`, `RadioButton`)
-
-- `label`: sentence case, no period
-
-### Empty states (`TabEmptyState`)
-
-- `description`: sentence case, `"No X found"` pattern, no period
-- `actionButtonText`: sentence case, verb phrase, no period
-
-```
-✅ description: "No perpetual positions found"
-✅ actionButtonText: "Start trading"
-❌ actionButtonText: "Start Trading"
-```
-
-### Titles (`TitleStandard`, `TitleSubpage`, `TitleHub`, `TitleAlert`)
-
-- Sentence case, no period
-
----
-
 ## Voice and tone
 
 ### Active voice
@@ -336,3 +209,4 @@ When adding or editing user-facing strings:
 - [ ] No "please", "click here", "successfully", "gas fee", or "dapp" in product copy
 - [ ] Tests that assert those strings were updated to match
 - [ ] Default alt text and accessibility strings follow the same rules
+- [ ] Component-specific prop rules checked against the component README via Storybook MCP

--- a/packages/design-system-react-native/src/components/ActionListItem/README.md
+++ b/packages/design-system-react-native/src/components/ActionListItem/README.md
@@ -236,3 +236,8 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `label`: sentence case, no period
+- `description`: sentence case, no period

--- a/packages/design-system-react-native/src/components/BannerAlert/README.md
+++ b/packages/design-system-react-native/src/components/BannerAlert/README.md
@@ -153,3 +153,9 @@ export const ConditionalBanner = ({ active }: { active: boolean }) => {
   );
 };
 ```
+
+## Content guidelines
+
+- `title`: sentence case, no period
+- `description`: sentence case, period if a complete sentence
+- `actionButtonProps.label`: sentence case, no period

--- a/packages/design-system-react-native/src/components/BannerBase/README.md
+++ b/packages/design-system-react-native/src/components/BannerBase/README.md
@@ -189,3 +189,9 @@ For detailed migration instructions from the Mobile component-library, see the [
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `title`: sentence case, no period
+- `description`: sentence case, period if a complete sentence
+- `actionButtonProps.label`: sentence case, no period

--- a/packages/design-system-react-native/src/components/BottomSheetHeader/README.md
+++ b/packages/design-system-react-native/src/components/BottomSheetHeader/README.md
@@ -158,3 +158,8 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `title`: sentence case, no period
+- Footer button labels: sentence case, no period

--- a/packages/design-system-react-native/src/components/BottomSheetHeader/README.md
+++ b/packages/design-system-react-native/src/components/BottomSheetHeader/README.md
@@ -161,5 +161,4 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 
 ## Content guidelines
 
-- `title`: sentence case, no period
-- Footer button labels: sentence case, no period
+- `children` (header title): sentence case, no period

--- a/packages/design-system-react-native/src/components/Button/README.md
+++ b/packages/design-system-react-native/src/components/Button/README.md
@@ -275,3 +275,14 @@ Migrating from `app/component-library/components/Buttons/Button` in MetaMask Mob
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/README.md
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonPrimary/README.md
@@ -126,3 +126,14 @@ export default App;
 - `ButtonPrimary` supports TailwindCSS classes via the `twClassName` prop for custom styling.
 - The button automatically adjusts its styles based on the `isDanger` and `isInverse` props.
 - Use the `isLoading` state to display a spinner and loading text, enhancing user feedback for asynchronous actions.
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/README.md
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonSecondary/README.md
@@ -126,3 +126,14 @@ export default App;
 - `ButtonSecondary` supports TailwindCSS classes via the `twClassName` prop for custom styling.
 - The button automatically adjusts its styles based on the `isDanger` and `isInverse` props.
 - Use the `isLoading` state to display a spinner and loading text, enhancing user feedback for asynchronous actions.
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/README.md
+++ b/packages/design-system-react-native/src/components/Button/variants/ButtonTertiary/README.md
@@ -126,3 +126,14 @@ export default App;
 - `ButtonTertiary` supports TailwindCSS classes via the `twClassName` prop for custom styling.
 - The button automatically adjusts its styles based on the `isDanger` and `isInverse` props.
 - Use the `isLoading` state to display a spinner and loading text, enhancing user feedback for asynchronous actions.
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react-native/src/components/ButtonBase/README.md
+++ b/packages/design-system-react-native/src/components/ButtonBase/README.md
@@ -145,3 +145,14 @@ Migrating from the legacy `ButtonBase` in `app/component-library/components/Butt
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react-native/src/components/ButtonHero/README.md
+++ b/packages/design-system-react-native/src/components/ButtonHero/README.md
@@ -196,3 +196,14 @@ Migrating from the legacy `ButtonHero` in `app/component-library/components-temp
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react-native/src/components/Checkbox/README.md
+++ b/packages/design-system-react-native/src/components/Checkbox/README.md
@@ -246,3 +246,7 @@ Migrating from `app/component-library/components/Checkbox` in MetaMask Mobile? S
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `label`: sentence case, no period

--- a/packages/design-system-react-native/src/components/HeaderBase/README.md
+++ b/packages/design-system-react-native/src/components/HeaderBase/README.md
@@ -171,3 +171,13 @@ Migrating from the legacy `HeaderBase` in `app/component-library/components/Head
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case — applies to all multi-word screen titles
+- No period
+
+```
+✅ "Account settings"
+❌ "Account Settings"
+```

--- a/packages/design-system-react-native/src/components/HeaderRoot/README.md
+++ b/packages/design-system-react-native/src/components/HeaderRoot/README.md
@@ -188,3 +188,13 @@ import { HeaderRoot } from '@metamask/design-system-react-native';
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case — applies to all multi-word screen titles
+- No period
+
+```
+✅ "Account settings"
+❌ "Account Settings"
+```

--- a/packages/design-system-react-native/src/components/HeaderStandard/README.md
+++ b/packages/design-system-react-native/src/components/HeaderStandard/README.md
@@ -185,3 +185,13 @@ Tailwind classes merged onto the root [HeaderBase](../HeaderBase/README.md) cont
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case — applies to all multi-word screen titles
+- No period
+
+```
+✅ "Account settings"
+❌ "Account Settings"
+```

--- a/packages/design-system-react-native/src/components/HelpText/README.md
+++ b/packages/design-system-react-native/src/components/HelpText/README.md
@@ -127,3 +127,14 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case
+- Full sentences end with a period; short phrases do not
+- Errors: say what happened, then what to do — no "Error:" prefix
+
+```
+✅ "Incorrect password. Try again."
+❌ "Error: You entered an invalid password."
+```

--- a/packages/design-system-react-native/src/components/KeyValueRow/README.md
+++ b/packages/design-system-react-native/src/components/KeyValueRow/README.md
@@ -297,6 +297,5 @@ Migrating from the legacy `KeyValueRow` in `app/component-library/components-tem
 
 ## Content guidelines
 
-- `field.label.text`: sentence case, no period
-- Tooltip `title`: sentence case, no period
-- Tooltip `content`: full sentence ending with a period
+- `keyLabel` string: sentence case, no period
+- `value` string: sentence case, no period

--- a/packages/design-system-react-native/src/components/KeyValueRow/README.md
+++ b/packages/design-system-react-native/src/components/KeyValueRow/README.md
@@ -294,3 +294,9 @@ Migrating from the legacy `KeyValueRow` in `app/component-library/components-tem
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `field.label.text`: sentence case, no period
+- Tooltip `title`: sentence case, no period
+- Tooltip `content`: full sentence ending with a period

--- a/packages/design-system-react-native/src/components/Label/README.md
+++ b/packages/design-system-react-native/src/components/Label/README.md
@@ -88,3 +88,8 @@ For detailed migration instructions from the Mobile component-library, see the [
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case
+- No colon, no period

--- a/packages/design-system-react-native/src/components/RadioButton/README.md
+++ b/packages/design-system-react-native/src/components/RadioButton/README.md
@@ -197,3 +197,7 @@ const tw = useTailwind();
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `label`: sentence case, no period

--- a/packages/design-system-react-native/src/components/SectionHeader/README.md
+++ b/packages/design-system-react-native/src/components/SectionHeader/README.md
@@ -297,3 +297,12 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, no period
+
+```
+✅ "Your positions"
+❌ "Your Positions"
+```

--- a/packages/design-system-react-native/src/components/TabEmptyState/README.md
+++ b/packages/design-system-react-native/src/components/TabEmptyState/README.md
@@ -170,3 +170,14 @@ Migrating from the legacy `TabEmptyState` in `app/component-library/components-t
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `description`: sentence case, "No X found" pattern, no period
+- `actionButtonText`: sentence case, verb phrase, no period
+
+```
+✅ description: "No perpetual positions found"
+✅ actionButtonText: "Start trading"
+❌ actionButtonText: "Start Trading"
+```

--- a/packages/design-system-react-native/src/components/Tag/README.md
+++ b/packages/design-system-react-native/src/components/Tag/README.md
@@ -166,3 +166,8 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case at source — `TagColored` applies `textTransform: uppercase` via CSS, so the source string does not need to be uppercase
+- No period

--- a/packages/design-system-react-native/src/components/Tag/README.md
+++ b/packages/design-system-react-native/src/components/Tag/README.md
@@ -169,5 +169,4 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 
 ## Content guidelines
 
-- Sentence case at source — `TagColored` applies `textTransform: uppercase` via CSS, so the source string does not need to be uppercase
-- No period
+- `children` string: sentence case, no period

--- a/packages/design-system-react-native/src/components/TextField/README.md
+++ b/packages/design-system-react-native/src/components/TextField/README.md
@@ -311,3 +311,15 @@ export const ConditionalExample = ({ isActive }: { isActive: boolean }) => {
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case
+- Imperative verb starters: "Enter", "Search"
+- Ellipsis only for genuinely open-ended input; prefer specificity
+
+```
+✅ "Search tokens, sites, URLs"
+✅ "Enter amount"
+❌ "Enter Amount..."
+```

--- a/packages/design-system-react-native/src/components/TextFieldSearch/README.md
+++ b/packages/design-system-react-native/src/components/TextFieldSearch/README.md
@@ -57,11 +57,10 @@ const [searchText, setSearchText] = useState('');
 ## Content guidelines
 
 - Sentence case
-- Imperative verb starters: "Enter", "Search"
+- Imperative verb starters: "Search"
 - Ellipsis only for genuinely open-ended input; prefer specificity
 
 ```
-✅ "Search tokens, sites, URLs"
-✅ "Enter amount"
-❌ "Enter Amount..."
+✅ "Search tokens, sites, and URLs"
+❌ "Search Tokens, Sites, And URLs..."
 ```

--- a/packages/design-system-react-native/src/components/TextFieldSearch/README.md
+++ b/packages/design-system-react-native/src/components/TextFieldSearch/README.md
@@ -53,3 +53,15 @@ const [searchText, setSearchText] = useState('');
   placeholder="Search..."
 />;
 ```
+
+## Content guidelines
+
+- Sentence case
+- Imperative verb starters: "Enter", "Search"
+- Ellipsis only for genuinely open-ended input; prefer specificity
+
+```
+✅ "Search tokens, sites, URLs"
+✅ "Enter amount"
+❌ "Enter Amount..."
+```

--- a/packages/design-system-react-native/src/components/Toast/README.md
+++ b/packages/design-system-react-native/src/components/Toast/README.md
@@ -145,3 +145,9 @@ toast({
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case throughout
+- `description`: full sentence ending with a period
+- Action button label: sentence case, no period, no exclamation point

--- a/packages/design-system-react/src/components/BannerAlert/README.mdx
+++ b/packages/design-system-react/src/components/BannerAlert/README.mdx
@@ -412,3 +412,9 @@ Use the `style` prop when you need inline styles that can't be achieved with `cl
 ## Component API
 
 <Controls of={BannerAlertStories.Default} />
+
+## Content guidelines
+
+- `title`: sentence case, no period
+- `description`: sentence case, period if a complete sentence
+- `actionButtonProps.label`: sentence case, no period

--- a/packages/design-system-react/src/components/BannerBase/README.mdx
+++ b/packages/design-system-react/src/components/BannerBase/README.mdx
@@ -415,3 +415,9 @@ For detailed migration instructions from the Extension component-library, see th
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `title`: sentence case, no period
+- `description`: sentence case, period if a complete sentence
+- `actionButtonProps.label`: sentence case, no period

--- a/packages/design-system-react/src/components/Button/README.mdx
+++ b/packages/design-system-react/src/components/Button/README.mdx
@@ -385,3 +385,14 @@ Migrating from `ui/components/component-library/button` in MetaMask Extension? S
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react/src/components/Button/variants/ButtonPrimary/README.mdx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonPrimary/README.mdx
@@ -299,3 +299,14 @@ The `style` prop should primarily be used for dynamic inline styles that cannot 
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react/src/components/Button/variants/ButtonSecondary/README.mdx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonSecondary/README.mdx
@@ -299,3 +299,14 @@ The `style` prop should primarily be used for dynamic inline styles that cannot 
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react/src/components/Button/variants/ButtonTertiary/README.mdx
+++ b/packages/design-system-react/src/components/Button/variants/ButtonTertiary/README.mdx
@@ -299,3 +299,14 @@ The `style` prop should primarily be used for dynamic inline styles that cannot 
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react/src/components/ButtonBase/README.mdx
+++ b/packages/design-system-react/src/components/ButtonBase/README.mdx
@@ -459,3 +459,14 @@ Migrating from `ui/components/component-library/button-base` in MetaMask Extensi
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react/src/components/ButtonHero/README.mdx
+++ b/packages/design-system-react/src/components/ButtonHero/README.mdx
@@ -251,3 +251,14 @@ The `style` prop should primarily be used for dynamic inline styles that cannot 
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case, 1–3 words, imperative verb first
+- No punctuation
+- `loadingText` prop uses an ellipsis: `"Turning on..."`
+
+```
+✅ "Turn on"  ✅ "Save"  ✅ "Turn on notifications"
+❌ "Turn On Notifications"  ❌ "Submit."
+```

--- a/packages/design-system-react/src/components/Checkbox/README.mdx
+++ b/packages/design-system-react/src/components/Checkbox/README.mdx
@@ -373,3 +373,7 @@ Migrating from `ui/components/component-library/checkbox` in MetaMask Extension?
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `label`: sentence case, no period

--- a/packages/design-system-react/src/components/HeaderBase/README.mdx
+++ b/packages/design-system-react/src/components/HeaderBase/README.mdx
@@ -167,3 +167,13 @@ Migrating from `ui/components/component-library/header-base` in MetaMask Extensi
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case — applies to all multi-word screen titles
+- No period
+
+```
+✅ "Account settings"
+❌ "Account Settings"
+```

--- a/packages/design-system-react/src/components/HelpText/README.mdx
+++ b/packages/design-system-react/src/components/HelpText/README.mdx
@@ -192,3 +192,14 @@ Use the `className` prop to add custom CSS classes to the component. Classes mer
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case
+- Full sentences end with a period; short phrases do not
+- Errors: say what happened, then what to do — no "Error:" prefix
+
+```
+✅ "Incorrect password. Try again."
+❌ "Error: You entered an invalid password."
+```

--- a/packages/design-system-react/src/components/Label/README.mdx
+++ b/packages/design-system-react/src/components/Label/README.mdx
@@ -118,3 +118,8 @@ Use the `className` prop to add custom CSS classes. Classes are merged with the 
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case
+- No colon, no period

--- a/packages/design-system-react/src/components/Modal/README.mdx
+++ b/packages/design-system-react/src/components/Modal/README.mdx
@@ -336,3 +336,9 @@ Migrating from `ui/components/component-library/modal` in MetaMask Extension? Se
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `title` / header text: sentence case, no period
+- Body / description: sentence case, period if a complete sentence
+- Button labels (`cancelLabel`, `confirmLabel`, `buttonText`): sentence case, no period

--- a/packages/design-system-react/src/components/Modal/README.mdx
+++ b/packages/design-system-react/src/components/Modal/README.mdx
@@ -339,6 +339,6 @@ Migrating from `ui/components/component-library/modal` in MetaMask Extension? Se
 
 ## Content guidelines
 
-- `title` / header text: sentence case, no period
-- Body / description: sentence case, period if a complete sentence
-- Button labels (`cancelLabel`, `confirmLabel`, `buttonText`): sentence case, no period
+- `ModalHeader` `children` (header title): sentence case, no period
+- `ModalBody` `children` (body content): sentence case, period if a complete sentence
+- `ModalFooter` button labels (`primaryButtonProps.children`, `secondaryButtonProps.children`): sentence case, no period

--- a/packages/design-system-react/src/components/ModalBody/README.mdx
+++ b/packages/design-system-react/src/components/ModalBody/README.mdx
@@ -129,6 +129,4 @@ Migrating from `ui/components/component-library/modal-body` in MetaMask Extensio
 
 ## Content guidelines
 
-- `title` / header text: sentence case, no period
-- Body / description: sentence case, period if a complete sentence
-- Button labels (`cancelLabel`, `confirmLabel`, `buttonText`): sentence case, no period
+- `children` (body content): sentence case, period if a complete sentence

--- a/packages/design-system-react/src/components/ModalBody/README.mdx
+++ b/packages/design-system-react/src/components/ModalBody/README.mdx
@@ -126,3 +126,9 @@ Migrating from `ui/components/component-library/modal-body` in MetaMask Extensio
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `title` / header text: sentence case, no period
+- Body / description: sentence case, period if a complete sentence
+- Button labels (`cancelLabel`, `confirmLabel`, `buttonText`): sentence case, no period

--- a/packages/design-system-react/src/components/ModalFooter/README.mdx
+++ b/packages/design-system-react/src/components/ModalFooter/README.mdx
@@ -175,6 +175,4 @@ Migrating from `ui/components/component-library/modal-footer` in MetaMask Extens
 
 ## Content guidelines
 
-- `title` / header text: sentence case, no period
-- Body / description: sentence case, period if a complete sentence
-- Button labels (`cancelLabel`, `confirmLabel`, `buttonText`): sentence case, no period
+- Button labels (`primaryButtonProps.children`, `secondaryButtonProps.children`): sentence case, no period

--- a/packages/design-system-react/src/components/ModalFooter/README.mdx
+++ b/packages/design-system-react/src/components/ModalFooter/README.mdx
@@ -172,3 +172,9 @@ Migrating from `ui/components/component-library/modal-footer` in MetaMask Extens
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `title` / header text: sentence case, no period
+- Body / description: sentence case, period if a complete sentence
+- Button labels (`cancelLabel`, `confirmLabel`, `buttonText`): sentence case, no period

--- a/packages/design-system-react/src/components/ModalHeader/README.mdx
+++ b/packages/design-system-react/src/components/ModalHeader/README.mdx
@@ -201,6 +201,4 @@ Migrating from `ui/components/component-library/modal-header` in MetaMask Extens
 
 ## Content guidelines
 
-- `title` / header text: sentence case, no period
-- Body / description: sentence case, period if a complete sentence
-- Button labels (`cancelLabel`, `confirmLabel`, `buttonText`): sentence case, no period
+- `children` (header title): sentence case, no period

--- a/packages/design-system-react/src/components/ModalHeader/README.mdx
+++ b/packages/design-system-react/src/components/ModalHeader/README.mdx
@@ -198,3 +198,9 @@ Migrating from `ui/components/component-library/modal-header` in MetaMask Extens
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- `title` / header text: sentence case, no period
+- Body / description: sentence case, period if a complete sentence
+- Button labels (`cancelLabel`, `confirmLabel`, `buttonText`): sentence case, no period

--- a/packages/design-system-react/src/components/Tag/README.mdx
+++ b/packages/design-system-react/src/components/Tag/README.mdx
@@ -284,5 +284,4 @@ Standard HTML attributes (`data-testid`, `aria-*`, etc.) are forwarded to the ro
 
 ## Content guidelines
 
-- Sentence case at source — `TagColored` applies `textTransform: uppercase` via CSS, so the source string does not need to be uppercase
-- No period
+- `children` string: sentence case, no period

--- a/packages/design-system-react/src/components/Tag/README.mdx
+++ b/packages/design-system-react/src/components/Tag/README.mdx
@@ -281,3 +281,8 @@ Standard HTML attributes (`data-testid`, `aria-*`, etc.) are forwarded to the ro
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case at source — `TagColored` applies `textTransform: uppercase` via CSS, so the source string does not need to be uppercase
+- No period

--- a/packages/design-system-react/src/components/TextField/README.mdx
+++ b/packages/design-system-react/src/components/TextField/README.mdx
@@ -80,3 +80,15 @@ Replaces the default `Input` with a custom element when you need a different inn
 ## Controls
 
 <Controls of={TextFieldStories.Default} />
+
+## Content guidelines
+
+- Sentence case
+- Imperative verb starters: "Enter", "Search"
+- Ellipsis only for genuinely open-ended input; prefer specificity
+
+```
+✅ "Search tokens, sites, URLs"
+✅ "Enter amount"
+❌ "Enter Amount..."
+```

--- a/packages/design-system-react/src/components/TextFieldSearch/README.mdx
+++ b/packages/design-system-react/src/components/TextFieldSearch/README.mdx
@@ -59,11 +59,10 @@ All other `TextField` props (`isReadOnly`, `placeholder`, `inputProps`, `inputRe
 ## Content guidelines
 
 - Sentence case
-- Imperative verb starters: "Enter", "Search"
+- Imperative verb starters: "Search"
 - Ellipsis only for genuinely open-ended input; prefer specificity
 
 ```
-✅ "Search tokens, sites, URLs"
-✅ "Enter amount"
-❌ "Enter Amount..."
+✅ "Search tokens, sites, and URLs"
+❌ "Search Tokens, Sites, And URLs..."
 ```

--- a/packages/design-system-react/src/components/TextFieldSearch/README.mdx
+++ b/packages/design-system-react/src/components/TextFieldSearch/README.mdx
@@ -55,3 +55,15 @@ All other `TextField` props (`isReadOnly`, `placeholder`, `inputProps`, `inputRe
 ## Controls
 
 <Controls of={TextFieldSearchStories.Default} />
+
+## Content guidelines
+
+- Sentence case
+- Imperative verb starters: "Enter", "Search"
+- Ellipsis only for genuinely open-ended input; prefer specificity
+
+```
+✅ "Search tokens, sites, URLs"
+✅ "Enter amount"
+❌ "Enter Amount..."
+```

--- a/packages/design-system-react/src/components/Toast/README.mdx
+++ b/packages/design-system-react/src/components/Toast/README.mdx
@@ -212,3 +212,9 @@ toast({
 ## References
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
+
+## Content guidelines
+
+- Sentence case throughout
+- `description`: full sentence ending with a period
+- Action button label: sentence case, no period, no exclamation point


### PR DESCRIPTION
## Description

Moves per-component content copy rules out of the shared Cursor rule and into each component's README, where Storybook MCP can expose them to agents at query time — so guidance stays current as components evolve rather than going stale in a centralised file.

**Changes:**
- Removes the `## Per-component rules` section from `.cursor/rules/content-guidelines.mdc` and adds a pointer to the component READMEs
- Adds a `## Content guidelines` section to 44 component READMEs across `design-system-react` and `design-system-react-native` (Button variants, Label, TextField, HelpText, Banners, Toast, Headers, Tag, Checkbox, RadioButton, TabEmptyState, Modal components, and more)

## Related

- [MetaMask/skills#137](https://github.com/MetaMask/skills/pull/137) — content-guidelines skill (per-component section removed there too, replaced by a pointer to MMDS READMEs)
- [#1461](https://github.com/MetaMask/metamask-design-system/pull/1461) — story/test copy fixes; should merge before or alongside this PR
- [Agentic design system strategy](https://github.com/MetaMask/metamask-design-system/blob/main/docs/agentic-design-system-strategy.md)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring

## Reviewer checklist

- [ ] `## Content guidelines` section appears correctly in Storybook documentation for at least one updated component (verify via Storybook MCP)
- [ ] Cursor rule no longer contains a `## Per-component rules` section
- [ ] README guidance is consistent with the copy in the component stories

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Cursor-rule updates only; no runtime or API behavior changes.
> 
> **Overview**
> **Decentralizes copy guidance** so prop-level rules live next to each component instead of in one Cursor rule that could drift out of date.
> 
> The shared `.cursor/rules/content-guidelines.mdc` file **drops the long `## Per-component rules` block** and instead tells agents to read each component’s `README.md` / `README.mdx` via **Storybook MCP**. Global rules (capitalization, punctuation, voice, terminology) and the verification checklist stay; the checklist gains an item to **check component READMEs** for prop-specific rules.
> 
> **Adds a `## Content guidelines` section** to dozens of component docs across `design-system-react` (MDX) and `design-system-react-native` (README), covering the same patterns that used to live centrally—e.g. button labels and `loadingText`, banner `title`/`description`, headers, fields, modals, toast, empty states, and similar. Wording is largely a **relocate**, not a policy change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f23883f81c201d32afb0868aa4855f01fbcf8252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->