### PR TITLE
fix(react-native): stop BadgeWrapper infinite layout loop

### DIFF
--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -649,6 +649,195 @@ describe('BadgeWrapper', () => {
     expect(badgeContainer.props.style[1]).toStrictEqual(expectedBadgeStyle[1]);
   });
 
+  it('ignores a subsequent onLayout call whose raw size rounds to the same integer as before', () => {
+    // Regression test for an infinite measure -> reposition -> re-measure
+    // loop: `finalPositions` derives the badge container's own position from
+    // `badgeWidth`/`badgeHeight`, and that position is applied to the same
+    // `View` that `onLayout` measures. Repositioning by a sub-pixel amount
+    // can change how the native layout engine rounds the next measured
+    // size, so unrounded raw values could previously flip-flop forever
+    // between two adjacent sub-pixel values (e.g. 12.19/11.81 swapping with
+    // 11.81/12.19), triggering `setState` (and a real reposition) on every
+    // single layout pass and pegging the JS thread. These two raw sizes are
+    // real values captured from that infinite loop; both round to (12, 12),
+    // so the second call must be a no-op and the position must still
+    // reflect the rounded size from the first layout.
+    const TestComponent = () => (
+      <BadgeWrapper
+        testID="wrapper"
+        position={BadgeWrapperPosition.TopRight}
+        badge={<Text testID="badgeElement">Badge</Text>}
+      >
+        <Text testID="anchorChild">Anchor</Text>
+      </BadgeWrapper>
+    );
+
+    const { getByTestId } = render(<TestComponent />);
+    let wrapper = getByTestId('wrapper');
+    const anchorContainer = wrapper.props.children[0];
+    const badgeContainer = wrapper.props.children[1];
+
+    act(() => {
+      anchorContainer.props.onLayout({
+        nativeEvent: { layout: { width: 100, height: 50 } },
+      });
+      badgeContainer.props.onLayout({
+        nativeEvent: {
+          layout: { width: 12.19, height: 11.81 },
+        },
+      });
+    });
+
+    act(() => {
+      badgeContainer.props.onLayout({
+        nativeEvent: {
+          layout: { width: 11.81, height: 12.19 },
+        },
+      });
+    });
+
+    wrapper = getByTestId('wrapper');
+    const updatedBadgeContainer = wrapper.props.children[1];
+    const positions = updatedBadgeContainer.props.style[1];
+    expect(positions).toStrictEqual({
+      top: 50 * 0.1464 - 12 / 2,
+      right: 100 * 0.1464 - 12 / 2,
+    });
+  });
+
+  it('ignores a subsequent anchor onLayout call whose raw size rounds to the same integer as before', () => {
+    // Same regression as the badge-side test above, but for the anchor
+    // measurement path.
+    const TestComponent = () => (
+      <BadgeWrapper
+        testID="wrapper"
+        position={BadgeWrapperPosition.TopRight}
+        badge={<Text testID="badgeElement">Badge</Text>}
+      >
+        <Text testID="anchorChild">Anchor</Text>
+      </BadgeWrapper>
+    );
+
+    const { getByTestId } = render(<TestComponent />);
+    let wrapper = getByTestId('wrapper');
+    const anchorContainer = wrapper.props.children[0];
+    const badgeContainer = wrapper.props.children[1];
+
+    act(() => {
+      anchorContainer.props.onLayout({
+        nativeEvent: { layout: { width: 100.4, height: 49.6 } },
+      });
+      badgeContainer.props.onLayout({
+        nativeEvent: { layout: { width: 20, height: 20 } },
+      });
+    });
+
+    act(() => {
+      anchorContainer.props.onLayout({
+        nativeEvent: { layout: { width: 99.6, height: 50.4 } },
+      });
+    });
+
+    wrapper = getByTestId('wrapper');
+    const updatedBadgeContainer = wrapper.props.children[1];
+    const positions = updatedBadgeContainer.props.style[1];
+    // Both raw anchor sizes round to (100, 50), so the second call must be a
+    // no-op and the position must still reflect the rounded size from the
+    // first layout.
+    expect(positions).toStrictEqual({
+      top: 50 * 0.1464 - 20 / 2,
+      right: 100 * 0.1464 - 20 / 2,
+    });
+  });
+
+  it('ignores sub-pixel noise even when it straddles a rounding boundary (e.g. 12.3 / 12.7)', () => {
+    // Rounding alone isn't a sufficient guard: two raw values close enough
+    // together to be noise can still round to different integers if they
+    // straddle an `n.5` boundary (12.3 rounds to 12, 12.7 rounds to 13).
+    // The fix has to compare against the last accepted raw measurement, not
+    // just the previous rounded value, or this case would still loop.
+    const TestComponent = () => (
+      <BadgeWrapper
+        testID="wrapper"
+        position={BadgeWrapperPosition.TopRight}
+        badge={<Text testID="badgeElement">Badge</Text>}
+      >
+        <Text testID="anchorChild">Anchor</Text>
+      </BadgeWrapper>
+    );
+
+    const { getByTestId } = render(<TestComponent />);
+    let wrapper = getByTestId('wrapper');
+    const anchorContainer = wrapper.props.children[0];
+    const badgeContainer = wrapper.props.children[1];
+
+    act(() => {
+      anchorContainer.props.onLayout({
+        nativeEvent: { layout: { width: 100, height: 50 } },
+      });
+      badgeContainer.props.onLayout({
+        nativeEvent: {
+          layout: { width: 12.3, height: 12.3 },
+        },
+      });
+    });
+
+    act(() => {
+      badgeContainer.props.onLayout({
+        nativeEvent: {
+          layout: { width: 12.7, height: 12.7 },
+        },
+      });
+    });
+
+    wrapper = getByTestId('wrapper');
+    const updatedBadgeContainer = wrapper.props.children[1];
+    const positions = updatedBadgeContainer.props.style[1];
+    expect(positions).toStrictEqual({
+      top: 50 * 0.1464 - 12 / 2,
+      right: 100 * 0.1464 - 12 / 2,
+    });
+  });
+
+  it('accepts a sub-1px first measurement instead of treating it as noise', () => {
+    // The hysteresis guard compares each measurement to the last *accepted*
+    // one. Before there is one, a badge whose very first real size is under
+    // 1px should still be accepted, not stuck at the initial 0.
+    const TestComponent = () => (
+      <BadgeWrapper
+        testID="wrapper"
+        position={BadgeWrapperPosition.TopRight}
+        badge={<Text testID="badgeElement">Badge</Text>}
+      >
+        <Text testID="anchorChild">Anchor</Text>
+      </BadgeWrapper>
+    );
+
+    const { getByTestId } = render(<TestComponent />);
+    let wrapper = getByTestId('wrapper');
+    const anchorContainer = wrapper.props.children[0];
+    const badgeContainer = wrapper.props.children[1];
+
+    act(() => {
+      anchorContainer.props.onLayout({
+        nativeEvent: { layout: { width: 100, height: 50 } },
+      });
+      badgeContainer.props.onLayout({
+        nativeEvent: {
+          layout: { width: 0.6, height: 0.6 },
+        },
+      });
+    });
+
+    wrapper = getByTestId('wrapper');
+    const updatedBadgeContainer = wrapper.props.children[1];
+    const positions = updatedBadgeContainer.props.style[1];
+    expect(positions).toStrictEqual({
+      top: 50 * 0.1464 - 1 / 2,
+      right: 100 * 0.1464 - 1 / 2,
+    });
+  });
+
   it('applies additional container style and forwards extra props', () => {
     // Since BadgeWrapper renders:
     // <View style={[tw`relative self-start`, style]} {...props}>

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -2,8 +2,7 @@ import {
   BadgeWrapperPositionAnchorShape,
   BadgeWrapperPosition,
 } from '@metamask/design-system-shared';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { render, act } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import React from 'react';
 import { StyleSheet } from 'react-native';
 
@@ -11,831 +10,163 @@ import { Text } from '../Text';
 
 import { BadgeWrapper } from './BadgeWrapper';
 
-// Helper function to round numeric properties to two decimals.
-const roundPositions = (pos: {
-  [key: string]: number;
-}): { [key: string]: number } => {
-  const result: { [key: string]: number } = {};
-  Object.keys(pos).forEach((key) => {
-    result[key] = Number(pos[key].toFixed(2));
-  });
-  return result;
+// Re-derived independently (not imported) so this test catches the
+// component's formula drifting from the intended geometry.
+const CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT = `${
+  ((2 - Math.sqrt(2)) / 4) * 100
+}%`;
+
+const renderBadgeWrapper = (
+  props: Partial<React.ComponentProps<typeof BadgeWrapper>> = {},
+) => {
+  const { getByTestId } = render(
+    <BadgeWrapper
+      testID="wrapper"
+      badge={<Text testID="badgeElement">Badge</Text>}
+      {...props}
+    >
+      <Text testID="anchorChild">Anchor</Text>
+    </BadgeWrapper>,
+  );
+  const wrapper = getByTestId('wrapper');
+  const [anchorContainer, badgeContainer] = wrapper.props.children;
+  return { wrapper, anchorContainer, badgeContainer };
 };
+
 describe('BadgeWrapper', () => {
-  it('computes the top right final positions correctly on circular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using props:
-      // position: TopRight, positionAnchorShape: Circular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 100 * 0.1464 = 14.64
-      //   anchorShapeYOffset = 50 * 0.1464 = 7.32
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 14.64 - 10 + 0 = 4.64
-      //   finalYOffset = 7.32 - 10 + 0 = -2.68
-      // For TopRight Circular, expected positions: { top: -2.68, right: 4.64 }.
-      const expectedPositions = { top: -2.68, right: 4.64 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.TopRight}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
+  it('does not measure either the anchor or the badge via onLayout', () => {
+    // Positioning comes purely from layout now, so there's nothing left to
+    // measure -- and nothing that can jump or loop from a measurement.
+    const { anchorContainer, badgeContainer } = renderBadgeWrapper();
+    expect(anchorContainer.props.onLayout).toBeUndefined();
+    expect(badgeContainer.props.onLayout).toBeUndefined();
   });
 
-  it('computes the top right final positions correctly on rectangular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using default props:
-      // position: TopRight, positionAnchorShape: Rectangular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 0
-      //   anchorShapeYOffset = 0
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 0 - 10 + 0 = -10
-      //   finalYOffset = 0 - 10 + 0 = -10
-      // For TopRight Rectangular, expected positions: { top: -10, right: -10 }.
-      const expectedPositions = { top: -10, right: -10 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.TopRight}
-            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
+  it.each([
+    {
+      position: BadgeWrapperPosition.TopRight,
+      expected: {
+        top: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+        right: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+        transform: [
+          { translateY: '-50%' },
+          { translateY: 0 },
+          { translateX: '50%' },
+          { translateX: 0 },
+        ],
+      },
+    },
+    {
+      position: BadgeWrapperPosition.TopLeft,
+      expected: {
+        top: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+        left: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+        transform: [
+          { translateY: '-50%' },
+          { translateY: 0 },
+          { translateX: '-50%' },
+          { translateX: 0 },
+        ],
+      },
+    },
+    {
+      position: BadgeWrapperPosition.BottomRight,
+      expected: {
+        bottom: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+        right: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+        transform: [
+          { translateY: '50%' },
+          { translateY: 0 },
+          { translateX: '50%' },
+          { translateX: 0 },
+        ],
+      },
+    },
+    {
+      position: BadgeWrapperPosition.BottomLeft,
+      expected: {
+        bottom: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+        left: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+        transform: [
+          { translateY: '50%' },
+          { translateY: 0 },
+          { translateX: '-50%' },
+          { translateX: 0 },
+        ],
+      },
+    },
+  ])(
+    'computes the $position position on a circular anchor (default shape)',
+    ({ position, expected }) => {
+      const { badgeContainer } = renderBadgeWrapper({ position });
+      expect(badgeContainer.props.style[1]).toStrictEqual(expected);
+    },
+  );
 
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
+  it.each([
+    {
+      position: BadgeWrapperPosition.TopRight,
+      expected: {
+        top: 0,
+        right: 0,
+        transform: [
+          { translateY: '-50%' },
+          { translateY: 0 },
+          { translateX: '50%' },
+          { translateX: 0 },
+        ],
+      },
+    },
+    {
+      position: BadgeWrapperPosition.BottomLeft,
+      expected: {
+        bottom: 0,
+        left: 0,
+        transform: [
+          { translateY: '50%' },
+          { translateY: 0 },
+          { translateX: '-50%' },
+          { translateX: 0 },
+        ],
+      },
+    },
+  ])(
+    'computes the $position position on a rectangular anchor (no corner offset)',
+    ({ position, expected }) => {
+      const { badgeContainer } = renderBadgeWrapper({
+        position,
+        positionAnchorShape: BadgeWrapperPositionAnchorShape.Rectangular,
       });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
+      expect(badgeContainer.props.style[1]).toStrictEqual(expected);
+    },
+  );
+
+  it('applies positionXOffset and positionYOffset as extra pixel translate steps', () => {
+    const { badgeContainer } = renderBadgeWrapper({
+      position: BadgeWrapperPosition.BottomRight,
+      positionXOffset: 3,
+      positionYOffset: -4,
     });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
+    expect(badgeContainer.props.style[1]).toStrictEqual({
+      bottom: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+      right: CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT,
+      transform: [
+        { translateY: '50%' },
+        { translateY: -4 },
+        { translateX: '50%' },
+        { translateX: 3 },
+      ],
+    });
   });
 
-  it('computes the bottom right final positions correctly on circular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using props:
-      // position: BottomRight, positionAnchorShape: Circular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 100 * 0.1464 = 14.64
-      //   anchorShapeYOffset = 50 * 0.1464 = 7.32
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 14.64 - 10 + 0 = 4.64
-      //   finalYOffset = 7.32 - 10 + 0 = -2.68
-      // For BottomRight Circular, expected positions: { bottom: -2.68, right: 4.64 }.
-      const expectedPositions = { bottom: -2.68, right: 4.64 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.BottomRight}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the bottom right final positions correctly on rectangular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using default props:
-      // position: BottomRight, positionAnchorShape: Rectangular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 0
-      //   anchorShapeYOffset = 0
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 0 - 10 + 0 = -10
-      //   finalYOffset = 0 - 10 + 0 = -10
-      // For BottomRight Rectangular, expected positions: { bottom: -10, right: -10 }.
-      const expectedPositions = { bottom: -10, right: -10 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.BottomRight}
-            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the bottom left final positions correctly on circular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using props:
-      // position: BottomLeft, positionAnchorShape: Circular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 100 * 0.1464 = 14.64
-      //   anchorShapeYOffset = 50 * 0.1464 = 7.32
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 14.64 - 10 + 0 = 4.64
-      //   finalYOffset = 7.32 - 10 + 0 = -2.68
-      // For BottomLeft Circular, expected positions: { bottom: -2.68, left: 4.64 }.
-      const expectedPositions = { bottom: -2.68, left: 4.64 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.BottomLeft}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the bottom left final positions correctly on rectangular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using default props:
-      // position: BottomLeft, positionAnchorShape: Rectangular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 0
-      //   anchorShapeYOffset = 0
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 0 - 10 + 0 = -10
-      //   finalYOffset = 0 - 10 + 0 = -10
-      // For BottomLeft Rectangular, expected positions: { bottom: -10, left: -10 }.
-      const expectedPositions = { bottom: -10, left: -10 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.BottomLeft}
-            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the top left final positions correctly on circular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using props:
-      // position: TopLeft, positionAnchorShape: Circular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 100 * 0.1464 = 14.64
-      //   anchorShapeYOffset = 50 * 0.1464 = 7.32
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 14.64 - 10 + 0 = 4.64
-      //   finalYOffset = 7.32 - 10 + 0 = -2.68
-      // For TopLeft Circular, expected positions: { top: -2.68, left: 4.64 }.
-      const expectedPositions = { top: -2.68, left: 4.64 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.TopLeft}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the top left final positions correctly on rectangular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using default props:
-      // position: TopLeft, positionAnchorShape: Rectangular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 0
-      //   anchorShapeYOffset = 0
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 0 - 10 + 0 = -10
-      //   finalYOffset = 0 - 10 + 0 = -10
-      // For TopLeft Rectangular, expected positions: { top: -10, left: -10 }.
-      const expectedPositions = { top: -10, left: -10 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.TopLeft}
-            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('uses customPosition if provided, ignoring layout events', () => {
+  it('uses customPosition if provided, bypassing the corner-offset calculation entirely', () => {
     const customPosition = { top: 5, left: 10 };
-    const TestComponent = () => {
-      const tw = useTailwind();
-      const computedExpectedBadgeStyle = [tw.style('absolute'), customPosition];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            customPosition={customPosition}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-    const expectedBadgeStyle = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const badgeContainer = children[1];
-    expect(badgeContainer.props.style[1]).toStrictEqual(expectedBadgeStyle[1]);
-  });
-
-  it('ignores a subsequent onLayout call whose raw size rounds to the same integer as before', () => {
-    // Regression test for an infinite measure -> reposition -> re-measure
-    // loop: `finalPositions` derives the badge container's own position from
-    // `badgeWidth`/`badgeHeight`, and that position is applied to the same
-    // `View` that `onLayout` measures. Repositioning by a sub-pixel amount
-    // can change how the native layout engine rounds the next measured
-    // size, so unrounded raw values could previously flip-flop forever
-    // between two adjacent sub-pixel values (e.g. 12.19/11.81 swapping with
-    // 11.81/12.19), triggering `setState` (and a real reposition) on every
-    // single layout pass and pegging the JS thread. These two raw sizes are
-    // real values captured from that infinite loop; both round to (12, 12),
-    // so the second call must be a no-op and the position must still
-    // reflect the rounded size from the first layout.
-    const TestComponent = () => (
-      <BadgeWrapper
-        testID="wrapper"
-        position={BadgeWrapperPosition.TopRight}
-        badge={<Text testID="badgeElement">Badge</Text>}
-      >
-        <Text testID="anchorChild">Anchor</Text>
-      </BadgeWrapper>
-    );
-
-    const { getByTestId } = render(<TestComponent />);
-    let wrapper = getByTestId('wrapper');
-    const anchorContainer = wrapper.props.children[0];
-    const badgeContainer = wrapper.props.children[1];
-
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: {
-          layout: { width: 12.19, height: 11.81 },
-        },
-      });
+    const { badgeContainer } = renderBadgeWrapper({
+      position: BadgeWrapperPosition.BottomRight,
+      positionXOffset: 100,
+      customPosition,
     });
-
-    act(() => {
-      badgeContainer.props.onLayout({
-        nativeEvent: {
-          layout: { width: 11.81, height: 12.19 },
-        },
-      });
-    });
-
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-    const positions = updatedBadgeContainer.props.style[1];
-    expect(positions).toStrictEqual({
-      top: 50 * 0.1464 - 12 / 2,
-      right: 100 * 0.1464 - 12 / 2,
-    });
-  });
-
-  it('ignores a subsequent anchor onLayout call whose raw size rounds to the same integer as before', () => {
-    // Same regression as the badge-side test above, but for the anchor
-    // measurement path.
-    const TestComponent = () => (
-      <BadgeWrapper
-        testID="wrapper"
-        position={BadgeWrapperPosition.TopRight}
-        badge={<Text testID="badgeElement">Badge</Text>}
-      >
-        <Text testID="anchorChild">Anchor</Text>
-      </BadgeWrapper>
-    );
-
-    const { getByTestId } = render(<TestComponent />);
-    let wrapper = getByTestId('wrapper');
-    const anchorContainer = wrapper.props.children[0];
-    const badgeContainer = wrapper.props.children[1];
-
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100.4, height: 49.6 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 99.6, height: 50.4 } },
-      });
-    });
-
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-    const positions = updatedBadgeContainer.props.style[1];
-    // Both raw anchor sizes round to (100, 50), so the second call must be a
-    // no-op and the position must still reflect the rounded size from the
-    // first layout.
-    expect(positions).toStrictEqual({
-      top: 50 * 0.1464 - 20 / 2,
-      right: 100 * 0.1464 - 20 / 2,
-    });
-  });
-
-  it('ignores sub-pixel noise even when it straddles a rounding boundary (e.g. 12.3 / 12.7)', () => {
-    // Rounding alone isn't a sufficient guard: two raw values close enough
-    // together to be noise can still round to different integers if they
-    // straddle an `n.5` boundary (12.3 rounds to 12, 12.7 rounds to 13).
-    // The fix has to compare against the last accepted raw measurement, not
-    // just the previous rounded value, or this case would still loop.
-    const TestComponent = () => (
-      <BadgeWrapper
-        testID="wrapper"
-        position={BadgeWrapperPosition.TopRight}
-        badge={<Text testID="badgeElement">Badge</Text>}
-      >
-        <Text testID="anchorChild">Anchor</Text>
-      </BadgeWrapper>
-    );
-
-    const { getByTestId } = render(<TestComponent />);
-    let wrapper = getByTestId('wrapper');
-    const anchorContainer = wrapper.props.children[0];
-    const badgeContainer = wrapper.props.children[1];
-
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: {
-          layout: { width: 12.3, height: 12.3 },
-        },
-      });
-    });
-
-    act(() => {
-      badgeContainer.props.onLayout({
-        nativeEvent: {
-          layout: { width: 12.7, height: 12.7 },
-        },
-      });
-    });
-
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-    const positions = updatedBadgeContainer.props.style[1];
-    expect(positions).toStrictEqual({
-      top: 50 * 0.1464 - 12 / 2,
-      right: 100 * 0.1464 - 12 / 2,
-    });
-  });
-
-  it('accepts a sub-1px first measurement instead of treating it as noise', () => {
-    // The hysteresis guard compares each measurement to the last *accepted*
-    // one. Before there is one, a badge whose very first real size is under
-    // 1px should still be accepted, not stuck at the initial 0.
-    const TestComponent = () => (
-      <BadgeWrapper
-        testID="wrapper"
-        position={BadgeWrapperPosition.TopRight}
-        badge={<Text testID="badgeElement">Badge</Text>}
-      >
-        <Text testID="anchorChild">Anchor</Text>
-      </BadgeWrapper>
-    );
-
-    const { getByTestId } = render(<TestComponent />);
-    let wrapper = getByTestId('wrapper');
-    const anchorContainer = wrapper.props.children[0];
-    const badgeContainer = wrapper.props.children[1];
-
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: {
-          layout: { width: 0.6, height: 0.6 },
-        },
-      });
-    });
-
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-    const positions = updatedBadgeContainer.props.style[1];
-    expect(positions).toStrictEqual({
-      top: 50 * 0.1464 - 1 / 2,
-      right: 100 * 0.1464 - 1 / 2,
-    });
+    expect(badgeContainer.props.style[1]).toStrictEqual(customPosition);
   });
 
   it('applies additional container style and forwards extra props', () => {

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -3,51 +3,75 @@ import {
   BadgeWrapperPositionAnchorShape,
 } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, { useCallback, useState, useMemo, useRef } from 'react';
-import type { LayoutChangeEvent } from 'react-native';
+import React, { useMemo } from 'react';
+import type { DimensionValue, StyleProp, ViewStyle } from 'react-native';
 import { View } from 'react-native';
 
 import type { BadgeWrapperProps } from './BadgeWrapper.types';
 
-// Below this, a measurement is treated as noise rather than a real resize.
-const STABLE_SIZE_THRESHOLD_PX = 1;
+// How far a circle inscribed in a square sits from the square's corner,
+// as a fraction of its side. Used to pull the badge in from the anchor's
+// bounding-box corner to where a circular anchor actually curves.
+const CIRCULAR_ANCHOR_CORNER_OFFSET_RATIO = (2 - Math.sqrt(2)) / 4;
+const CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT: DimensionValue = `${
+  CIRCULAR_ANCHOR_CORNER_OFFSET_RATIO * 100
+}%` as DimensionValue;
 
 /**
- * Tracks a measured element's rounded width/height via `onLayout`.
+ * Computes the badge's position style using percentage insets and a
+ * percentage-based transform, so the layout engine can resolve everything
+ * in one pass. No `onLayout` measuring, so no extra render pass and no
+ * jump once a measurement comes back.
  *
- * `BadgeWrapper` positions an element based on its own measured size, so
- * applying that position can shift the next measurement by a sub-pixel
- * amount, which can flip-flop forever without this guard. Rounding alone
- * isn't enough to prevent that: two raw values close enough together to be
- * noise can still round to different integers if they straddle a `.5`
- * boundary. Instead this only accepts a new size once it has moved a full
- * pixel away from the last accepted raw measurement (starting from
- * `-Infinity`, so the first real measurement is always accepted), which
- * absorbs sub-pixel noise regardless of where it falls, while still
- * reacting to genuine size changes.
- *
- * @returns A `[width, height, onLayout]` tuple.
+ * @param options - The options for computing the position style.
+ * @param options.position - Where the badge should sit relative to the anchor.
+ * @param options.positionAnchorShape - The shape of the anchor element.
+ * @param options.positionXOffset - Additional horizontal pixel offset.
+ * @param options.positionYOffset - Additional vertical pixel offset.
+ * @param options.customPosition - Bypasses this calculation entirely.
+ * @returns The style to apply to the badge's absolutely-positioned container.
  */
-const useStableMeasuredSize = () => {
-  const [width, setWidth] = useState<number>(0);
-  const [height, setHeight] = useState<number>(0);
-  const lastAcceptedRawRef = useRef({ width: -Infinity, height: -Infinity });
+const getBadgePositionStyle = ({
+  position,
+  positionAnchorShape,
+  positionXOffset,
+  positionYOffset,
+  customPosition,
+}: Pick<
+  BadgeWrapperProps,
+  | 'position'
+  | 'positionAnchorShape'
+  | 'positionXOffset'
+  | 'positionYOffset'
+  | 'customPosition'
+>): StyleProp<ViewStyle> => {
+  if (customPosition) {
+    return customPosition;
+  }
 
-  const onLayout = useCallback((event: LayoutChangeEvent) => {
-    const { width: rawWidth, height: rawHeight } = event.nativeEvent.layout;
-    const lastAccepted = lastAcceptedRawRef.current;
-    const hasMoved =
-      Math.abs(rawWidth - lastAccepted.width) >= STABLE_SIZE_THRESHOLD_PX ||
-      Math.abs(rawHeight - lastAccepted.height) >= STABLE_SIZE_THRESHOLD_PX;
-    if (!hasMoved) {
-      return;
-    }
-    lastAcceptedRawRef.current = { width: rawWidth, height: rawHeight };
-    setWidth(Math.round(rawWidth));
-    setHeight(Math.round(rawHeight));
-  }, []);
+  const shapeOffset: DimensionValue =
+    positionAnchorShape === BadgeWrapperPositionAnchorShape.Rectangular
+      ? 0
+      : CIRCULAR_ANCHOR_CORNER_OFFSET_PERCENT;
+  const isTop =
+    position === BadgeWrapperPosition.TopRight ||
+    position === BadgeWrapperPosition.TopLeft;
+  const isLeft =
+    position === BadgeWrapperPosition.TopLeft ||
+    position === BadgeWrapperPosition.BottomLeft;
 
-  return [width, height, onLayout] as const;
+  return {
+    ...(isTop ? { top: shapeOffset } : { bottom: shapeOffset }),
+    ...(isLeft ? { left: shapeOffset } : { right: shapeOffset }),
+    // Centers the badge on that corner point using its own size (percentage
+    // translate), then nudges it by any pixel offsets.
+    transform: [
+      { translateY: isTop ? '-50%' : '50%' },
+      { translateY: positionYOffset },
+      { translateX: isLeft ? '-50%' : '50%' },
+      { translateX: positionXOffset },
+    ],
+  };
 };
 
 export const BadgeWrapper = ({
@@ -65,79 +89,33 @@ export const BadgeWrapper = ({
   ...props
 }: BadgeWrapperProps) => {
   const tw = useTailwind();
-  // Fetching the dimensions of the anchor and badge element to properly position the badge
-  const [anchorWidth, anchorHeight, getAnchorSize] = useStableMeasuredSize();
-  const [badgeWidth, badgeHeight, getBadgeSize] = useStableMeasuredSize();
 
-  const finalPositions = useMemo(() => {
-    if (customPosition) {
-      return customPosition;
-    }
-    // 0.1464 is a mathematical coeeficient to move
-    // from a 0,0 corner of a rectangular shape to the closest "corner"
-    // of a circular shape anchor element
-    const anchorShapeXOffset =
-      positionAnchorShape === BadgeWrapperPositionAnchorShape.Rectangular
-        ? 0
-        : anchorWidth * 0.1464;
-    const anchorShapeYOffset =
-      positionAnchorShape === BadgeWrapperPositionAnchorShape.Rectangular
-        ? 0
-        : anchorHeight * 0.1464;
-    // This is to center the badge in the corner of the anchor element
-    const badgeCenteringXOffset = badgeWidth / 2;
-    const badgeCenteringYOffset = badgeHeight / 2;
-
-    const finalXOffset =
-      anchorShapeXOffset - badgeCenteringXOffset + positionXOffset;
-    const finalYOffset =
-      anchorShapeYOffset - badgeCenteringYOffset + positionYOffset;
-    switch (position) {
-      case BadgeWrapperPosition.TopRight:
-        return {
-          top: finalYOffset,
-          right: finalXOffset,
-        };
-      case BadgeWrapperPosition.BottomLeft:
-        return {
-          bottom: finalYOffset,
-          left: finalXOffset,
-        };
-      case BadgeWrapperPosition.TopLeft:
-        return {
-          top: finalYOffset,
-          left: finalXOffset,
-        };
-      case BadgeWrapperPosition.BottomRight:
-      default:
-        return {
-          bottom: finalYOffset,
-          right: finalXOffset,
-        };
-    }
-  }, [
-    position,
-    positionAnchorShape,
-    anchorWidth,
-    anchorHeight,
-    badgeWidth,
-    badgeHeight,
-    positionXOffset,
-    positionYOffset,
-    customPosition,
-  ]);
+  const badgePositionStyle = useMemo(
+    () =>
+      getBadgePositionStyle({
+        position,
+        positionAnchorShape,
+        positionXOffset,
+        positionYOffset,
+        customPosition,
+      }),
+    [
+      position,
+      positionAnchorShape,
+      positionXOffset,
+      positionYOffset,
+      customPosition,
+    ],
+  );
 
   return (
     <View
       {...props}
       style={[tw.style('relative self-start', twClassName), style]}
     >
-      <View onLayout={getAnchorSize} {...childrenContainerProps}>
-        {children}
-      </View>
+      <View {...childrenContainerProps}>{children}</View>
       <View
-        onLayout={getBadgeSize}
-        style={[tw.style('absolute'), { ...finalPositions }]}
+        style={[tw.style('absolute'), badgePositionStyle]}
         {...badgeContainerProps}
       >
         {badge}

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -3,11 +3,52 @@ import {
   BadgeWrapperPositionAnchorShape,
 } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, { useCallback, useState, useMemo } from 'react';
+import React, { useCallback, useState, useMemo, useRef } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { View } from 'react-native';
 
 import type { BadgeWrapperProps } from './BadgeWrapper.types';
+
+// Below this, a measurement is treated as noise rather than a real resize.
+const STABLE_SIZE_THRESHOLD_PX = 1;
+
+/**
+ * Tracks a measured element's rounded width/height via `onLayout`.
+ *
+ * `BadgeWrapper` positions an element based on its own measured size, so
+ * applying that position can shift the next measurement by a sub-pixel
+ * amount, which can flip-flop forever without this guard. Rounding alone
+ * isn't enough to prevent that: two raw values close enough together to be
+ * noise can still round to different integers if they straddle a `.5`
+ * boundary. Instead this only accepts a new size once it has moved a full
+ * pixel away from the last accepted raw measurement (starting from
+ * `-Infinity`, so the first real measurement is always accepted), which
+ * absorbs sub-pixel noise regardless of where it falls, while still
+ * reacting to genuine size changes.
+ *
+ * @returns A `[width, height, onLayout]` tuple.
+ */
+const useStableMeasuredSize = () => {
+  const [width, setWidth] = useState<number>(0);
+  const [height, setHeight] = useState<number>(0);
+  const lastAcceptedRawRef = useRef({ width: -Infinity, height: -Infinity });
+
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
+    const { width: rawWidth, height: rawHeight } = event.nativeEvent.layout;
+    const lastAccepted = lastAcceptedRawRef.current;
+    const hasMoved =
+      Math.abs(rawWidth - lastAccepted.width) >= STABLE_SIZE_THRESHOLD_PX ||
+      Math.abs(rawHeight - lastAccepted.height) >= STABLE_SIZE_THRESHOLD_PX;
+    if (!hasMoved) {
+      return;
+    }
+    lastAcceptedRawRef.current = { width: rawWidth, height: rawHeight };
+    setWidth(Math.round(rawWidth));
+    setHeight(Math.round(rawHeight));
+  }, []);
+
+  return [width, height, onLayout] as const;
+};
 
 export const BadgeWrapper = ({
   children,
@@ -24,22 +65,9 @@ export const BadgeWrapper = ({
   ...props
 }: BadgeWrapperProps) => {
   const tw = useTailwind();
-  const [anchorWidth, setAnchorWidth] = useState<number>(0);
-  const [anchorHeight, setAnchorHeight] = useState<number>(0);
-  const [badgeWidth, setbadgeWidth] = useState<number>(0);
-  const [badgeHeight, setbadgeHeight] = useState<number>(0);
-
-  // Fetching the dimensions of the anchor and bagde element to properly position the badge
-  const getAnchorSize = useCallback((event: LayoutChangeEvent) => {
-    const { width, height } = event.nativeEvent.layout;
-    setAnchorWidth(width);
-    setAnchorHeight(height);
-  }, []);
-  const getBadgeSize = useCallback((event: LayoutChangeEvent) => {
-    const { width, height } = event.nativeEvent.layout;
-    setbadgeWidth(width);
-    setbadgeHeight(height);
-  }, []);
+  // Fetching the dimensions of the anchor and badge element to properly position the badge
+  const [anchorWidth, anchorHeight, getAnchorSize] = useStableMeasuredSize();
+  const [badgeWidth, badgeHeight, getBadgeSize] = useStableMeasuredSize();
 
   const finalPositions = useMemo(() => {
     if (customPosition) {


### PR DESCRIPTION
## **Description**

`BadgeWrapper` positioned the badge using its own measured width and height (via `onLayout`), to center it on the anchor's corner. The problem is that applying that position changes the badge's layout by a tiny sub-pixel amount, which can change how the next measurement rounds. On certain sizes this started a loop: measure, reposition, re-measure at a slightly different size, reposition again, forever.

We found this while chasing a JS thread performance issue in MetaMask Mobile. After sign-in, CPU usage stayed pegged at 90-100% and never settled. Tracing it down led to a notification badge inside `BadgeWrapper` calling `setState` continuously, dozens of times per second, and never stopping. Logging the raw values from `onLayout` showed the width and height literally swapping back and forth between two numbers on every call (for example `12.19 / 11.81` then `11.81 / 12.19`), which confirmed it wasn't real content resizing, it was the position feedback loop described above.

The first version of this fix rounded the measured size and skipped the state update when it hadn't changed, to break the loop. While validating it against a follow-up issue (the badge would render once at the wrong spot, then visibly jump into place a frame later, since the real measurement only arrives after the first paint), it became clear the underlying measurement approach was the real source of both problems. So instead of patching around it, this PR removes the measurement entirely.

The badge is now positioned purely through layout: percentage insets (`top`/`right`/`bottom`/`left`) plus a percentage-based `transform: translate`, both resolved by the native layout engine in a single pass. There's nothing to measure, so there's nothing to jump and nothing that can loop. This also let us replace the old `0.1464` corner-offset literal with a constant derived from the actual circle-in-square geometry, instead of a magic rounded number.

### How long has this been around?

The underlying bug has been in `BadgeWrapper` since it was first added, back in March 2025. It just never got triggered before because it only happens once a badge actually appears while mounted, at a size where the rounding happens to be unstable. Mobile started using this `BadgeWrapper` for things like the wallet notification badge and the Earn asset badges in March 2026, and only noticed the CPU impact recently once that code path got hit under the right conditions.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3928

## **Manual testing steps**

1. Render a `BadgeWrapper` with a badge that becomes visible after some async condition (e.g. a notification count fetched after sign-in).
2. Before this fix: watch the JS thread / CPU usage after the badge appears, it stays elevated and never settles, and the badge visibly jumps a few pixels into place after first appearing.
3. After this fix: CPU usage settles back down shortly after the badge appears, and the badge renders directly in its final position with no jump.

## **Screenshots/Recordings**

### **Before & After**

<img width="12516" height="4308" alt="image" src="https://github.com/user-attachments/assets/a667d68a-f7e9-4983-904e-035b97a498db" />

https://github.com/user-attachments/assets/b13ffcf3-81e2-4682-b633-b4a7fefcdf05

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
