### PR TITLE
fix: prevent BadgeWrapper layout loop

### DIFF
--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -13,7 +13,6 @@ import { SAMPLE_AVATARNETWORK_URIS } from '../AvatarNetwork/AvatarNetwork.dev';
 import { AvatarToken } from '../AvatarToken';
 import { SAMPLE_AVATARTOKEN_URIS } from '../AvatarToken/AvatarToken.dev';
 import { BadgeCount } from '../BadgeCount';
-import { BadgeIcon } from '../BadgeIcon';
 import { BadgeNetwork } from '../BadgeNetwork';
 import { BadgeStatus, BadgeStatusStatus } from '../BadgeStatus';
 import { ButtonIcon } from '../ButtonIcon';
@@ -326,30 +325,23 @@ export const Badge: Story = {
           </BadgeWrapper>
         ))}
       </View>
-      {/* Status indicator example. */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.TopRight}
-        positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
-        badge={<BadgeStatus status={BadgeStatusStatus.New} />}
-      >
-        <ButtonIcon
-          iconName={IconName.Menu}
-          size={ButtonIconSize.Md}
-          accessibilityLabel="Open menu"
-        />
-      </BadgeWrapper>
-      {/* Icon badge example. */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
-        badge={<BadgeIcon iconName={IconName.Snaps} />}
-      >
-        <ButtonIcon
-          iconName={IconName.Menu}
-          size={ButtonIconSize.Md}
-          accessibilityLabel="Open menu"
-        />
-      </BadgeWrapper>
+      {/* Status indicator examples. */}
+      <View style={{ flexDirection: 'row', gap: 16 }}>
+        {Object.values(ButtonIconSize).map((size) => (
+          <BadgeWrapper
+            key={`status-${size}`}
+            position={BadgeWrapperPosition.TopRight}
+            positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+            badge={<BadgeStatus status={BadgeStatusStatus.New} />}
+          >
+            <ButtonIcon
+              iconName={IconName.Menu}
+              size={size}
+              accessibilityLabel={`Open menu (${size})`}
+            />
+          </BadgeWrapper>
+        ))}
+      </View>
     </View>
   ),
 };

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -13,6 +13,7 @@ import { SAMPLE_AVATARNETWORK_URIS } from '../AvatarNetwork/AvatarNetwork.dev';
 import { AvatarToken } from '../AvatarToken';
 import { SAMPLE_AVATARTOKEN_URIS } from '../AvatarToken/AvatarToken.dev';
 import { BadgeCount } from '../BadgeCount';
+import { BadgeIcon } from '../BadgeIcon';
 import { BadgeNetwork } from '../BadgeNetwork';
 import { BadgeStatus, BadgeStatusStatus } from '../BadgeStatus';
 import { ButtonIcon } from '../ButtonIcon';
