### PR TITLE
Release 64.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "63.0.0",
+  "version": "64.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.0]
+
 ### Uncategorized
 
 - ci: automate Figma Code Connect validation and publishing ([#1369](https://github.com/MetaMask/metamask-design-system/pull/1369))
@@ -732,7 +734,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.43.0...HEAD
+[0.43.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.1...@metamask/design-system-react-native@0.43.0
 [0.42.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.0...@metamask/design-system-react-native@0.42.1
 [0.42.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.41.0...@metamask/design-system-react-native@0.42.0
 [0.41.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.40.0...@metamask/design-system-react-native@0.41.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- ci: automate Figma Code Connect validation and publishing ([#1369](https://github.com/MetaMask/metamask-design-system/pull/1369))
+- chore(deps): bump @metamask/utils from 11.11.0 to 11.12.0 ([#1490](https://github.com/MetaMask/metamask-design-system/pull/1490))
+- chore: Add Code Connect for HeaderSearch ([#1486](https://github.com/MetaMask/metamask-design-system/pull/1486))
+- chore: Add Code Connect for SelectButton ([#1487](https://github.com/MetaMask/metamask-design-system/pull/1487))
+- chore: Remove 111 unused icons from the shared set ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))
+- fix: align BadgeNetwork Xs border radius with Figma ([#1480](https://github.com/MetaMask/metamask-design-system/pull/1480))
+- chore: Add Code Connect for Card ([#1470](https://github.com/MetaMask/metamask-design-system/pull/1470))
+- chore: Add and update Code Connect for Button components ([#1468](https://github.com/MetaMask/metamask-design-system/pull/1468))
+- Add IconAlert Figma Code Connect (React + React Native) ([#1477](https://github.com/MetaMask/metamask-design-system/pull/1477))
+
 ## [0.42.1]
 
 ### Changed

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,17 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.43.0]
 
-### Uncategorized
+### Changed
 
-- ci: automate Figma Code Connect validation and publishing ([#1369](https://github.com/MetaMask/metamask-design-system/pull/1369))
-- chore(deps): bump @metamask/utils from 11.11.0 to 11.12.0 ([#1490](https://github.com/MetaMask/metamask-design-system/pull/1490))
-- chore: Add Code Connect for HeaderSearch ([#1486](https://github.com/MetaMask/metamask-design-system/pull/1486))
-- chore: Add Code Connect for SelectButton ([#1487](https://github.com/MetaMask/metamask-design-system/pull/1487))
-- chore: Remove 111 unused icons from the shared set ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))
-- fix: align BadgeNetwork Xs border radius with Figma ([#1480](https://github.com/MetaMask/metamask-design-system/pull/1480))
-- chore: Add Code Connect for Card ([#1470](https://github.com/MetaMask/metamask-design-system/pull/1470))
-- chore: Add and update Code Connect for Button components ([#1468](https://github.com/MetaMask/metamask-design-system/pull/1468))
-- Add IconAlert Figma Code Connect (React + React Native) ([#1477](https://github.com/MetaMask/metamask-design-system/pull/1477))
+- **BREAKING:** Removed 111 unused icons from `IconName` to reduce icon bundle size ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))
+  - TypeScript will fail on remaining references to removed `IconName` members
+  - See [Migration Guide](./MIGRATION.md#from-version-0421-to-0430)
+
+### Fixed
+
+- Fixed `BadgeNetwork` Xs size border radius to match Figma ([#1480](https://github.com/MetaMask/metamask-design-system/pull/1480))
 
 ## [0.42.1]
 

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -4,7 +4,7 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Table of Contents
 
-- [From version X.XX.X to X.XX.X](#from-version-xxx-to-xxx)
+- [From version 0.42.1 to 0.43.0](#from-version-0421-to-0430)
 - [From version 0.41.0 to 0.42.0](#from-version-0410-to-0420)
 - [From version 0.37.0 to 0.38.0](#from-version-0370-to-0380)
 - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
@@ -51,7 +51,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TabEmptyState Component](#tabemptystate-component)
   - [Toast Component](#toast-component)
 - [Version Updates](#version-updates)
-  - [From version X.XX.X to X.XX.X](#from-version-xxx-to-xxx)
+  - [From version 0.42.1 to 0.43.0](#from-version-0421-to-0430)
   - [From version 0.41.0 to 0.42.0](#from-version-0410-to-0420)
   - [From version 0.37.0 to 0.38.0](#from-version-0370-to-0380)
   - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
@@ -74,15 +74,29 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Version Updates
 
-### From version X.XX.X to X.XX.X
+### From version 0.42.1 to 0.43.0
 
-<a id="from-version-xxx-to-xxx"></a>
+<a id="from-version-0421-to-0430"></a>
 
 <a id="iconname-unused-icons-removed"></a>
 
 #### `IconName`: unused icons removed
 
-111 unused icons are removed from **`IconName`** (shared with `@metamask/design-system-shared`). See the [shared package migration guide](../design-system-shared/MIGRATION.md#iconname-unused-icons-removed) for the full removed list and suggested replacements.
+111 unused icons are removed from **`IconName`** (shared with `@metamask/design-system-shared`) to reduce icon bundle size. See the [shared package migration guide](../design-system-shared/MIGRATION.md#from-version-0340-to-0350) for the full removed list and suggested replacements.
+
+**Migration:**
+
+```tsx
+// Before (0.42.1)
+import { Icon, IconName } from '@metamask/design-system-react-native';
+
+<Icon name={IconName.User} />;
+
+// After (0.43.0)
+import { Icon, IconName } from '@metamask/design-system-react-native';
+
+<Icon name={IconName.UserCircle} />;
+```
 
 **Impact:** TypeScript will fail on any remaining references to the removed icon names.
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.42.1",
+  "version": "0.43.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0]
+
 ### Uncategorized
 
 - ci: automate Figma Code Connect validation and publishing ([#1369](https://github.com/MetaMask/metamask-design-system/pull/1369))
@@ -529,7 +531,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.39.0...HEAD
+[0.39.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.1...@metamask/design-system-react@0.39.0
 [0.38.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.0...@metamask/design-system-react@0.38.1
 [0.38.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.0...@metamask/design-system-react@0.38.0
 [0.37.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.36.0...@metamask/design-system-react@0.37.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,14 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.39.0]
 
-### Uncategorized
+### Changed
 
-- ci: automate Figma Code Connect validation and publishing ([#1369](https://github.com/MetaMask/metamask-design-system/pull/1369))
-- chore(deps): bump @metamask/utils from 11.11.0 to 11.12.0 ([#1490](https://github.com/MetaMask/metamask-design-system/pull/1490))
-- chore: Remove 111 unused icons from the shared set ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))
-- fix: align BadgeNetwork Xs border radius with Figma ([#1480](https://github.com/MetaMask/metamask-design-system/pull/1480))
-- chore: Add and update Code Connect for Button components ([#1468](https://github.com/MetaMask/metamask-design-system/pull/1468))
-- Add IconAlert Figma Code Connect (React + React Native) ([#1477](https://github.com/MetaMask/metamask-design-system/pull/1477))
+- **BREAKING:** Removed 111 unused icons from `IconName` to reduce icon bundle size ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))
+  - TypeScript will fail on remaining references to removed `IconName` members
+  - See [Migration Guide](./MIGRATION.md#from-version-0381-to-0390)
+
+### Fixed
+
+- Fixed `BadgeNetwork` Xs size border radius to match Figma ([#1480](https://github.com/MetaMask/metamask-design-system/pull/1480))
 
 ## [0.38.1]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- ci: automate Figma Code Connect validation and publishing ([#1369](https://github.com/MetaMask/metamask-design-system/pull/1369))
+- chore(deps): bump @metamask/utils from 11.11.0 to 11.12.0 ([#1490](https://github.com/MetaMask/metamask-design-system/pull/1490))
+- chore: Remove 111 unused icons from the shared set ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))
+- fix: align BadgeNetwork Xs border radius with Figma ([#1480](https://github.com/MetaMask/metamask-design-system/pull/1480))
+- chore: Add and update Code Connect for Button components ([#1468](https://github.com/MetaMask/metamask-design-system/pull/1468))
+- Add IconAlert Figma Code Connect (React + React Native) ([#1477](https://github.com/MetaMask/metamask-design-system/pull/1477))
+
 ## [0.38.1]
 
 ### Changed

--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -48,7 +48,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TextFieldSearch Component](#textfieldsearch-component)
   - [FormTextField Component](#formtextfield-component)
 - [Version Updates](#version-updates)
-  - [From version X.XX.X to X.XX.X](#from-version-xxx-to-xxx)
+  - [From version 0.38.1 to 0.39.0](#from-version-0381-to-0390)
   - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
   - [From version 0.34.0 to 0.35.0](#from-version-0340-to-0350)
   - [From version 0.27.x to 0.28.0](#from-version-027x-to-0280)
@@ -3630,15 +3630,29 @@ The new `TextFieldSearch` reuses `TextField`'s Tailwind chrome instead of the `m
 
 ## Version Updates
 
-### From version X.XX.X to X.XX.X
+### From version 0.38.1 to 0.39.0
 
-<a id="from-version-xxx-to-xxx"></a>
+<a id="from-version-0381-to-0390"></a>
 
 <a id="iconname-unused-icons-removed"></a>
 
 #### `IconName`: unused icons removed
 
-111 unused icons are removed from **`IconName`** (shared with `@metamask/design-system-shared`). See the [shared package migration guide](../design-system-shared/MIGRATION.md#iconname-unused-icons-removed) for the full removed list and suggested replacements.
+111 unused icons are removed from **`IconName`** (shared with `@metamask/design-system-shared`) to reduce icon bundle size. See the [shared package migration guide](../design-system-shared/MIGRATION.md#from-version-0340-to-0350) for the full removed list and suggested replacements.
+
+**Migration:**
+
+```tsx
+// Before (0.38.1)
+import { Icon, IconName } from '@metamask/design-system-react';
+
+<Icon name={IconName.User} />;
+
+// After (0.39.0)
+import { Icon, IconName } from '@metamask/design-system-react';
+
+<Icon name={IconName.UserCircle} />;
+```
 
 **Impact:** TypeScript will fail on any remaining references to the removed icon names.
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.0]
 
-### Uncategorized
+### Changed
 
-- chore(deps): bump @metamask/utils from 11.11.0 to 11.12.0 ([#1490](https://github.com/MetaMask/metamask-design-system/pull/1490))
-- chore: Remove 111 unused icons from the shared set ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))
+- **BREAKING:** Removed 111 unused icons from `IconName` to reduce the shared icon bundle size ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))
+  - SVG assets and generated React / React Native icon outputs no longer include these names
+  - TypeScript will fail on remaining references to removed `IconName` members
+  - See [Migration Guide](./MIGRATION.md#from-version-0340-to-0350)
 
 ## [0.34.0]
 

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(deps): bump @metamask/utils from 11.11.0 to 11.12.0 ([#1490](https://github.com/MetaMask/metamask-design-system/pull/1490))
+- chore: Remove 111 unused icons from the shared set ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))
+
 ## [0.34.0]
 
 ### Changed

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0]
+
 ### Uncategorized
 
 - chore(deps): bump @metamask/utils from 11.11.0 to 11.12.0 ([#1490](https://github.com/MetaMask/metamask-design-system/pull/1490))
@@ -340,7 +342,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.34.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.35.0...HEAD
+[0.35.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.34.0...@metamask/design-system-shared@0.35.0
 [0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.33.0...@metamask/design-system-shared@0.34.0
 [0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.32.0...@metamask/design-system-shared@0.33.0
 [0.32.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.31.0...@metamask/design-system-shared@0.32.0

--- a/packages/design-system-shared/MIGRATION.md
+++ b/packages/design-system-shared/MIGRATION.md
@@ -5,7 +5,7 @@ This guide provides detailed instructions for migrating your project from one ve
 ## Table of Contents
 
 - [Version Updates](#version-updates)
-  - [From version X.XX.X to X.XX.X](#from-version-xxx-to-xxx)
+  - [From version 0.34.0 to 0.35.0](#from-version-0340-to-0350)
   - [From version 0.29.0 to 0.30.0](#from-version-0290-to-0300)
   - [From version 0.24.0 to 0.25.0](#from-version-0240-to-0250)
   - [From version 0.22.0 to 0.23.0](#from-version-0220-to-0230)
@@ -14,15 +14,20 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Version Updates
 
-### From version X.XX.X to X.XX.X
+### From version 0.34.0 to 0.35.0
 
-<a id="from-version-xxx-to-xxx"></a>
+<a id="from-version-0340-to-0350"></a>
 
 <a id="iconname-unused-icons-removed"></a>
 
 #### `IconName`: unused icons removed
 
-111 unused icon names are removed from **`IconName`**. The shared SVG assets and generated React / React Native icon outputs were regenerated without them.
+111 unused icon names are removed from **`IconName`** so the shared SVG assets and generated React / React Native icon outputs are smaller. Icons that were not used in MetaMask extension or mobile product UI were dropped.
+
+**What changed:**
+
+- Removed 111 `IconName` members (list below)
+- Regenerated shared SVG assets and platform icon outputs without those glyphs
 
 **Removed names:**
 
@@ -30,12 +35,24 @@ This guide provides detailed instructions for migrating your project from one ve
 
 **Migration:**
 
-Replace any usage of a removed name with a remaining `IconName` that matches the product intent. Common substitutions used in this repo:
+Replace any usage of a removed name with a remaining `IconName` that matches the product intent. Common substitutions:
 
 | Removed                  | Suggested replacement |
 | ------------------------ | --------------------- |
 | `IconName.User`          | `IconName.UserCircle` |
 | `IconName.SecurityAlert` | `IconName.Warning`    |
+
+```tsx
+// Before (0.34.0)
+import { IconName } from '@metamask/design-system-shared';
+
+iconName={IconName.User}
+
+// After (0.35.0)
+import { IconName } from '@metamask/design-system-shared';
+
+iconName={IconName.UserCircle}
+```
 
 **Impact:**
 

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Release 64.0.0

This release removes **111 unused icons** from `IconName` to reduce icon bundle size on web and native. The remaining consumer-facing change is a small `BadgeNetwork` Xs border-radius alignment with Figma.

**Action required:** Search product code for removed `IconName` members (especially `User` and `SecurityAlert`) and switch to remaining names before upgrading. TypeScript will fail on leftover references.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.35.0**
- `@metamask/design-system-react`: **0.39.0**
- `@metamask/design-system-react-native`: **0.43.0**

### 🔄 Shared Type Updates (0.35.0)

#### Changed — Breaking ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))

**What Changed:**

- **BREAKING:** Removed 111 unused icons from `IconName` to reduce the shared icon bundle size
  - SVG assets and generated React / React Native icon outputs no longer include these names
  - See [Migration Guide](./packages/design-system-shared/MIGRATION.md#from-version-0340-to-0350)

**Impact:**

- TypeScript fails on remaining references to removed `IconName` members
- React and React Native consumers must bump shared in the same upgrade

### 🌐 React Web Updates (0.39.0)

#### Changed — Breaking ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))

- **BREAKING:** Removed 111 unused icons from `IconName` to reduce icon bundle size
  - See [Migration Guide](./packages/design-system-react/MIGRATION.md#from-version-0381-to-0390)

#### Fixed

- Fixed `BadgeNetwork` Xs size border radius to match Figma ([#1480](https://github.com/MetaMask/metamask-design-system/pull/1480))

### 📱 React Native Updates (0.43.0)

#### Changed — Breaking ([#1481](https://github.com/MetaMask/metamask-design-system/pull/1481))

- **BREAKING:** Removed 111 unused icons from `IconName` to reduce icon bundle size
  - See [Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0421-to-0430)

#### Fixed

- Fixed `BadgeNetwork` Xs size border radius to match Figma ([#1480](https://github.com/MetaMask/metamask-design-system/pull/1480))

### ⚠️ Breaking Changes

#### Unused icons removed from `IconName` (Both platforms)

**What Changed:**

- 111 unused `IconName` members and their SVG assets were removed to shrink the icon bundle
- Icons that were not used in MetaMask extension or mobile product UI were dropped

**Migration:**

```tsx
// Before
import { Icon, IconName } from '@metamask/design-system-react';

<Icon name={IconName.User} />;

// After
import { Icon, IconName } from '@metamask/design-system-react';

<Icon name={IconName.UserCircle} />;
```

Common substitutions: `IconName.User` → `IconName.UserCircle`, `IconName.SecurityAlert` → `IconName.Warning`. Full removed list in the shared migration guide.

**Impact:**

- Any remaining `name={IconName.Removed}` (or equivalent) will fail TypeScript
- Bundle size is smaller for consumers who import the generated icon set

See migration guides for complete instructions:

- [Shared Migration Guide](./packages/design-system-shared/MIGRATION.md#from-version-0340-to-0350)
- [React Migration Guide](./packages/design-system-react/MIGRATION.md#from-version-0381-to-0390)
- [React Native Migration Guide](./packages/design-system-react-native/MIGRATION.md#from-version-0421-to-0430)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: minor (`0.34.0 → 0.35.0`) — breaking `IconName` removals (pre-1.0)
  - [x] design-system-react: minor (`0.38.1 → 0.39.0`) — breaking `IconName` removals (pre-1.0)
  - [x] design-system-react-native: minor (`0.42.1 → 0.43.0`) — breaking `IconName` removals (pre-1.0)
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples (if breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

Made with [Cursor](https://cursor.com)