### PR TITLE
Release 63.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "62.0.0",
+  "version": "63.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.42.1]
 
-### Uncategorized
+### Changed
 
-- fix: prevent BadgeWrapper layout loop ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))
-- test: update BadgeWrapper stories ([#1473](https://github.com/MetaMask/metamask-design-system/pull/1473))
-- docs: add Content guidelines sections to component READMEs ([#1466](https://github.com/MetaMask/metamask-design-system/pull/1466))
+- Added content guidelines to component documentation, including sentence case, punctuation, and prop-specific examples ([#1466](https://github.com/MetaMask/metamask-design-system/pull/1466))
+
+### Fixed
+
+- Fixed a `BadgeWrapper` layout feedback loop that could cause continuous layout updates and high CPU usage ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))
 
 ## [0.42.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.1]
+
 ### Uncategorized
 
 - fix: prevent BadgeWrapper layout loop ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))
@@ -716,7 +718,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.1...HEAD
+[0.42.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.0...@metamask/design-system-react-native@0.42.1
 [0.42.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.41.0...@metamask/design-system-react-native@0.42.0
 [0.41.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.40.0...@metamask/design-system-react-native@0.41.0
 [0.40.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.39.1...@metamask/design-system-react-native@0.40.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: prevent BadgeWrapper layout loop ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))
+- test: update BadgeWrapper stories ([#1473](https://github.com/MetaMask/metamask-design-system/pull/1473))
+- docs: add Content guidelines sections to component READMEs ([#1466](https://github.com/MetaMask/metamask-design-system/pull/1466))
+
 ## [0.42.0]
 
 ### Changed

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: prevent BadgeWrapper layout loop ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))
+- test: update BadgeWrapper stories ([#1473](https://github.com/MetaMask/metamask-design-system/pull/1473))
+- docs: add Content guidelines sections to component READMEs ([#1466](https://github.com/MetaMask/metamask-design-system/pull/1466))
+- docs(react): fix AvatarGroup migration guide for extension ([#1460](https://github.com/MetaMask/metamask-design-system/pull/1460))
+
 ## [0.38.0]
 
 ### Changed

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.38.1]
 
-### Uncategorized
+### Changed
 
-- fix: prevent BadgeWrapper layout loop ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))
-- test: update BadgeWrapper stories ([#1473](https://github.com/MetaMask/metamask-design-system/pull/1473))
-- docs: add Content guidelines sections to component READMEs ([#1466](https://github.com/MetaMask/metamask-design-system/pull/1466))
-- docs(react): fix AvatarGroup migration guide for extension ([#1460](https://github.com/MetaMask/metamask-design-system/pull/1460))
+- Added content guidelines to component documentation, including sentence case, punctuation, and prop-specific examples ([#1466](https://github.com/MetaMask/metamask-design-system/pull/1466))
+- Updated the `AvatarGroup` migration guide with extension-specific prop mappings and migration examples ([#1460](https://github.com/MetaMask/metamask-design-system/pull/1460))
+
+### Fixed
+
+- Fixed a `BadgeWrapper` layout feedback loop that could cause continuous layout updates and high CPU usage ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))
 
 ## [0.38.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1]
+
 ### Uncategorized
 
 - fix: prevent BadgeWrapper layout loop ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))
@@ -516,7 +518,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.1...HEAD
+[0.38.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.0...@metamask/design-system-react@0.38.1
 [0.38.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.0...@metamask/design-system-react@0.38.0
 [0.37.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.36.0...@metamask/design-system-react@0.37.0
 [0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.35.2...@metamask/design-system-react@0.36.0

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Release 63.0.0

This release fixes a `BadgeWrapper` layout feedback loop and adds consumer-facing content guidance to component documentation.

### 📦 Package Versions

- `@metamask/design-system-react`: **0.38.1**
- `@metamask/design-system-react-native`: **0.42.1**

### 🌐 React Web Updates (0.38.1)

#### Changed

- Added content guidelines to component documentation, including sentence case, punctuation, and prop-specific examples ([#1466](https://github.com/MetaMask/metamask-design-system/pull/1466))
- Updated the `AvatarGroup` migration guide with extension-specific prop mappings and migration examples ([#1460](https://github.com/MetaMask/metamask-design-system/pull/1460))

#### Fixed

- Fixed a `BadgeWrapper` layout feedback loop that could cause continuous layout updates and high CPU usage ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))

Tested fix with Flashlight in preview package and results look accurate

<img width="1080" height="859" alt="Screenshot 2026-09-01 at 11 44 32 AM" src="https://github.com/user-attachments/assets/0e0f7db1-9b87-4186-8777-a9f467dae62d" />

### 📱 React Native Updates (0.42.1)

#### Changed

- Added content guidelines to component documentation, including sentence case, punctuation, and prop-specific examples ([#1466](https://github.com/MetaMask/metamask-design-system/pull/1466))

#### Fixed

- Fixed a `BadgeWrapper` layout feedback loop that could cause continuous layout updates and high CPU usage ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474))

### ⚠️ Breaking Changes

There are no breaking changes in this release.

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-react: patch (`0.38.0 → 0.38.1`) - bug fix and documentation updates
  - [x] design-system-react-native: patch (`0.42.0 → 0.42.1`) - bug fix and documentation updates
- [x] Breaking changes documented with migration guidance - no breaking changes in this release
- [x] Migration guides updated with before/after examples - no breaking changes in this release
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [ ] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Patch release, but the BadgeWrapper layout fix changes shared overlay layout behavior on web and native; apps heavy on badge overlays should smoke-test after upgrade.
> 
> **Overview**
> **Release 63.0.0** bumps the monorepo to `63.0.0` and publishes patch releases for **`@metamask/design-system-react` (`0.38.1`)** and **`@metamask/design-system-react-native` (`0.42.1`)**, with new changelog sections and compare links only in this diff (no source changes here).
> 
> Consumer-facing notes recorded in the changelogs: both platforms fix a **`BadgeWrapper` layout feedback loop** that could trigger repeated layout and high CPU ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474)). Both add **content guidelines** to component docs (sentence case, punctuation, prop examples) ([#1466](https://github.com/MetaMask/metamask-design-system/pull/1466)). **React web** also expands the **`AvatarGroup` migration guide** with extension-specific prop mappings ([#1460](https://github.com/MetaMask/metamask-design-system/pull/1460)). No breaking changes are called out for this release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e13f98e5502a6ea52ea0df46f7d86f787c3820c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->