### PR TITLE
test: update BadgeWrapper stories

### DIFF
--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -275,7 +275,7 @@ export const CustomPosition: Story = {
 export const Badge: Story = {
   render: () => (
     <View style={{ gap: 20, padding: 12 }}>
-      {/* Mobile wallet token rows. */}
+      {/* Token examples. */}
       <View style={{ flexDirection: 'row', gap: 16 }}>
         {Object.values(AvatarTokenSize).map((size) => (
           <BadgeWrapper
@@ -290,7 +290,7 @@ export const Badge: Story = {
           </BadgeWrapper>
         ))}
       </View>
-      {/* Mobile rectangular asset/account rows. */}
+      {/* Account examples. */}
       <View style={{ flexDirection: 'row', gap: 16 }}>
         {Object.values(AvatarAccountSize).map((size) => (
           <BadgeWrapper
@@ -308,7 +308,7 @@ export const Badge: Story = {
           </BadgeWrapper>
         ))}
       </View>
-      {/* Mobile wallet notification badge. */}
+      {/* Notification badge examples. */}
       <View style={{ flexDirection: 'row', gap: 16 }}>
         {Object.values(ButtonIconSize).map((size) => (
           <BadgeWrapper
@@ -325,7 +325,7 @@ export const Badge: Story = {
           </BadgeWrapper>
         ))}
       </View>
-      {/* Mobile status indicator example. */}
+      {/* Status indicator example. */}
       <BadgeWrapper
         position={BadgeWrapperPosition.TopRight}
         positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -1,16 +1,21 @@
 import {
   BadgeWrapperPositionAnchorShape,
   BadgeWrapperPosition,
+  AvatarTokenSize,
+  ButtonIconSize,
 } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import { View } from 'react-native';
 
 import { AvatarAccount, AvatarAccountSize } from '../AvatarAccount';
 import { AvatarNetwork } from '../AvatarNetwork';
+import { SAMPLE_AVATARNETWORK_URIS } from '../AvatarNetwork/AvatarNetwork.dev';
+import { AvatarToken } from '../AvatarToken';
+import { SAMPLE_AVATARTOKEN_URIS } from '../AvatarToken/AvatarToken.dev';
 import { BadgeCount } from '../BadgeCount';
-import { BadgeIcon } from '../BadgeIcon';
 import { BadgeNetwork } from '../BadgeNetwork';
 import { BadgeStatus, BadgeStatusStatus } from '../BadgeStatus';
+import { ButtonIcon } from '../ButtonIcon';
 import { IconName } from '../Icon';
 
 import { BadgeWrapper } from './BadgeWrapper';
@@ -269,49 +274,60 @@ export const CustomPosition: Story = {
 
 export const Badge: Story = {
   render: () => (
-    <View style={{ padding: 12, gap: 20 }}>
-      {/* BadgeCount example */}
+    <View style={{ gap: 20, padding: 12 }}>
+      {/* Mobile wallet token rows. */}
+      <View style={{ flexDirection: 'row', gap: 16 }}>
+        {Object.values(AvatarTokenSize).map((size) => (
+          <BadgeWrapper
+            key={`token-${size}`}
+            position={BadgeWrapperPosition.BottomRight}
+            positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+            badge={
+              <BadgeNetwork name="ETH" src={SAMPLE_AVATARNETWORK_URIS[3]} />
+            }
+          >
+            <AvatarToken size={size} src={SAMPLE_AVATARTOKEN_URIS[1]} />
+          </BadgeWrapper>
+        ))}
+      </View>
+      {/* Mobile rectangular asset/account rows. */}
+      <View style={{ flexDirection: 'row', gap: 16 }}>
+        {Object.values(AvatarAccountSize).map((size) => (
+          <BadgeWrapper
+            key={`account-${size}`}
+            position={BadgeWrapperPosition.BottomRight}
+            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
+            badge={
+              <BadgeNetwork name="ETH" src={SAMPLE_AVATARNETWORK_URIS[3]} />
+            }
+          >
+            <AvatarAccount
+              size={size}
+              address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8"
+            />
+          </BadgeWrapper>
+        ))}
+      </View>
+      {/* Mobile wallet notification badge. */}
+      <View style={{ flexDirection: 'row', gap: 16 }}>
+        {Object.values(ButtonIconSize).map((size) => (
+          <BadgeWrapper
+            key={`notification-${size}`}
+            position={BadgeWrapperPosition.TopRight}
+            positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+            badge={<BadgeCount count={8} />}
+          >
+            <ButtonIcon iconName={IconName.Menu} size={size} />
+          </BadgeWrapper>
+        ))}
+      </View>
+      {/* Mobile status indicator example. */}
       <BadgeWrapper
         position={BadgeWrapperPosition.TopRight}
-        badge={<BadgeCount count={8} />}
+        positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+        badge={<BadgeStatus status={BadgeStatusStatus.New} />}
       >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
-      </BadgeWrapper>
-      {/* BadgeIcon example */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={<BadgeIcon iconName={IconName.Snaps} />}
-      >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
-      </BadgeWrapper>
-      {/* BadgeNetwork example */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={
-          <BadgeNetwork
-            name="ETH"
-            src={{
-              uri: 'https://cryptologos.cc/logos/ethereum-eth-logo.svg',
-            }}
-          />
-        }
-      >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
-      </BadgeWrapper>
-      {/* BadgeStatus example */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={<BadgeStatus status={BadgeStatusStatus.Active} />}
-      >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
-      </BadgeWrapper>
-      <BadgeWrapper
-        position={BadgeWrapperPosition.TopRight}
-        badge={
-          <BadgeStatus status={BadgeStatusStatus.Attention} hasBorder={false} />
-        }
-      >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
+        <ButtonIcon iconName={IconName.Menu} size={ButtonIconSize.Md} />
       </BadgeWrapper>
     </View>
   ),

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -317,7 +317,11 @@ export const Badge: Story = {
             positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
             badge={<BadgeCount count={8} />}
           >
-            <ButtonIcon iconName={IconName.Menu} size={size} />
+            <ButtonIcon
+              iconName={IconName.Menu}
+              size={size}
+              accessibilityLabel={`Open menu (${size})`}
+            />
           </BadgeWrapper>
         ))}
       </View>
@@ -327,7 +331,11 @@ export const Badge: Story = {
         positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
         badge={<BadgeStatus status={BadgeStatusStatus.New} />}
       >
-        <ButtonIcon iconName={IconName.Menu} size={ButtonIconSize.Md} />
+        <ButtonIcon
+          iconName={IconName.Menu}
+          size={ButtonIconSize.Md}
+          accessibilityLabel="Open menu"
+        />
       </BadgeWrapper>
     </View>
   ),

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -1,6 +1,8 @@
 import {
   BadgeWrapperPositionAnchorShape,
   BadgeWrapperPosition,
+  AvatarTokenSize,
+  ButtonIconSize,
 } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
@@ -8,10 +10,12 @@ import React from 'react';
 import { AvatarAccount, AvatarAccountSize } from '../AvatarAccount';
 import { AvatarNetwork } from '../AvatarNetwork';
 import { SAMPLE_AVATARNETWORK_URIS } from '../AvatarNetwork/AvatarNetwork.dev';
+import { AvatarToken } from '../AvatarToken';
+import { SAMPLE_AVATARTOKEN_URIS } from '../AvatarToken/AvatarToken.dev';
 import { BadgeCount } from '../BadgeCount';
-import { BadgeIcon } from '../BadgeIcon';
 import { BadgeNetwork } from '../BadgeNetwork';
 import { BadgeStatus, BadgeStatusStatus } from '../BadgeStatus';
+import { ButtonIcon } from '../ButtonIcon';
 import { IconName } from '../Icon';
 
 import { BadgeWrapper } from './BadgeWrapper';
@@ -201,41 +205,59 @@ export const CustomPosition: Story = {
 export const Badge: Story = {
   render: () => (
     <div className="flex flex-col gap-5 p-4">
-      {/* BadgeCount example */}
+      {/* Mobile wallet token rows. */}
+      <div className="flex flex-row gap-4">
+        {Object.values(AvatarTokenSize).map((size) => (
+          <BadgeWrapper
+            key={`token-${size}`}
+            position={BadgeWrapperPosition.BottomRight}
+            positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+            badge={
+              <BadgeNetwork name="ETH" src={SAMPLE_AVATARNETWORK_URIS[3]} />
+            }
+          >
+            <AvatarToken size={size} src={SAMPLE_AVATARTOKEN_URIS[1]} />
+          </BadgeWrapper>
+        ))}
+      </div>
+      {/* Mobile rectangular asset/account rows. */}
+      <div className="flex flex-row gap-4">
+        {Object.values(AvatarAccountSize).map((size) => (
+          <BadgeWrapper
+            key={`account-${size}`}
+            position={BadgeWrapperPosition.BottomRight}
+            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
+            badge={
+              <BadgeNetwork name="ETH" src={SAMPLE_AVATARNETWORK_URIS[3]} />
+            }
+          >
+            <AvatarAccount
+              size={size}
+              address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8"
+            />
+          </BadgeWrapper>
+        ))}
+      </div>
+      {/* Mobile wallet notification badge. */}
+      <div className="flex flex-row gap-4">
+        {Object.values(ButtonIconSize).map((size) => (
+          <BadgeWrapper
+            key={`notification-${size}`}
+            position={BadgeWrapperPosition.TopRight}
+            positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+            badge={<BadgeCount count={8} />}
+          >
+            <ButtonIcon iconName={IconName.Menu} size={size} />
+          </BadgeWrapper>
+        ))}
+      </div>
+      {/* Mobile status indicator example. */}
       <BadgeWrapper
         position={BadgeWrapperPosition.TopRight}
-        badge={<BadgeCount count={8} />}
+        positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+        badge={<BadgeStatus status={BadgeStatusStatus.New} />}
       >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
-      </BadgeWrapper>
-      {/* BadgeIcon example */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={<BadgeIcon iconName={IconName.Snaps} />}
-      >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
-      </BadgeWrapper>
-      {/* BadgeNetwork example */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={<BadgeNetwork name="ETH" src={SAMPLE_AVATARNETWORK_URIS[3]} />}
-      >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
-      </BadgeWrapper>
-      {/* BadgeStatus example */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={<BadgeStatus status={BadgeStatusStatus.Active} />}
-      >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
-      </BadgeWrapper>
-      <BadgeWrapper
-        position={BadgeWrapperPosition.TopRight}
-        badge={
-          <BadgeStatus status={BadgeStatusStatus.Attention} hasBorder={false} />
-        }
-      >
-        <AvatarAccount address="0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8" />
+        <ButtonIcon iconName={IconName.Menu} size={ButtonIconSize.Md} />
       </BadgeWrapper>
     </div>
   ),

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -247,7 +247,11 @@ export const Badge: Story = {
             positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
             badge={<BadgeCount count={8} />}
           >
-            <ButtonIcon iconName={IconName.Menu} size={size} />
+            <ButtonIcon
+              iconName={IconName.Menu}
+              size={size}
+              ariaLabel={`Open menu (${size})`}
+            />
           </BadgeWrapper>
         ))}
       </div>
@@ -257,7 +261,11 @@ export const Badge: Story = {
         positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
         badge={<BadgeStatus status={BadgeStatusStatus.New} />}
       >
-        <ButtonIcon iconName={IconName.Menu} size={ButtonIconSize.Md} />
+        <ButtonIcon
+          iconName={IconName.Menu}
+          size={ButtonIconSize.Md}
+          ariaLabel="Open menu"
+        />
       </BadgeWrapper>
     </div>
   ),

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -205,7 +205,7 @@ export const CustomPosition: Story = {
 export const Badge: Story = {
   render: () => (
     <div className="flex flex-col gap-5 p-4">
-      {/* Mobile wallet token rows. */}
+      {/* Token examples. */}
       <div className="flex flex-row gap-4">
         {Object.values(AvatarTokenSize).map((size) => (
           <BadgeWrapper
@@ -220,7 +220,7 @@ export const Badge: Story = {
           </BadgeWrapper>
         ))}
       </div>
-      {/* Mobile rectangular asset/account rows. */}
+      {/* Account examples. */}
       <div className="flex flex-row gap-4">
         {Object.values(AvatarAccountSize).map((size) => (
           <BadgeWrapper
@@ -238,7 +238,7 @@ export const Badge: Story = {
           </BadgeWrapper>
         ))}
       </div>
-      {/* Mobile wallet notification badge. */}
+      {/* Notification badge examples. */}
       <div className="flex flex-row gap-4">
         {Object.values(ButtonIconSize).map((size) => (
           <BadgeWrapper
@@ -255,7 +255,7 @@ export const Badge: Story = {
           </BadgeWrapper>
         ))}
       </div>
-      {/* Mobile status indicator example. */}
+      {/* Status indicator example. */}
       <BadgeWrapper
         position={BadgeWrapperPosition.TopRight}
         positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}


### PR DESCRIPTION
## Summary
Update React and React Native BadgeWrapper stories with app based examples

### Before

<img width="407" height="677" alt="Screenshot 2026-08-31 at 1 05 58 PM" src="https://github.com/user-attachments/assets/4c15afb1-d892-4356-bae4-9bcc3ea0bffb" />
<img width="396" height="497" alt="Screenshot 2026-08-31 at 1 06 06 PM" src="https://github.com/user-attachments/assets/dc41c824-7b75-40b5-bbe9-44102b556ee7" />


### After

<img width="580" height="330" alt="Screenshot 2026-08-31 at 1 05 31 PM" src="https://github.com/user-attachments/assets/3bbda92a-eb5c-4a53-a683-6c8408a921fc" />
<img width="661" height="695" alt="Screenshot 2026-08-31 at 1 05 42 PM" src="https://github.com/user-attachments/assets/c63cec13-2c87-425a-acbd-9ce653ad7124" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Storybook examples only; no runtime component or API changes.
> 
> **Overview**
> **Storybook-only** refresh of the `Badge` story in React and React Native `BadgeWrapper` stories, aligned with mobile usage and upcoming positioning work.
> 
> The old vertical stack of one-off examples (`BadgeCount`, `BadgeIcon`, `BadgeNetwork`, `BadgeStatus` on a single `AvatarAccount`) is replaced with grouped **size sweeps**: `AvatarToken` + network badge (circular anchor), `AvatarAccount` + network badge (rectangular anchor), `ButtonIcon` + `BadgeCount` (circular), and a single **status** example (`BadgeStatusStatus.New` on menu `ButtonIcon`). Stories now pull sample image URIs from dev helpers and set `positionAnchorShape` explicitly; **`BadgeIcon` is dropped** from these examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf754101f50c6252ba05ae10c7a5e26674ba869d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->