### PR TITLE
feat(storybook): add Storybook MCP to React Native web and Metro

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -2,6 +2,9 @@
   "mcpServers": {
     "storybook-mcp": {
       "url": "http://localhost:6006/mcp"
+    },
+    "storybook-react-native-mcp": {
+      "url": "http://localhost:6007/mcp"
     }
   }
 }

--- a/.cursor/rules/component-documentation.md
+++ b/.cursor/rules/component-documentation.md
@@ -7,7 +7,7 @@ Documentation standards for Storybook stories and README files for React and Rea
 ### README Structure
 
 - **React Web**: Use `.mdx` format with Storybook Canvas integration
-- **React Native**: Use `.md` format with comprehensive static examples
+- **React Native**: Use `.md` format with comprehensive static examples. Do not convert these to MDX for Storybook yet — on-device Storybook cannot render MDX, and shared CSF stories that import `.mdx` break Metro. React Native **web** Storybook can render MDX via `@storybook/addon-docs`, but that must stay web-only (not imported from native stories).
 - **ALWAYS** follow templates exactly: @docs/component-readme-examples/
 - **Cross-platform**: Keep documentation identical across web/native (same sections, descriptions, examples)
 
@@ -114,6 +114,7 @@ Follow **Storybook controls (cross-platform)** above; mobile panels work best wi
 ```bash
 # Run Storybook
 yarn storybook                # React web (port 6006)
+yarn workspace @metamask/storybook-react-native storybook:web  # React Native web (port 6007)
 yarn storybook:ios:build      # React Native iOS dev client (first time / native dep changes)
 yarn storybook:ios            # React Native iOS (Metro + dev client)
 yarn storybook:android:build  # React Native Android dev client (first time / native dep changes)
@@ -126,8 +127,10 @@ yarn build-storybook          # Build static site
 yarn test:storybook           # Run Storybook accessibility tests
 
 # MCP-assisted Storybook workflows (requires Storybook running)
-# MCP endpoint: http://localhost:6006/mcp
-# Tools: preview-stories, run-story-tests
+# React web MCP: http://localhost:6006/mcp
+# React Native web MCP: http://localhost:6007/mcp
+# React Native on-device MCP: http://localhost:7007/mcp (Metro; experimental)
+# Tools: preview-stories, run-story-tests (web); select-story (on-device + websockets)
 ```
 
 ## Golden Path Examples

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -3,6 +3,10 @@
     "storybook-mcp": {
       "type": "http",
       "url": "http://localhost:6006/mcp"
+    },
+    "storybook-react-native-mcp": {
+      "type": "http",
+      "url": "http://localhost:6007/mcp"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Legacy `component-library/` folders are migration **sources**, not audit targets
 
 When asked to **audit** usage, alignment, or gaps, scan **both** platforms above. Look for misalignments and emergent patterns: custom UI, repeated compositions, and use cases where product intent is not met by current MMDS components or APIs. APIs may differ; judge whether MMDS achieves the same intent for the use case. Findings may inform new components, patterns, or API changes in this repo.
 
-**MMDS component reference:** Local — `apps/storybook-react/storybook-static/manifests/components.json` after `yarn build-storybook`, or `http://localhost:6006/manifests/components.json` while `yarn storybook` is running. Published — https://metamask.github.io/metamask-design-system/manifests/components.json
+**MMDS component reference:** Local — `apps/storybook-react/storybook-static/manifests/components.json` after `yarn build-storybook`, or `http://localhost:6006/manifests/components.json` while `yarn storybook` is running. React Native web: `http://localhost:6007/manifests/components.json` (`yarn workspace @metamask/storybook-react-native storybook:web`). Published — https://metamask.github.io/metamask-design-system/manifests/components.json (RN nested at `/react-native/manifests/`).
 
 **MMDS Figma (canonical):** https://www.figma.com/design/1D6tnzXqWgnUC3spaAOELN/%F0%9F%A6%8A-MMDS-Components?node-id=0-1 (`fileKey`: `1D6tnzXqWgnUC3spaAOELN`)
 
@@ -88,6 +88,7 @@ yarn create-component:react-native --name ComponentName --description "Brief des
 
 # Storybook
 yarn storybook                # React web (port 6006)
+yarn workspace @metamask/storybook-react-native storybook:web  # React Native web (port 6007)
 yarn storybook:ios:build      # React Native iOS dev client (first time / native dep changes)
 yarn storybook:ios            # React Native iOS (Metro + dev client)
 yarn storybook:android:build  # React Native Android dev client (first time / native dep changes)

--- a/apps/storybook-react-native/.storybook/main.ts
+++ b/apps/storybook-react-native/.storybook/main.ts
@@ -18,6 +18,9 @@ function getAbsolutePath(value: string): string {
 }
 
 const config: StorybookConfig = {
+  features: {
+    componentsManifest: true,
+  },
   stories: [
     '../stories/**/*.stories.@(js|jsx|ts|tsx)',
     '../../../packages/design-system-react-native/src/**/*.stories.@(js|jsx|ts|tsx)',
@@ -27,6 +30,7 @@ const config: StorybookConfig = {
     getAbsolutePath('@storybook/addon-a11y'),
     getAbsolutePath('@storybook/addon-docs'),
     getAbsolutePath('@storybook/addon-vitest'),
+    getAbsolutePath('@storybook/addon-mcp'),
   ],
   framework: {
     name: getAbsolutePath('@storybook/react-native-web-vite'),

--- a/apps/storybook-react-native/README.md
+++ b/apps/storybook-react-native/README.md
@@ -54,6 +54,42 @@ yarn workspace @metamask/storybook-react-native storybook:web
 yarn workspace @metamask/storybook-react-native build-storybook
 ```
 
+## AI Integration (Storybook MCP)
+
+React Native Storybook exposes MCP on two paths. Composition into React Storybook (`http://localhost:6006`) does **not** include React Native entries in that host's MCP manifests, so agents that need DSRN components should connect to the React Native endpoints below.
+
+### React Native web (browser Storybook)
+
+When `yarn workspace @metamask/storybook-react-native storybook:web` is running:
+
+```text
+http://localhost:6007/mcp
+```
+
+This is the same `@storybook/addon-mcp` setup as `@metamask/storybook-react`. Static builds also emit `manifests/components.json` and `manifests/docs.json` (nested under `/react-native/` on GitHub Pages).
+
+Tools include `list-all-documentation`, `get-documentation`, `get-documentation-for-story`, `get-storybook-story-instructions`, `preview-stories`, and `run-story-tests` (when supported).
+
+### On-device (Metro)
+
+When Metro is running for this app (`yarn storybook:ios` / `yarn storybook:android`), `@storybook/react-native` serves an experimental MCP endpoint on the channel server (Storybook React Native v10.3+, `experimental_mcp: true` in `metro.config.js`):
+
+```text
+http://localhost:7007/mcp
+```
+
+Documentation query tools work with MCP alone. `select-story` (push the selected story to connected devices) requires WebSockets, which this app enables via `websockets: 'auto'`.
+
+Do not expose the Metro MCP port on public networks. This app is a Storybook development client, not a production mobile build.
+
+### MDX READMEs
+
+Do **not** convert React Native component `README.md` files to MDX and import them from shared CSF stories yet.
+
+- **On-device** (`@storybook/react-native`): MDX and autodocs are not supported. Maintainers document this as missing, not as a bug ([issue 341](https://github.com/storybookjs/react-native/issues/341), [discussion 293](https://github.com/storybookjs/react-native/discussions/293), [issue 617](https://github.com/storybookjs/react-native/issues/617)). On-device docs stay markdown notes (`@storybook/addon-ondevice-notes`).
+- **React Native web** (`@storybook/react-native-web-vite`): MDX and `@storybook/addon-docs` **are** supported. Importing `README.mdx` from the same `*.stories.tsx` files used on device still breaks Metro unless every `.mdx` import is mocked.
+- Keep native READMEs as `.md` for GitHub/npm consumers. Use CSF stories plus MCP manifests for agent discovery until on-device MDX exists or we split web-only doc files that native never imports.
+
 ## Run Storybook tests
 
 Component stories are tested in the browser via Vitest and Playwright (same approach as `@metamask/storybook-react`):

--- a/apps/storybook-react-native/metro.config.js
+++ b/apps/storybook-react-native/metro.config.js
@@ -19,4 +19,10 @@ defaultConfig.resolver.sourceExts = [
   'svg',
 ];
 
-module.exports = withStorybook(defaultConfig);
+module.exports = withStorybook(defaultConfig, {
+  // On-device MCP (Storybook React Native v10.3+). Documentation tools work
+  // with experimental_mcp alone; websockets are required for select-story.
+  // See https://storybookjs-react-native.mintlify.app/guides/mcp-integration
+  websockets: 'auto',
+  experimental_mcp: true,
+});

--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -49,6 +49,7 @@
     "@rolldown/plugin-babel": "^0.2.3",
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/addon-docs": "^10.4.6",
+    "@storybook/addon-mcp": "^0.6.0",
     "@storybook/addon-ondevice-actions": "10.4.7",
     "@storybook/addon-ondevice-backgrounds": "10.4.7",
     "@storybook/addon-ondevice-controls": "10.4.7",

--- a/apps/storybook-react/README.md
+++ b/apps/storybook-react/README.md
@@ -42,6 +42,8 @@ This endpoint helps AI agents work with the design system by exposing:
 
 Maintainers can use these tools while authoring stories in this repo. Consumer repositories get the most value by connecting their agent clients to this endpoint (local) or a published Storybook MCP endpoint.
 
+React Native components are **composed** into this Storybook UI but are **not** part of this MCP index. Use the React Native web endpoint (`http://localhost:6007/mcp`) documented in `apps/storybook-react-native/README.md`.
+
 ## Accessibility Testing
 
 Our Storybook setup includes accessibility testing capabilities. See [Accessibility Testing Documentation](../../docs/accessibility-testing.md).

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -109,6 +109,18 @@ The three-layer model provides static guidance (rules, conventions, and process)
 - Story-level examples that reduce prop/API hallucination
 - Optional story test execution and preview tooling when addon toolsets are enabled
 
+### Endpoints
+
+| Storybook                                                                          | Dev MCP                     | Manifests (local / GitHub Pages)                                                                                                             |
+| ---------------------------------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| React web (`yarn storybook`)                                                       | `http://localhost:6006/mcp` | `http://localhost:6006/manifests/components.json` · [published](https://metamask.github.io/metamask-design-system/manifests/components.json) |
+| React Native web (`yarn workspace @metamask/storybook-react-native storybook:web`) | `http://localhost:6007/mcp` | `http://localhost:6007/manifests/components.json` · nested at `/react-native/manifests/` on Pages                                            |
+| React Native on-device (Metro)                                                     | `http://localhost:7007/mcp` | Generated at runtime by `@storybook/react-native` (`experimental_mcp`)                                                                       |
+
+Composed refs in the React host Storybook do **not** merge React Native components into the `6006` MCP index. Query `6007` (or `7007` on device) for DSRN.
+
+React Native component READMEs stay Markdown (`.md`). MDX + Canvas docs are not supported on-device; shared stories must not import `.mdx` until that changes upstream.
+
 ### Maintainers vs consumers
 
 - **Maintainers (this repo):** Continue using `.cursor/rules/` as the source of truth for conventions. Storybook MCP is a workflow accelerator for story authoring and validation.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "publish-previews": "yarn workspaces foreach --all --no-private --parallel --verbose run publish:preview",
     "setup": "yarn install && yarn build",
     "storybook": "yarn workspace @metamask/storybook-react storybook",
+    "storybook:web": "yarn workspace @metamask/storybook-react-native storybook:web",
     "storybook:android": "yarn workspace @metamask/storybook-react-native android",
     "storybook:android:build": "yarn workspace @metamask/storybook-react-native android:build",
     "storybook:ios": "yarn workspace @metamask/storybook-react-native ios",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3711,6 +3711,7 @@ __metadata:
     "@rolldown/plugin-babel": "npm:^0.2.3"
     "@storybook/addon-a11y": "npm:^10.4.6"
     "@storybook/addon-docs": "npm:^10.4.6"
+    "@storybook/addon-mcp": "npm:^0.6.0"
     "@storybook/addon-ondevice-actions": "npm:10.4.7"
     "@storybook/addon-ondevice-backgrounds": "npm:10.4.7"
     "@storybook/addon-ondevice-controls": "npm:10.4.7"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Adds Storybook MCP to the React Native Storybook app, matching the React web setup from #987 and the GitHub Pages manifests work in #1189.

React Native stories are composed into the React host Storybook UI, but that host’s MCP index (`http://localhost:6006/mcp`) does **not** include DSRN components. Agents that need React Native components must query the RN endpoints.

**What changed**

- Register `@storybook/addon-mcp` and `features.componentsManifest` on `apps/storybook-react-native/.storybook` so `yarn storybook:web` (port **6007**) exposes `/mcp` and static builds emit `manifests/components.json` (nested under `/react-native/` on Pages).
- Enable `@storybook/react-native` `experimental_mcp` plus `websockets: 'auto'` in Metro (on-device MCP at `http://localhost:7007/mcp`, including `select-story` when devices are connected). This follows [storybookjs/react-native#849](https://github.com/storybookjs/react-native/pull/849) and the [MCP integration guide](https://storybookjs-react-native.mintlify.app/guides/mcp-integration).
- Point Cursor/VS Code MCP config at the RN web endpoint as well as the existing React web one.
- Document endpoints and why RN READMEs stay Markdown.

**MDX READMEs (looked up in storybookjs/react-native)**

It would **not** make sense to convert all RN `README.md` files to MDX and import them from shared CSF stories yet.

- **On-device:** MDX is not supported ([issue 341](https://github.com/storybookjs/react-native/issues/341), [discussion 293](https://github.com/storybookjs/react-native/discussions/293)). Autodocs are also not first-class yet ([issue 617](https://github.com/storybookjs/react-native/issues/617); planned after v10). Use `@storybook/addon-ondevice-notes` for markdown on device.
- **React Native web** (`@storybook/react-native-web-vite`): MDX and `@storybook/addon-docs` **are** supported (this app already has the docs addon).
- **Shared stories:** DSRN `*.stories.tsx` files are loaded by both Metro and Vite. `import README from './README.mdx'` in those files breaks native unless every `.mdx` import is mocked in Metro (a workaround, not a supported path).

Keep `.md` READMEs for GitHub/npm. Use CSF + MCP manifests for agent discovery. A later, web-only MDX glob that native never imports could add Canvas docs without converting the shared story files.

## **Related issues**

Follow-up to #987 and #1189 (React Storybook MCP).

## **Manual testing steps**

1. From repo root, run `yarn storybook:web` and wait until the RN web Storybook is up on port **6007**.
2. Open `http://localhost:6007` and confirm stories still load.
3. Confirm `http://localhost:6007/manifests/components.json` returns a component index (not 404).
4. Confirm the MCP endpoint is reachable at `http://localhost:6007/mcp` (POST JSON-RPC / MCP client).
5. Run `yarn workspace @metamask/storybook-react-native build-storybook` and confirm `apps/storybook-react-native/storybook-static/manifests/components.json` exists.
6. (Optional, on-device) `yarn storybook:ios` and confirm Metro logs an MCP endpoint around `http://localhost:7007/mcp`.

## **Screenshots/Recordings**

### **Before**

React Native web Storybook had no MCP addon / component manifests. On-device Metro did not enable `experimental_mcp`.

### **After**

Verified locally against `yarn storybook:web`:

- `GET http://localhost:6007/manifests/components.json` → **200**, 86 components (e.g. `components-button` with 12 stories + react-docgen).
- `POST http://localhost:6007/mcp` initialize → **200** MCP session (`protocolVersion` 2024-11-05, Storybook MCP workflow instructions).
- `GET http://localhost:6007/manifests/docs.json` → **404** in this setup because there are no MDX/docs pages yet (expected; story-level docs still live in `components.json`).

On-device Metro MCP (`7007`) was not started in this environment (no iOS/Android simulator).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a684191-0028-4589-8c15-34b490bae0ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a684191-0028-4589-8c15-34b490bae0ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