@@ -330,6 +331,18 @@ export const Badge: Story = {
         position={BadgeWrapperPosition.TopRight}
         positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
         badge={<BadgeStatus status={BadgeStatusStatus.New} />}
+      >
+        <ButtonIcon
+          iconName={IconName.Menu}
+          size={ButtonIconSize.Md}
+          accessibilityLabel="Open menu"
+        />
+      </BadgeWrapper>
+      {/* Icon badge example. */}
+      <BadgeWrapper
+        position={BadgeWrapperPosition.BottomRight}
+        positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+        badge={<BadgeIcon iconName={IconName.Snaps} />}
       >
         <ButtonIcon
           iconName={IconName.Menu}

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -332,7 +332,7 @@ export const Badge: Story = {
             key={`status-${size}`}
             position={BadgeWrapperPosition.TopRight}
             positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
-            badge={<BadgeStatus status={BadgeStatusStatus.New} />}
+            badge={<BadgeStatus status={BadgeStatusStatus.Attention} />}
           >
             <ButtonIcon
               iconName={IconName.Menu}

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -10,72 +10,62 @@ import { Text } from '../Text';
 import { BadgeWrapper } from './BadgeWrapper';
 
 describe('BadgeWrapper', () => {
-  it('renders the anchor and badge without layout handlers', () => {
+  it('renders the anchor and badge', () => {
     const { getByTestId } = render(
-      <BadgeWrapper testID="wrapper" badge={<Text testID="badge">Badge</Text>}>
+      <BadgeWrapper
+        testID="wrapper"
+        badgeContainerProps={{ testID: 'badge-container' }}
+        badge={<Text testID="badge">Badge</Text>}
+      >
         <Text testID="anchor">Anchor</Text>
       </BadgeWrapper>,
     );
 
-    const wrapper = getByTestId('wrapper');
-    const [anchorContainer, badgeContainer] = wrapper.props.children;
-
     expect(getByTestId('anchor')).toBeDefined();
     expect(getByTestId('badge')).toBeDefined();
-    expect(anchorContainer.props.onLayout).toBeUndefined();
-    expect(badgeContainer.props.onLayout).toBeUndefined();
+    expect(getByTestId('badge-container')).toBeOnTheScreen();
   });
 
   it.each([
-    [BadgeWrapperPosition.TopRight, { top: 4, right: 4 }],
-    [BadgeWrapperPosition.BottomRight, { bottom: 4, right: 4 }],
-    [BadgeWrapperPosition.BottomLeft, { bottom: 4, left: 4 }],
-    [BadgeWrapperPosition.TopLeft, { top: 4, left: 4 }],
+    [BadgeWrapperPosition.TopRight, { top: -8, right: -8 }],
+    [BadgeWrapperPosition.BottomRight, { bottom: -8, right: -8 }],
+    [BadgeWrapperPosition.BottomLeft, { bottom: -8, left: -8 }],
+    [BadgeWrapperPosition.TopLeft, { top: -8, left: -8 }],
   ])('uses static circular position for %s', (position, edgeStyle) => {
     const { getByTestId } = render(
       <BadgeWrapper
         testID="wrapper"
         position={position}
+        badgeContainerProps={{ testID: 'badge-container' }}
         badge={<Text>Badge</Text>}
       >
         <Text>Anchor</Text>
       </BadgeWrapper>,
     );
 
-    const badgeContainer = getByTestId('wrapper').props.children[1];
-
-    expect(badgeContainer.props.style[1]).toMatchObject({
-      width: 16,
-      height: 16,
+    expect(getByTestId('badge-container')).toHaveStyle({
+      ...edgeStyle,
+      transform: [{ translateX: 0 }, { translateY: 0 }],
     });
-    expect(badgeContainer.props.style[2]).toStrictEqual(
-      expect.objectContaining({
-        ...edgeStyle,
-        transform: expect.any(Array),
-      }),
-    );
   });
 
-  it('uses zero edge inset for rectangular anchors', () => {
+  it('uses static overlap for rectangular anchors', () => {
     const { getByTestId } = render(
       <BadgeWrapper
         testID="wrapper"
         position={BadgeWrapperPosition.BottomRight}
         positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
+        badgeContainerProps={{ testID: 'badge-container' }}
         badge={<Text>Badge</Text>}
       >
         <Text>Anchor</Text>
       </BadgeWrapper>,
     );
 
-    expect(
-      getByTestId('wrapper').props.children[1].props.style[2],
-    ).toStrictEqual(
-      expect.objectContaining({
-        bottom: 0,
-        right: 0,
-      }),
-    );
+    expect(getByTestId('badge-container')).toHaveStyle({
+      bottom: -6,
+      right: -6,
+    });
   });
 
   it('applies offsets without measuring', () => {
@@ -85,15 +75,16 @@ describe('BadgeWrapper', () => {
         position={BadgeWrapperPosition.BottomRight}
         positionXOffset={3}
         positionYOffset={-4}
+        badgeContainerProps={{ testID: 'badge-container' }}
         badge={<Text>Badge</Text>}
       >
         <Text>Anchor</Text>
       </BadgeWrapper>,
     );
 
-    expect(
-      getByTestId('wrapper').props.children[1].props.style[2].transform,
-    ).toStrictEqual([{ translateX: 11 }, { translateY: 4 }]);
+    expect(getByTestId('badge-container')).toHaveStyle({
+      transform: [{ translateX: 3 }, { translateY: -4 }],
+    });
   });
 
   it('uses customPosition and allows badge container styles', () => {
@@ -101,15 +92,21 @@ describe('BadgeWrapper', () => {
       <BadgeWrapper
         testID="wrapper"
         customPosition={{ top: 5, right: 10 }}
-        badgeContainerProps={{ style: { width: 8, height: 8 } }}
+        badgeContainerProps={{
+          testID: 'badge-container',
+          style: { width: 8, height: 8 },
+        }}
         badge={<Text>Badge</Text>}
       >
         <Text>Anchor</Text>
       </BadgeWrapper>,
     );
 
-    const badgeStyle = getByTestId('wrapper').props.children[1].props.style;
-    expect(badgeStyle[2]).toStrictEqual({ top: 5, right: 10 });
-    expect(badgeStyle[3]).toStrictEqual({ width: 8, height: 8 });
+    expect(getByTestId('badge-container')).toHaveStyle({
+      top: 5,
+      right: 10,
+      width: 8,
+      height: 8,
+    });
   });
 });

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -2,680 +2,114 @@ import {
   BadgeWrapperPositionAnchorShape,
   BadgeWrapperPosition,
 } from '@metamask/design-system-shared';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { render, act } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import React from 'react';
-import { StyleSheet } from 'react-native';
 
 import { Text } from '../Text';
 
 import { BadgeWrapper } from './BadgeWrapper';
 
-// Helper function to round numeric properties to two decimals.
-const roundPositions = (pos: {
-  [key: string]: number;
-}): { [key: string]: number } => {
-  const result: { [key: string]: number } = {};
-  Object.keys(pos).forEach((key) => {
-    result[key] = Number(pos[key].toFixed(2));
-  });
-  return result;
-};
 describe('BadgeWrapper', () => {
-  it('computes the top right final positions correctly on circular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using props:
-      // position: TopRight, positionAnchorShape: Circular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 100 * 0.1464 = 14.64
-      //   anchorShapeYOffset = 50 * 0.1464 = 7.32
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 14.64 - 10 + 0 = 4.64
-      //   finalYOffset = 7.32 - 10 + 0 = -2.68
-      // For TopRight Circular, expected positions: { top: -2.68, right: 4.64 }.
-      const expectedPositions = { top: -2.68, right: 4.64 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.TopRight}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
+  it('renders the anchor and badge without layout handlers', () => {
+    const { getByTestId } = render(
+      <BadgeWrapper testID="wrapper" badge={<Text testID="badge">Badge</Text>}>
+        <Text testID="anchor">Anchor</Text>
+      </BadgeWrapper>,
     );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
 
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the top right final positions correctly on rectangular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using default props:
-      // position: TopRight, positionAnchorShape: Rectangular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 0
-      //   anchorShapeYOffset = 0
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 0 - 10 + 0 = -10
-      //   finalYOffset = 0 - 10 + 0 = -10
-      // For TopRight Rectangular, expected positions: { top: -10, right: -10 }.
-      const expectedPositions = { top: -10, right: -10 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.TopRight}
-            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the bottom right final positions correctly on circular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using props:
-      // position: BottomRight, positionAnchorShape: Circular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 100 * 0.1464 = 14.64
-      //   anchorShapeYOffset = 50 * 0.1464 = 7.32
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 14.64 - 10 + 0 = 4.64
-      //   finalYOffset = 7.32 - 10 + 0 = -2.68
-      // For BottomRight Circular, expected positions: { bottom: -2.68, right: 4.64 }.
-      const expectedPositions = { bottom: -2.68, right: 4.64 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.BottomRight}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the bottom right final positions correctly on rectangular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using default props:
-      // position: BottomRight, positionAnchorShape: Rectangular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 0
-      //   anchorShapeYOffset = 0
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 0 - 10 + 0 = -10
-      //   finalYOffset = 0 - 10 + 0 = -10
-      // For BottomRight Rectangular, expected positions: { bottom: -10, right: -10 }.
-      const expectedPositions = { bottom: -10, right: -10 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.BottomRight}
-            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the bottom left final positions correctly on circular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using props:
-      // position: BottomLeft, positionAnchorShape: Circular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 100 * 0.1464 = 14.64
-      //   anchorShapeYOffset = 50 * 0.1464 = 7.32
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 14.64 - 10 + 0 = 4.64
-      //   finalYOffset = 7.32 - 10 + 0 = -2.68
-      // For BottomLeft Circular, expected positions: { bottom: -2.68, left: 4.64 }.
-      const expectedPositions = { bottom: -2.68, left: 4.64 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.BottomLeft}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the bottom left final positions correctly on rectangular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using default props:
-      // position: BottomLeft, positionAnchorShape: Rectangular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 0
-      //   anchorShapeYOffset = 0
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 0 - 10 + 0 = -10
-      //   finalYOffset = 0 - 10 + 0 = -10
-      // For BottomLeft Rectangular, expected positions: { bottom: -10, left: -10 }.
-      const expectedPositions = { bottom: -10, left: -10 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.BottomLeft}
-            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the top left final positions correctly on circular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using props:
-      // position: TopLeft, positionAnchorShape: Circular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 100 * 0.1464 = 14.64
-      //   anchorShapeYOffset = 50 * 0.1464 = 7.32
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 14.64 - 10 + 0 = 4.64
-      //   finalYOffset = 7.32 - 10 + 0 = -2.68
-      // For TopLeft Circular, expected positions: { top: -2.68, left: 4.64 }.
-      const expectedPositions = { top: -2.68, left: 4.64 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.TopLeft}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('computes the top left final positions correctly on rectangular anchor', () => {
-    const TestComponent = () => {
-      const tw = useTailwind();
-      // Using default props:
-      // position: TopLeft, positionAnchorShape: Rectangular,
-      // positionXOffset & positionYOffset: 0.
-      // Simulated dimensions:
-      //   Anchor: width = 100, height = 50.
-      //   Badge: width = 20, height = 20.
-      //
-      // Computation:
-      //   anchorShapeXOffset = 0
-      //   anchorShapeYOffset = 0
-      //   badgeCenteringXOffset = 20 / 2 = 10
-      //   badgeCenteringYOffset = 20 / 2 = 10
-      //   finalXOffset = 0 - 10 + 0 = -10
-      //   finalYOffset = 0 - 10 + 0 = -10
-      // For TopLeft Rectangular, expected positions: { top: -10, left: -10 }.
-      const expectedPositions = { top: -10, left: -10 };
-      const computedExpectedBadgeStyle = [
-        tw.style('absolute'),
-        expectedPositions,
-      ];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            position={BadgeWrapperPosition.TopLeft}
-            positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-
-    // Initially get the wrapper and its children.
-    let wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const anchorContainer = children[0];
-    const badgeContainer = children[1];
-
-    // Simulate layout events:
-    act(() => {
-      anchorContainer.props.onLayout({
-        nativeEvent: { layout: { width: 100, height: 50 } },
-      });
-      badgeContainer.props.onLayout({
-        nativeEvent: { layout: { width: 20, height: 20 } },
-      });
-    });
-    // Force a re-read of the updated component.
-    wrapper = getByTestId('wrapper');
-    const updatedBadgeContainer = wrapper.props.children[1];
-
-    const expectedBadgeStyleRaw = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
-    const expectedPositionsRounded = roundPositions(expectedBadgeStyleRaw[1]);
-    const actualPositions = updatedBadgeContainer.props.style[1];
-    const actualPositionsRounded = roundPositions(actualPositions);
-
-    // Check the first element (the absolute style) and the computed positions.
-    expect(updatedBadgeContainer.props.style[0]).toStrictEqual(
-      expectedBadgeStyleRaw[0],
-    );
-    expect(actualPositionsRounded).toStrictEqual(expectedPositionsRounded);
-  });
-
-  it('uses customPosition if provided, ignoring layout events', () => {
-    const customPosition = { top: 5, left: 10 };
-    const TestComponent = () => {
-      const tw = useTailwind();
-      const computedExpectedBadgeStyle = [tw.style('absolute'), customPosition];
-      return (
-        <>
-          <BadgeWrapper
-            testID="wrapper"
-            customPosition={customPosition}
-            badge={<Text testID="badgeElement">Badge</Text>}
-          >
-            <Text testID="anchorChild">Anchor</Text>
-          </BadgeWrapper>
-          <Text testID="expectedBadgeStyle">
-            {JSON.stringify(computedExpectedBadgeStyle)}
-          </Text>
-        </>
-      );
-    };
-
-    const { getByTestId } = render(<TestComponent />);
-    const expectedBadgeStyle = JSON.parse(
-      getByTestId('expectedBadgeStyle').props.children,
-    );
     const wrapper = getByTestId('wrapper');
-    const { children } = wrapper.props;
-    const badgeContainer = children[1];
-    expect(badgeContainer.props.style[1]).toStrictEqual(expectedBadgeStyle[1]);
+    const [anchorContainer, badgeContainer] = wrapper.props.children;
+
+    expect(getByTestId('anchor')).toBeDefined();
+    expect(getByTestId('badge')).toBeDefined();
+    expect(anchorContainer.props.onLayout).toBeUndefined();
+    expect(badgeContainer.props.onLayout).toBeUndefined();
   });
 
-  it('applies additional container style and forwards extra props', () => {
-    // Since BadgeWrapper renders:
-    // <View style={[tw`relative self-start`, style]} {...props}>
-    // The default style from tw`relative self-start` is merged with custom style.
-    // We expect the flattened style to contain both default properties and the custom style.
-    const customStyle = { margin: 10 };
-    const extraProp = { accessibilityLabel: 'badge-wrapper' };
-    const TestComponent = () => (
+  it.each([
+    [BadgeWrapperPosition.TopRight, { top: 4, right: 4 }],
+    [BadgeWrapperPosition.BottomRight, { bottom: 4, right: 4 }],
+    [BadgeWrapperPosition.BottomLeft, { bottom: 4, left: 4 }],
+    [BadgeWrapperPosition.TopLeft, { top: 4, left: 4 }],
+  ])('uses static circular position for %s', (position, edgeStyle) => {
+    const { getByTestId } = render(
       <BadgeWrapper
         testID="wrapper"
-        style={customStyle}
-        {...extraProp}
+        position={position}
         badge={<Text>Badge</Text>}
       >
         <Text>Anchor</Text>
-      </BadgeWrapper>
+      </BadgeWrapper>,
     );
-    const { getByTestId } = render(<TestComponent />);
-    const wrapper = getByTestId('wrapper');
-    // Flatten the style to compare:
-    const flattenedStyle = StyleSheet.flatten(wrapper.props.style);
-    // Expect default properties from tw`relative self-start`
-    expect(flattenedStyle).toMatchObject({
-      position: 'relative',
-      alignSelf: 'flex-start',
-      margin: 10,
+
+    const badgeContainer = getByTestId('wrapper').props.children[1];
+
+    expect(badgeContainer.props.style[1]).toMatchObject({
+      width: 16,
+      height: 16,
     });
-    expect(wrapper.props.accessibilityLabel).toBe('badge-wrapper');
+    expect(badgeContainer.props.style[2]).toStrictEqual(
+      expect.objectContaining({
+        ...edgeStyle,
+        transform: expect.any(Array),
+      }),
+    );
+  });
+
+  it('uses zero edge inset for rectangular anchors', () => {
+    const { getByTestId } = render(
+      <BadgeWrapper
+        testID="wrapper"
+        position={BadgeWrapperPosition.BottomRight}
+        positionAnchorShape={BadgeWrapperPositionAnchorShape.Rectangular}
+        badge={<Text>Badge</Text>}
+      >
+        <Text>Anchor</Text>
+      </BadgeWrapper>,
+    );
+
+    expect(
+      getByTestId('wrapper').props.children[1].props.style[2],
+    ).toStrictEqual(
+      expect.objectContaining({
+        bottom: 0,
+        right: 0,
+      }),
+    );
+  });
+
+  it('applies offsets without measuring', () => {
+    const { getByTestId } = render(
+      <BadgeWrapper
+        testID="wrapper"
+        position={BadgeWrapperPosition.BottomRight}
+        positionXOffset={3}
+        positionYOffset={-4}
+        badge={<Text>Badge</Text>}
+      >
+        <Text>Anchor</Text>
+      </BadgeWrapper>,
+    );
+
+    expect(
+      getByTestId('wrapper').props.children[1].props.style[2].transform,
+    ).toStrictEqual([{ translateX: 11 }, { translateY: 4 }]);
+  });
+
+  it('uses customPosition and allows badge container styles', () => {
+    const { getByTestId } = render(
+      <BadgeWrapper
+        testID="wrapper"
+        customPosition={{ top: 5, right: 10 }}
+        badgeContainerProps={{ style: { width: 8, height: 8 } }}
+        badge={<Text>Badge</Text>}
+      >
+        <Text>Anchor</Text>
+      </BadgeWrapper>,
+    );
+
+    const badgeStyle = getByTestId('wrapper').props.children[1].props.style;
+    expect(badgeStyle[2]).toStrictEqual({ top: 5, right: 10 });
+    expect(badgeStyle[3]).toStrictEqual({ width: 8, height: 8 });
   });
 });

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -27,29 +27,48 @@ describe('BadgeWrapper', () => {
   });
 
   it.each([
-    [BadgeWrapperPosition.TopRight, { top: -8, right: -8 }],
-    [BadgeWrapperPosition.BottomRight, { bottom: -8, right: -8 }],
-    [BadgeWrapperPosition.BottomLeft, { bottom: -8, left: -8 }],
-    [BadgeWrapperPosition.TopLeft, { top: -8, left: -8 }],
-  ])('uses static circular position for %s', (position, edgeStyle) => {
-    const { getByTestId } = render(
-      <BadgeWrapper
-        testID="wrapper"
-        position={position}
-        badgeContainerProps={{ testID: 'badge-container' }}
-        badge={<Text>Badge</Text>}
-      >
-        <Text>Anchor</Text>
-      </BadgeWrapper>,
-    );
+    [
+      BadgeWrapperPosition.TopRight,
+      { top: '7%', right: '7%' },
+      [{ translateX: '50%' }, { translateY: '-50%' }],
+    ],
+    [
+      BadgeWrapperPosition.BottomRight,
+      { bottom: '7%', right: '7%' },
+      [{ translateX: '50%' }, { translateY: '50%' }],
+    ],
+    [
+      BadgeWrapperPosition.BottomLeft,
+      { bottom: '7%', left: '7%' },
+      [{ translateX: '-50%' }, { translateY: '50%' }],
+    ],
+    [
+      BadgeWrapperPosition.TopLeft,
+      { top: '7%', left: '7%' },
+      [{ translateX: '-50%' }, { translateY: '-50%' }],
+    ],
+  ])(
+    'uses percentage circular position for %s',
+    (position, edgeStyle, transform) => {
+      const { getByTestId } = render(
+        <BadgeWrapper
+          testID="wrapper"
+          position={position}
+          badgeContainerProps={{ testID: 'badge-container' }}
+          badge={<Text>Badge</Text>}
+        >
+          <Text>Anchor</Text>
+        </BadgeWrapper>,
+      );
 
-    expect(getByTestId('badge-container')).toHaveStyle({
-      ...edgeStyle,
-      transform: [{ translateX: 0 }, { translateY: 0 }],
-    });
-  });
+      expect(getByTestId('badge-container')).toHaveStyle({
+        ...edgeStyle,
+        transform: [...transform, { translateX: 0 }, { translateY: 0 }],
+      });
+    },
+  );
 
-  it('uses static overlap for rectangular anchors', () => {
+  it('uses percentage edge inset for rectangular anchors', () => {
     const { getByTestId } = render(
       <BadgeWrapper
         testID="wrapper"
@@ -63,8 +82,8 @@ describe('BadgeWrapper', () => {
     );
 
     expect(getByTestId('badge-container')).toHaveStyle({
-      bottom: -6,
-      right: -6,
+      bottom: '11%',
+      right: '11%',
     });
   });
 
@@ -83,7 +102,12 @@ describe('BadgeWrapper', () => {
     );
 
     expect(getByTestId('badge-container')).toHaveStyle({
-      transform: [{ translateX: 3 }, { translateY: -4 }],
+      transform: [
+        { translateX: '50%' },
+        { translateY: '50%' },
+        { translateX: 3 },
+        { translateY: -4 },
+      ],
     });
   });
 

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -4,10 +4,13 @@ import {
 } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
-import type { DimensionValue, StyleProp, ViewStyle } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 import { View } from 'react-native';
 
 import type { BadgeWrapperProps } from './BadgeWrapper.types';
+
+const CIRCULAR_BADGE_OVERLAP = -8;
+const RECTANGULAR_BADGE_OVERLAP = -6;
 
 export const BadgeWrapper = ({
   children,
@@ -24,35 +27,26 @@ export const BadgeWrapper = ({
   ...props
 }: BadgeWrapperProps) => {
   const tw = useTailwind();
-  const finalPositions: StyleProp<ViewStyle> = (() => {
-    if (customPosition) {
-      return customPosition as StyleProp<ViewStyle>;
-    }
-    const edgeInset: DimensionValue =
-      positionAnchorShape === BadgeWrapperPositionAnchorShape.Circular ? 4 : 0;
-    const isTop =
-      position === BadgeWrapperPosition.TopRight ||
-      position === BadgeWrapperPosition.TopLeft;
-    const isLeft =
-      position === BadgeWrapperPosition.TopLeft ||
-      position === BadgeWrapperPosition.BottomLeft;
-    const halfBadgeSize = 8;
-
-    return {
-      ...(isTop ? { top: edgeInset } : { bottom: edgeInset }),
-      ...(isLeft ? { left: edgeInset } : { right: edgeInset }),
-      transform: [
-        {
-          translateX:
-            (isLeft ? -halfBadgeSize : halfBadgeSize) + positionXOffset,
-        },
-        {
-          translateY:
-            (isTop ? -halfBadgeSize : halfBadgeSize) + positionYOffset,
-        },
-      ],
-    };
-  })();
+  const isTop =
+    position === BadgeWrapperPosition.TopRight ||
+    position === BadgeWrapperPosition.TopLeft;
+  const isLeft =
+    position === BadgeWrapperPosition.TopLeft ||
+    position === BadgeWrapperPosition.BottomLeft;
+  const badgeOverlap =
+    positionAnchorShape === BadgeWrapperPositionAnchorShape.Circular
+      ? CIRCULAR_BADGE_OVERLAP
+      : RECTANGULAR_BADGE_OVERLAP;
+  const finalPositions: StyleProp<ViewStyle> = customPosition
+    ? (customPosition as StyleProp<ViewStyle>)
+    : {
+        ...(isTop ? { top: badgeOverlap } : { bottom: badgeOverlap }),
+        ...(isLeft ? { left: badgeOverlap } : { right: badgeOverlap }),
+        transform: [
+          { translateX: positionXOffset },
+          { translateY: positionYOffset },
+        ],
+      };
 
   return (
     <View
@@ -64,12 +58,6 @@ export const BadgeWrapper = ({
         {...badgeContainerProps}
         style={[
           tw.style('absolute'),
-          {
-            width: 16,
-            height: 16,
-            alignItems: 'center',
-            justifyContent: 'center',
-          },
           finalPositions,
           badgeContainerProps?.style,
         ]}

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -3,8 +3,8 @@ import {
   BadgeWrapperPositionAnchorShape,
 } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, { useCallback, useState, useMemo } from 'react';
-import type { LayoutChangeEvent } from 'react-native';
+import React from 'react';
+import type { DimensionValue, StyleProp, ViewStyle } from 'react-native';
 import { View } from 'react-native';
 
 import type { BadgeWrapperProps } from './BadgeWrapper.types';
@@ -24,93 +24,55 @@ export const BadgeWrapper = ({
   ...props
 }: BadgeWrapperProps) => {
   const tw = useTailwind();
-  const [anchorWidth, setAnchorWidth] = useState<number>(0);
-  const [anchorHeight, setAnchorHeight] = useState<number>(0);
-  const [badgeWidth, setbadgeWidth] = useState<number>(0);
-  const [badgeHeight, setbadgeHeight] = useState<number>(0);
-
-  // Fetching the dimensions of the anchor and bagde element to properly position the badge
-  const getAnchorSize = useCallback((event: LayoutChangeEvent) => {
-    const { width, height } = event.nativeEvent.layout;
-    setAnchorWidth(width);
-    setAnchorHeight(height);
-  }, []);
-  const getBadgeSize = useCallback((event: LayoutChangeEvent) => {
-    const { width, height } = event.nativeEvent.layout;
-    setbadgeWidth(width);
-    setbadgeHeight(height);
-  }, []);
-
-  const finalPositions = useMemo(() => {
+  const finalPositions: StyleProp<ViewStyle> = (() => {
     if (customPosition) {
-      return customPosition;
+      return customPosition as StyleProp<ViewStyle>;
     }
-    // 0.1464 is a mathematical coeeficient to move
-    // from a 0,0 corner of a rectangular shape to the closest "corner"
-    // of a circular shape anchor element
-    const anchorShapeXOffset =
-      positionAnchorShape === BadgeWrapperPositionAnchorShape.Rectangular
-        ? 0
-        : anchorWidth * 0.1464;
-    const anchorShapeYOffset =
-      positionAnchorShape === BadgeWrapperPositionAnchorShape.Rectangular
-        ? 0
-        : anchorHeight * 0.1464;
-    // This is to center the badge in the corner of the anchor element
-    const badgeCenteringXOffset = badgeWidth / 2;
-    const badgeCenteringYOffset = badgeHeight / 2;
+    const edgeInset: DimensionValue =
+      positionAnchorShape === BadgeWrapperPositionAnchorShape.Circular ? 4 : 0;
+    const isTop =
+      position === BadgeWrapperPosition.TopRight ||
+      position === BadgeWrapperPosition.TopLeft;
+    const isLeft =
+      position === BadgeWrapperPosition.TopLeft ||
+      position === BadgeWrapperPosition.BottomLeft;
+    const halfBadgeSize = 8;
 
-    const finalXOffset =
-      anchorShapeXOffset - badgeCenteringXOffset + positionXOffset;
-    const finalYOffset =
-      anchorShapeYOffset - badgeCenteringYOffset + positionYOffset;
-    switch (position) {
-      case BadgeWrapperPosition.TopRight:
-        return {
-          top: finalYOffset,
-          right: finalXOffset,
-        };
-      case BadgeWrapperPosition.BottomLeft:
-        return {
-          bottom: finalYOffset,
-          left: finalXOffset,
-        };
-      case BadgeWrapperPosition.TopLeft:
-        return {
-          top: finalYOffset,
-          left: finalXOffset,
-        };
-      case BadgeWrapperPosition.BottomRight:
-      default:
-        return {
-          bottom: finalYOffset,
-          right: finalXOffset,
-        };
-    }
-  }, [
-    position,
-    positionAnchorShape,
-    anchorWidth,
-    anchorHeight,
-    badgeWidth,
-    badgeHeight,
-    positionXOffset,
-    positionYOffset,
-    customPosition,
-  ]);
+    return {
+      ...(isTop ? { top: edgeInset } : { bottom: edgeInset }),
+      ...(isLeft ? { left: edgeInset } : { right: edgeInset }),
+      transform: [
+        {
+          translateX:
+            (isLeft ? -halfBadgeSize : halfBadgeSize) + positionXOffset,
+        },
+        {
+          translateY:
+            (isTop ? -halfBadgeSize : halfBadgeSize) + positionYOffset,
+        },
+      ],
+    };
+  })();
 
   return (
     <View
       {...props}
-      style={[tw.style('relative self-start', twClassName), style]}
+      style={[tw.style('relative flex-row self-start', twClassName), style]}
     >
-      <View onLayout={getAnchorSize} {...childrenContainerProps}>
-        {children}
-      </View>
+      <View {...childrenContainerProps}>{children}</View>
       <View
-        onLayout={getBadgeSize}
-        style={[tw.style('absolute'), { ...finalPositions }]}
         {...badgeContainerProps}
+        style={[
+          tw.style('absolute'),
+          {
+            width: 16,
+            height: 16,
+            alignItems: 'center',
+            justifyContent: 'center',
+          },
+          finalPositions,
+          badgeContainerProps?.style,
+        ]}
       >
         {badge}
       </View>

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -59,7 +59,7 @@ export const BadgeWrapper = ({
       <View
         {...badgeContainerProps}
         style={[
-          tw.style('absolute'),
+          tw.style('absolute items-center justify-center'),
           finalPositions,
           badgeContainerProps?.style,
         ]}

--- a/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react-native/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -4,13 +4,13 @@ import {
 } from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
-import type { StyleProp, ViewStyle } from 'react-native';
+import type { DimensionValue, StyleProp, ViewStyle } from 'react-native';
 import { View } from 'react-native';
 
 import type { BadgeWrapperProps } from './BadgeWrapper.types';
 
-const CIRCULAR_BADGE_OVERLAP = -8;
-const RECTANGULAR_BADGE_OVERLAP = -6;
+const CIRCULAR_ANCHOR_EDGE_INSET: DimensionValue = '7%';
+const RECTANGULAR_ANCHOR_EDGE_INSET: DimensionValue = '11%';
 
 export const BadgeWrapper = ({
   children,
@@ -33,16 +33,18 @@ export const BadgeWrapper = ({
   const isLeft =
     position === BadgeWrapperPosition.TopLeft ||
     position === BadgeWrapperPosition.BottomLeft;
-  const badgeOverlap =
+  const edgeInset =
     positionAnchorShape === BadgeWrapperPositionAnchorShape.Circular
-      ? CIRCULAR_BADGE_OVERLAP
-      : RECTANGULAR_BADGE_OVERLAP;
+      ? CIRCULAR_ANCHOR_EDGE_INSET
+      : RECTANGULAR_ANCHOR_EDGE_INSET;
   const finalPositions: StyleProp<ViewStyle> = customPosition
     ? (customPosition as StyleProp<ViewStyle>)
     : {
-        ...(isTop ? { top: badgeOverlap } : { bottom: badgeOverlap }),
-        ...(isLeft ? { left: badgeOverlap } : { right: badgeOverlap }),
+        ...(isTop ? { top: edgeInset } : { bottom: edgeInset }),
+        ...(isLeft ? { left: edgeInset } : { right: edgeInset }),
         transform: [
+          { translateX: isLeft ? '-50%' : '50%' },
+          { translateY: isTop ? '-50%' : '50%' },
           { translateX: positionXOffset },
           { translateY: positionYOffset },
         ],

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -262,7 +262,7 @@ export const Badge: Story = {
             key={`status-${size}`}
             position={BadgeWrapperPosition.TopRight}
             positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
-            badge={<BadgeStatus status={BadgeStatusStatus.New} />}
+            badge={<BadgeStatus status={BadgeStatusStatus.Attention} />}
           >
             <ButtonIcon
               iconName={IconName.Menu}

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -13,6 +13,7 @@ import { SAMPLE_AVATARNETWORK_URIS } from '../AvatarNetwork/AvatarNetwork.dev';
 import { AvatarToken } from '../AvatarToken';
 import { SAMPLE_AVATARTOKEN_URIS } from '../AvatarToken/AvatarToken.dev';
 import { BadgeCount } from '../BadgeCount';
+import { BadgeIcon } from '../BadgeIcon';
 import { BadgeNetwork } from '../BadgeNetwork';
 import { BadgeStatus, BadgeStatusStatus } from '../BadgeStatus';
 import { ButtonIcon } from '../ButtonIcon';
@@ -260,6 +261,18 @@ export const Badge: Story = {
         position={BadgeWrapperPosition.TopRight}
         positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
         badge={<BadgeStatus status={BadgeStatusStatus.New} />}
+      >
+        <ButtonIcon
+          iconName={IconName.Menu}
+          size={ButtonIconSize.Md}
+          ariaLabel="Open menu"
+        />
+      </BadgeWrapper>
+      {/* Icon badge example. */}
+      <BadgeWrapper
+        position={BadgeWrapperPosition.BottomRight}
+        positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+        badge={<BadgeIcon iconName={IconName.Snaps} />}
       >
         <ButtonIcon
           iconName={IconName.Menu}

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.stories.tsx
@@ -13,7 +13,6 @@ import { SAMPLE_AVATARNETWORK_URIS } from '../AvatarNetwork/AvatarNetwork.dev';
 import { AvatarToken } from '../AvatarToken';
 import { SAMPLE_AVATARTOKEN_URIS } from '../AvatarToken/AvatarToken.dev';
 import { BadgeCount } from '../BadgeCount';
-import { BadgeIcon } from '../BadgeIcon';
 import { BadgeNetwork } from '../BadgeNetwork';
 import { BadgeStatus, BadgeStatusStatus } from '../BadgeStatus';
 import { ButtonIcon } from '../ButtonIcon';
@@ -256,30 +255,23 @@ export const Badge: Story = {
           </BadgeWrapper>
         ))}
       </div>
-      {/* Status indicator example. */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.TopRight}
-        positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
-        badge={<BadgeStatus status={BadgeStatusStatus.New} />}
-      >
-        <ButtonIcon
-          iconName={IconName.Menu}
-          size={ButtonIconSize.Md}
-          ariaLabel="Open menu"
-        />
-      </BadgeWrapper>
-      {/* Icon badge example. */}
-      <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
-        badge={<BadgeIcon iconName={IconName.Snaps} />}
-      >
-        <ButtonIcon
-          iconName={IconName.Menu}
-          size={ButtonIconSize.Md}
-          ariaLabel="Open menu"
-        />
-      </BadgeWrapper>
+      {/* Status indicator examples. */}
+      <div className="flex flex-row gap-4">
+        {Object.values(ButtonIconSize).map((size) => (
+          <BadgeWrapper
+            key={`status-${size}`}
+            position={BadgeWrapperPosition.TopRight}
+            positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+            badge={<BadgeStatus status={BadgeStatusStatus.New} />}
+          >
+            <ButtonIcon
+              iconName={IconName.Menu}
+              size={size}
+              ariaLabel={`Open menu (${size})`}
+            />
+          </BadgeWrapper>
+        ))}
+      </div>
     </div>
   ),
 };

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -32,7 +32,11 @@ describe('BadgeWrapper', () => {
     // Ensure the parent element exists
     expect(badgeEl.parentElement).toBeInTheDocument();
     // Apply styles check only after confirming parent exists
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '7%', right: '7%' });
+    expect(badgeEl.parentElement).toHaveStyle({
+      bottom: '7%',
+      right: '7%',
+      transform: 'translate(50%, 50%)',
+    });
   });
 
   it('applies BottomLeft position correctly', () => {
@@ -46,7 +50,11 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '7%', left: '7%' });
+    expect(badgeEl.parentElement).toHaveStyle({
+      bottom: '7%',
+      left: '7%',
+      transform: 'translate(-50%, 50%)',
+    });
   });
 
   it('applies TopLeft position correctly', () => {
@@ -60,7 +68,11 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ top: '7%', left: '7%' });
+    expect(badgeEl.parentElement).toHaveStyle({
+      top: '7%',
+      left: '7%',
+      transform: 'translate(-50%, -50%)',
+    });
   });
 
   it('applies TopRight position correctly', () => {
@@ -74,7 +86,11 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ top: '7%', right: '7%' });
+    expect(badgeEl.parentElement).toHaveStyle({
+      top: '7%',
+      right: '7%',
+      transform: 'translate(50%, -50%)',
+    });
   });
 
   it('respects positionXOffset and positionYOffset', () => {
@@ -89,7 +105,11 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '7%', right: '7%' });
+    expect(badgeEl.parentElement).toHaveStyle({
+      bottom: '7%',
+      right: '7%',
+      transform: 'translate(calc(50% + 5px), calc(50% + 10px))',
+    });
   });
 
   it('uses Rectangular anchor shape (no extra shape offset)', () => {
@@ -108,6 +128,7 @@ describe('BadgeWrapper', () => {
     expect(badgeEl.parentElement).toHaveStyle({
       bottom: '11%',
       right: '11%',
+      transform: 'translate(calc(50% + 3px), calc(50% + 4px))',
     });
   });
 
@@ -159,7 +180,7 @@ describe('BadgeWrapper', () => {
     expect(ref.current?.tagName).toBe('DIV');
   });
 
-  it('uses static badge dimensions and transforms', () => {
+  it('uses percentage badge transforms without fixed dimensions', () => {
     render(
       <BadgeWrapper badge={<div data-testid="badge-m" />}>
         <div data-testid="anchor-m" />
@@ -175,9 +196,9 @@ describe('BadgeWrapper', () => {
     expect(badgeDiv).toHaveStyle({
       bottom: '7%',
       right: '7%',
-      width: '16px',
-      height: '16px',
-      transform: 'translate(8px, 8px)',
+      transform: 'translate(50%, 50%)',
     });
+
+    expect(badgeDiv).not.toHaveStyle({ width: '16px', height: '16px' });
   });
 });

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -32,7 +32,7 @@ describe('BadgeWrapper', () => {
     // Ensure the parent element exists
     expect(badgeEl.parentElement).toBeInTheDocument();
     // Apply styles check only after confirming parent exists
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '4px', right: '4px' });
+    expect(badgeEl.parentElement).toHaveStyle({ bottom: '7%', right: '7%' });
   });
 
   it('applies BottomLeft position correctly', () => {
@@ -46,7 +46,7 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '4px', left: '4px' });
+    expect(badgeEl.parentElement).toHaveStyle({ bottom: '7%', left: '7%' });
   });
 
   it('applies TopLeft position correctly', () => {
@@ -60,7 +60,7 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ top: '4px', left: '4px' });
+    expect(badgeEl.parentElement).toHaveStyle({ top: '7%', left: '7%' });
   });
 
   it('applies TopRight position correctly', () => {
@@ -74,7 +74,7 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ top: '4px', right: '4px' });
+    expect(badgeEl.parentElement).toHaveStyle({ top: '7%', right: '7%' });
   });
 
   it('respects positionXOffset and positionYOffset', () => {
@@ -89,7 +89,7 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '4px', right: '4px' });
+    expect(badgeEl.parentElement).toHaveStyle({ bottom: '7%', right: '7%' });
   });
 
   it('uses Rectangular anchor shape (no extra shape offset)', () => {
@@ -105,7 +105,10 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '0px', right: '0px' });
+    expect(badgeEl.parentElement).toHaveStyle({
+      bottom: '11%',
+      right: '11%',
+    });
   });
 
   it('overrides with customPosition when provided', () => {
@@ -170,8 +173,8 @@ describe('BadgeWrapper', () => {
     const badgeDiv = badgeEl.parentElement!;
 
     expect(badgeDiv).toHaveStyle({
-      bottom: '4px',
-      right: '4px',
+      bottom: '7%',
+      right: '7%',
       width: '16px',
       height: '16px',
       transform: 'translate(8px, 8px)',

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -170,6 +170,32 @@ describe('BadgeWrapper', () => {
     expect(wrapper).toHaveStyle({ margin: '7px' });
   });
 
+  it('merges badge container className and style', () => {
+    render(
+      <BadgeWrapper
+        badgeContainerProps={{
+          id: 'badge-container',
+          className: 'bg-default',
+          style: { margin: 7 },
+        }}
+        badge={<div />}
+      >
+        <div />
+      </BadgeWrapper>,
+    );
+
+    const badgeContainer = document.getElementById('badge-container');
+    expect(badgeContainer).toBeInTheDocument();
+    expect(badgeContainer).toHaveClass(
+      'absolute',
+      'inline-flex',
+      'items-center',
+      'justify-center',
+      'bg-default',
+    );
+    expect(badgeContainer).toHaveStyle({ margin: '7px' });
+  });
+
   it('forwards ref to the container div', () => {
     const ref = createRef<HTMLDivElement>();
     render(

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.test.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.test.tsx
@@ -8,26 +8,6 @@ import React, { createRef } from 'react';
 import { BadgeWrapper } from './BadgeWrapper';
 
 describe('BadgeWrapper', () => {
-  beforeEach(() => {
-    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
-      width: 0,
-      height: 0,
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => {
-        // Empty implementation needed for mock
-        return '';
-      },
-    });
-  });
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   it('renders the wrapper, anchor, and badge elements', () => {
     render(
       <BadgeWrapper
@@ -52,7 +32,7 @@ describe('BadgeWrapper', () => {
     // Ensure the parent element exists
     expect(badgeEl.parentElement).toBeInTheDocument();
     // Apply styles check only after confirming parent exists
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '0px', right: '0px' });
+    expect(badgeEl.parentElement).toHaveStyle({ bottom: '4px', right: '4px' });
   });
 
   it('applies BottomLeft position correctly', () => {
@@ -66,7 +46,7 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '0px', left: '0px' });
+    expect(badgeEl.parentElement).toHaveStyle({ bottom: '4px', left: '4px' });
   });
 
   it('applies TopLeft position correctly', () => {
@@ -80,7 +60,7 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ top: '0px', left: '0px' });
+    expect(badgeEl.parentElement).toHaveStyle({ top: '4px', left: '4px' });
   });
 
   it('applies TopRight position correctly', () => {
@@ -94,7 +74,7 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ top: '0px', right: '0px' });
+    expect(badgeEl.parentElement).toHaveStyle({ top: '4px', right: '4px' });
   });
 
   it('respects positionXOffset and positionYOffset', () => {
@@ -109,7 +89,7 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '10px', right: '5px' });
+    expect(badgeEl.parentElement).toHaveStyle({ bottom: '4px', right: '4px' });
   });
 
   it('uses Rectangular anchor shape (no extra shape offset)', () => {
@@ -125,7 +105,7 @@ describe('BadgeWrapper', () => {
     );
     const badgeEl = screen.getByTestId('badge');
     expect(badgeEl.parentElement).toBeInTheDocument();
-    expect(badgeEl.parentElement).toHaveStyle({ bottom: '4px', right: '3px' });
+    expect(badgeEl.parentElement).toHaveStyle({ bottom: '0px', right: '0px' });
   });
 
   it('overrides with customPosition when provided', () => {
@@ -176,41 +156,7 @@ describe('BadgeWrapper', () => {
     expect(ref.current?.tagName).toBe('DIV');
   });
 
-  it('calculates finalPositions correctly', () => {
-    jest.restoreAllMocks();
-    const anchorRect = {
-      width: 100,
-      height: 50,
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => {
-        // Empty implementation needed for mock
-        return '';
-      },
-    };
-    const badgeRect = {
-      width: 20,
-      height: 10,
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => {
-        // Empty implementation needed for mock
-        return '';
-      },
-    };
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockReturnValueOnce(anchorRect)
-      .mockReturnValueOnce(badgeRect);
-
+  it('uses static badge dimensions and transforms', () => {
     render(
       <BadgeWrapper badge={<div data-testid="badge-m" />}>
         <div data-testid="anchor-m" />
@@ -223,16 +169,12 @@ describe('BadgeWrapper', () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const badgeDiv = badgeEl.parentElement!;
 
-    // Computed offsets:
-    // anchorShapeXOffset = 100 * .1464 = 14.64
-    // badgeCenteringXOffset = 20/2 = 10
-    // finalXOffset = 14.64 - 10 = 4.64
-    // anchorShapeYOffset = 50 * .1464 = 7.32
-    // badgeCenteringYOffset = 10/2 = 5
-    // finalYOffset = 7.32 - 5 = 2.32
-    const bottom = parseFloat(badgeDiv.style.bottom);
-    const right = parseFloat(badgeDiv.style.right);
-    expect(bottom).toBeCloseTo(2.32, 2);
-    expect(right).toBeCloseTo(4.64, 2);
+    expect(badgeDiv).toHaveStyle({
+      bottom: '4px',
+      right: '4px',
+      width: '16px',
+      height: '16px',
+      transform: 'translate(8px, 8px)',
+    });
   });
 });

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -9,9 +9,11 @@ import { twMerge } from '../../utils/tw-merge';
 
 import type { BadgeWrapperProps } from './BadgeWrapper.types';
 
-const STATIC_BADGE_SIZE = 16;
 const CIRCULAR_ANCHOR_EDGE_INSET = '7%';
 const RECTANGULAR_ANCHOR_EDGE_INSET = '11%';
+
+const getTransformValue = (percentage: string, offset: number) =>
+  offset === 0 ? percentage : `calc(${percentage} + ${offset}px)`;
 
 export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
   (
@@ -46,7 +48,7 @@ export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
       : {
           ...(isTop ? { top: edgeInset } : { bottom: edgeInset }),
           ...(isLeft ? { left: edgeInset } : { right: edgeInset }),
-          transform: `translate(${(isLeft ? -8 : 8) + positionXOffset}px, ${(isTop ? -8 : 8) + positionYOffset}px)`,
+          transform: `translate(${getTransformValue(isLeft ? '-50%' : '50%', positionXOffset)}, ${getTransformValue(isTop ? '-50%' : '50%', positionYOffset)})`,
         };
 
     const containerClassName = twMerge(
@@ -62,10 +64,8 @@ export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
 
         <div
           {...badgeContainerProps}
-          className="absolute inline-flex size-4 items-center justify-center"
+          className="absolute inline-flex items-center justify-center"
           style={{
-            width: STATIC_BADGE_SIZE,
-            height: STATIC_BADGE_SIZE,
             ...finalPositions,
             ...(badgeContainerProps?.style as CSSProperties),
           }}

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -64,7 +64,10 @@ export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
 
         <div
           {...badgeContainerProps}
-          className="absolute inline-flex items-center justify-center"
+          className={twMerge(
+            'absolute inline-flex items-center justify-center',
+            badgeContainerProps?.className,
+          )}
           style={{
             ...finalPositions,
             ...(badgeContainerProps?.style as CSSProperties),

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -3,17 +3,14 @@ import {
   BadgeWrapperPositionAnchorShape,
 } from '@metamask/design-system-shared';
 import type { CSSProperties } from 'react';
-import React, {
-  forwardRef,
-  useState,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { forwardRef } from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
 
 import type { BadgeWrapperProps } from './BadgeWrapper.types';
+
+const STATIC_BADGE_SIZE = 16;
+const CIRCULAR_ANCHOR_EDGE_INSET = 4;
 
 export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
   (
@@ -33,72 +30,28 @@ export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
     },
     ref,
   ) => {
-    const [anchorWidth, setAnchorWidth] = useState(0);
-    const [anchorHeight, setAnchorHeight] = useState(0);
-    const [badgeWidth, setBadgeWidth] = useState(0);
-    const [badgeHeight, setBadgeHeight] = useState(0);
-
-    const anchorRef = useRef<HTMLDivElement | null>(null);
-    const badgeRef = useRef<HTMLDivElement | null>(null);
-
-    // Measure both elements once on mount
-    useLayoutEffect(() => {
-      if (anchorRef.current) {
-        const { width, height } = anchorRef.current.getBoundingClientRect();
-        setAnchorWidth(width);
-        setAnchorHeight(height);
-      }
-      if (badgeRef.current) {
-        const { width, height } = badgeRef.current.getBoundingClientRect();
-        setBadgeWidth(width);
-        setBadgeHeight(height);
-      }
-    }, []); // empty deps → run only after first render
-
-    const finalPositions = useMemo<React.CSSProperties>(() => {
+    const finalPositions: React.CSSProperties = (() => {
       if (customPosition) {
         return customPosition as CSSProperties;
       }
 
-      const anchorShapeXOffset =
-        positionAnchorShape === BadgeWrapperPositionAnchorShape.Rectangular
-          ? 0
-          : anchorWidth * 0.1464;
-      const anchorShapeYOffset =
-        positionAnchorShape === BadgeWrapperPositionAnchorShape.Rectangular
-          ? 0
-          : anchorHeight * 0.1464;
+      const edgeInset =
+        positionAnchorShape === BadgeWrapperPositionAnchorShape.Circular
+          ? CIRCULAR_ANCHOR_EDGE_INSET
+          : 0;
+      const isTop =
+        position === BadgeWrapperPosition.TopRight ||
+        position === BadgeWrapperPosition.TopLeft;
+      const isLeft =
+        position === BadgeWrapperPosition.TopLeft ||
+        position === BadgeWrapperPosition.BottomLeft;
 
-      const badgeCenteringXOffset = badgeWidth / 2;
-      const badgeCenteringYOffset = badgeHeight / 2;
-
-      const finalXOffset =
-        anchorShapeXOffset - badgeCenteringXOffset + positionXOffset;
-      const finalYOffset =
-        anchorShapeYOffset - badgeCenteringYOffset + positionYOffset;
-
-      switch (position) {
-        case BadgeWrapperPosition.TopRight:
-          return { top: finalYOffset, right: finalXOffset };
-        case BadgeWrapperPosition.TopLeft:
-          return { top: finalYOffset, left: finalXOffset };
-        case BadgeWrapperPosition.BottomLeft:
-          return { bottom: finalYOffset, left: finalXOffset };
-        case BadgeWrapperPosition.BottomRight:
-        default:
-          return { bottom: finalYOffset, right: finalXOffset };
-      }
-    }, [
-      position,
-      positionAnchorShape,
-      anchorWidth,
-      anchorHeight,
-      badgeWidth,
-      badgeHeight,
-      positionXOffset,
-      positionYOffset,
-      customPosition,
-    ]);
+      return {
+        ...(isTop ? { top: edgeInset } : { bottom: edgeInset }),
+        ...(isLeft ? { left: edgeInset } : { right: edgeInset }),
+        transform: `translate(${(isLeft ? -8 : 8) + positionXOffset}px, ${(isTop ? -8 : 8) + positionYOffset}px)`,
+      };
+    })();
 
     const containerClassName = twMerge(
       'relative inline-flex self-start',
@@ -107,19 +60,19 @@ export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
 
     return (
       <div ref={ref} className={containerClassName} style={style} {...props}>
-        <div
-          className="inline-flex"
-          ref={anchorRef}
-          {...childrenContainerProps}
-        >
+        <div className="inline-flex" {...childrenContainerProps}>
           {children}
         </div>
 
         <div
-          ref={badgeRef}
-          className="absolute"
-          style={finalPositions}
           {...badgeContainerProps}
+          className="absolute inline-flex size-4 items-center justify-center"
+          style={{
+            width: STATIC_BADGE_SIZE,
+            height: STATIC_BADGE_SIZE,
+            ...finalPositions,
+            ...(badgeContainerProps?.style as CSSProperties),
+          }}
         >
           {badge}
         </div>

--- a/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
+++ b/packages/design-system-react/src/components/BadgeWrapper/BadgeWrapper.tsx
@@ -10,7 +10,8 @@ import { twMerge } from '../../utils/tw-merge';
 import type { BadgeWrapperProps } from './BadgeWrapper.types';
 
 const STATIC_BADGE_SIZE = 16;
-const CIRCULAR_ANCHOR_EDGE_INSET = 4;
+const CIRCULAR_ANCHOR_EDGE_INSET = '7%';
+const RECTANGULAR_ANCHOR_EDGE_INSET = '11%';
 
 export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
   (
@@ -30,28 +31,23 @@ export const BadgeWrapper = forwardRef<HTMLDivElement, BadgeWrapperProps>(
     },
     ref,
   ) => {
-    const finalPositions: React.CSSProperties = (() => {
-      if (customPosition) {
-        return customPosition as CSSProperties;
-      }
-
-      const edgeInset =
-        positionAnchorShape === BadgeWrapperPositionAnchorShape.Circular
-          ? CIRCULAR_ANCHOR_EDGE_INSET
-          : 0;
-      const isTop =
-        position === BadgeWrapperPosition.TopRight ||
-        position === BadgeWrapperPosition.TopLeft;
-      const isLeft =
-        position === BadgeWrapperPosition.TopLeft ||
-        position === BadgeWrapperPosition.BottomLeft;
-
-      return {
-        ...(isTop ? { top: edgeInset } : { bottom: edgeInset }),
-        ...(isLeft ? { left: edgeInset } : { right: edgeInset }),
-        transform: `translate(${(isLeft ? -8 : 8) + positionXOffset}px, ${(isTop ? -8 : 8) + positionYOffset}px)`,
-      };
-    })();
+    const isTop =
+      position === BadgeWrapperPosition.TopRight ||
+      position === BadgeWrapperPosition.TopLeft;
+    const isLeft =
+      position === BadgeWrapperPosition.TopLeft ||
+      position === BadgeWrapperPosition.BottomLeft;
+    const edgeInset =
+      positionAnchorShape === BadgeWrapperPositionAnchorShape.Circular
+        ? CIRCULAR_ANCHOR_EDGE_INSET
+        : RECTANGULAR_ANCHOR_EDGE_INSET;
+    const finalPositions: React.CSSProperties = customPosition
+      ? (customPosition as CSSProperties)
+      : {
+          ...(isTop ? { top: edgeInset } : { bottom: edgeInset }),
+          ...(isLeft ? { left: edgeInset } : { right: edgeInset }),
+          transform: `translate(${(isLeft ? -8 : 8) + positionXOffset}px, ${(isTop ? -8 : 8) + positionYOffset}px)`,
+        };
 
     const containerClassName = twMerge(
       'relative inline-flex self-start',


### PR DESCRIPTION
## **Description**

`BadgeWrapper` contained a critical layout feedback loop that could peg the React Native JS thread at 90–100% CPU indefinitely.

The component measured both the anchor and badge, used those measurements to position the badge, and then triggered another layout change. Sub-pixel rounding could change the next measurement, causing the position to oscillate forever. The issue was dormant until a real badge rendered through `BadgeWrapper`, which meant it could affect any mobile surface using the component. Known examples include wallet notification badges and network badges on token logos in Earn.

This PR follows the original fix in [metamask-design-system#1471](https://github.com/MetaMask/metamask-design-system/pull/1471) and simplifies the implementation further:

- Removes layout listeners, measurements, state, effects, and recalculation logic from React and React Native.
- Uses static circular and rectangular edge insets with percentage transforms based on the badge’s own dimensions.
- Keeps badges content-sized instead of forcing a fixed badge size.
- Preserves `positionXOffset`, `positionYOffset`, and `customPosition` for cases that need fine-tuning or a fully custom placement.
- Preserves consumer-provided badge container classes and styles.

This approach is also consistent with the legacy Extension `BadgeWrapper`, which used static percentage positioning in production. The MMDS migration introduced unnecessary measurement complexity; this change returns to the simpler, production-tested positioning model:
[legacy Extension BadgeWrapper styles](https://github.com/MetaMask/metamask-extension/blob/main/ui/components/component-library/badge-wrapper/badge-wrapper.scss#L35-L36).

An audit of BadgeWrapper usage across Mobile and Extension found that these static defaults meet the positioning needs of about 95% of use cases. The override props cover the remaining cases without reintroducing layout measurement.

The React Native implementation uses percentage translations available in React Native 0.75+ with the New Architecture. This repository uses React Native 0.81.5 with the New Architecture enabled.

Performance investigation context is available in the [Slack thread](https://consensys.slack.com/archives/C07KB8HRZ4J/p1788187006207879?thread_ts=1784549133.381919&cid=C07KB8HRZ4J).

## **Related issues**

Fixes: N/A

Follow-up to [metamask-design-system#1471](https://github.com/MetaMask/metamask-design-system/pull/1471).

## **Manual testing steps**

1. Run `yarn storybook` and open `React Components/BadgeWrapper/Badge`.
2. Confirm the Badge story shows all AvatarToken, AvatarAccount, and ButtonIcon sizes.
3. Confirm the notification and red status badges remain centered at each ButtonIcon corner.
4. Run `yarn storybook:ios` or the React Native Storybook web target and open `Components/BadgeWrapper/Badge`.
5. Confirm the React Native story matches the React story across light and dark themes.
6. Verify custom positions and X/Y offsets still override the defaults.

## **Screenshots/Recordings**

Before and after performance recordings and Storybook comparisons are included in the PR discussion.

### **Before**

Story showing the dynamic positioning of the most common badge usage

**React Native**

<img width="586" height="316" alt="Screenshot 2026-08-31 at 3 29 36 PM" src="https://github.com/user-attachments/assets/4bb8c0b3-6e69-4f63-b7be-2050cd479498" />

**React** 

<img width="654" height="677" alt="Screenshot 2026-08-31 at 3 29 
https://github.com/user-attachments/assets/48d35c39-e650-46e6-8dbe-adfad5a627b3


All stories run through to ensure no visual regressions in other props

https://github.com/user-attachments/assets/14168443-7750-4fb6-8feb-94874bd48237


https://github.com/user-attachments/assets/c7249a46-a4ae-4dc8-aba2-eaaf5cc6c55e


### **After**

See that the positioning doesn't change much with static and much more performant positioning.

**React Native**

<img width="607" height="375" alt="Screenshot 2026-08-31 at 3 08 53 PM" src="https://github.com/user-attachments/assets/f5c09d99-d2f0-483e-8922-bad76e11d927" />

**React** 

<img width="715" height="722" alt="Screenshot 2026-08-31 at 3 08 50 PM" src="https://github.com/user-attachments/assets/7c194e6c-46e5-4c62-96a6-035e1355c77c" />

All stories run through to ensure no visual regressions in other props

https://github.com/user-attachments/assets/3e1ac961-d81c-4285-9796-31d1b6ad0563

https://github.com/user-attachments/assets/9555dae9-00aa-4c5a-bebd-c861b7173213



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

