### PR TITLE
Release 65.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "64.0.0",
+  "version": "65.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.0]
+
 ### Uncategorized
 
 - feat: Update remaining MMDS icons to Phosphor ([#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
@@ -739,7 +741,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.43.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.44.0...HEAD
+[0.44.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.43.0...@metamask/design-system-react-native@0.44.0
 [0.43.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.1...@metamask/design-system-react-native@0.43.0
 [0.42.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.0...@metamask/design-system-react-native@0.42.1
 [0.42.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.41.0...@metamask/design-system-react-native@0.42.0

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,12 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.44.0]
 
-### Uncategorized
+### Changed
 
-- feat: Update remaining MMDS icons to Phosphor ([#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
-- feat: Update MMDS Mobile icons to Phosphor ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475))
-- feat: Update MMDS Extension icons to Phosphor ([#1482](https://github.com/MetaMask/metamask-design-system/pull/1482))
-- chore(deps): bump @metamask/utils from 11.12.0 to 11.12.1 ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))
+- Updated `Icon` artwork to Phosphor-based glyphs for the brand migration, keeping existing `IconName` values, `viewBox="0 0 24 24"`, and `currentColor` fills ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475), [#1482](https://github.com/MetaMask/metamask-design-system/pull/1482), [#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
+  - `AppleLogo`, `Bridge`, and `MetamaskFoxOutline` are unchanged
+- Bumped `@metamask/utils` from `^11.12.0` to `^11.12.1` ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))
 
 ## [0.43.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: Update remaining MMDS icons to Phosphor ([#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
+- feat: Update MMDS Mobile icons to Phosphor ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475))
+- feat: Update MMDS Extension icons to Phosphor ([#1482](https://github.com/MetaMask/metamask-design-system/pull/1482))
+- chore(deps): bump @metamask/utils from 11.12.0 to 11.12.1 ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))
+
 ## [0.43.0]
 
 ### Changed

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: Update remaining MMDS icons to Phosphor ([#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
+- feat: Update MMDS Mobile icons to Phosphor ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475))
+- feat: Update MMDS Extension icons to Phosphor ([#1482](https://github.com/MetaMask/metamask-design-system/pull/1482))
+- chore(deps): bump @metamask/utils from 11.12.0 to 11.12.1 ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))
+
 ## [0.39.0]
 
 ### Changed

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0]
+
 ### Uncategorized
 
 - feat: Update remaining MMDS icons to Phosphor ([#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
@@ -539,7 +541,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.39.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.40.0...HEAD
+[0.40.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.39.0...@metamask/design-system-react@0.40.0
 [0.39.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.1...@metamask/design-system-react@0.39.0
 [0.38.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.0...@metamask/design-system-react@0.38.1
 [0.38.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.37.0...@metamask/design-system-react@0.38.0

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,12 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.40.0]
 
-### Uncategorized
+### Changed
 
-- feat: Update remaining MMDS icons to Phosphor ([#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
-- feat: Update MMDS Mobile icons to Phosphor ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475))
-- feat: Update MMDS Extension icons to Phosphor ([#1482](https://github.com/MetaMask/metamask-design-system/pull/1482))
-- chore(deps): bump @metamask/utils from 11.12.0 to 11.12.1 ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))
+- Updated `Icon` artwork to Phosphor-based glyphs for the brand migration, keeping existing `IconName` values, `viewBox="0 0 24 24"`, and `currentColor` fills ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475), [#1482](https://github.com/MetaMask/metamask-design-system/pull/1482), [#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
+  - `AppleLogo`, `Bridge`, and `MetamaskFoxOutline` are unchanged
+- Bumped `@metamask/utils` from `^11.12.0` to `^11.12.1` ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))
 
 ## [0.39.0]
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0]
+
 ### Uncategorized
 
 - feat: Update remaining MMDS icons to Phosphor ([#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
@@ -351,7 +353,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Initial release** - MetaMask Design System Shared
 - Adding CAIP-10 address utilities ([#817](https://github.com/MetaMask/metamask-design-system/pull/817))
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.35.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.36.0...HEAD
+[0.36.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.35.0...@metamask/design-system-shared@0.36.0
 [0.35.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.34.0...@metamask/design-system-shared@0.35.0
 [0.34.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.33.0...@metamask/design-system-shared@0.34.0
 [0.33.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-shared@0.32.0...@metamask/design-system-shared@0.33.0

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -9,12 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.36.0]
 
-### Uncategorized
+### Changed
 
-- feat: Update remaining MMDS icons to Phosphor ([#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
-- feat: Update MMDS Mobile icons to Phosphor ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475))
-- feat: Update MMDS Extension icons to Phosphor ([#1482](https://github.com/MetaMask/metamask-design-system/pull/1482))
-- chore(deps): bump @metamask/utils from 11.12.0 to 11.12.1 ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))
+- Updated shared `Icon` artwork to Phosphor-based glyphs for the brand migration, keeping existing `IconName` values, `viewBox="0 0 24 24"`, and `currentColor` fills ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475), [#1482](https://github.com/MetaMask/metamask-design-system/pull/1482), [#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
+  - `AppleLogo`, `Bridge`, and `MetamaskFoxOutline` are unchanged
+- Bumped `@metamask/utils` from `^11.12.0` to `^11.12.1` ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))
 
 ## [0.35.0]
 

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: Update remaining MMDS icons to Phosphor ([#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
+- feat: Update MMDS Mobile icons to Phosphor ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475))
+- feat: Update MMDS Extension icons to Phosphor ([#1482](https://github.com/MetaMask/metamask-design-system/pull/1482))
+- chore(deps): bump @metamask/utils from 11.12.0 to 11.12.1 ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))
+
 ## [0.35.0]
 
 ### Changed

--- a/packages/design-system-shared/package.json
+++ b/packages/design-system-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-shared",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Shared types for design system libraries",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Release 65.0.0

This release updates the remaining MMDS `Icon` artwork to Phosphor-based glyphs for the brand migration. Icon names, `viewBox`, and `currentColor` are unchanged, so Extension and Mobile can pick up the new art without code changes.

Includes [#1475](https://github.com/MetaMask/metamask-design-system/pull/1475) (mobile-used icons), [#1482](https://github.com/MetaMask/metamask-design-system/pull/1482) (extension-used icons), and [#1493](https://github.com/MetaMask/metamask-design-system/pull/1493) (remaining shared icons). `AppleLogo`, `Bridge`, and `MetamaskFoxOutline` are unchanged.

### 📦 Package Versions

- `@metamask/design-system-shared`: **0.36.0**
- `@metamask/design-system-react`: **0.40.0**
- `@metamask/design-system-react-native`: **0.44.0**

### 🔄 Shared Type Updates (0.36.0)

#### Changed ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475), [#1482](https://github.com/MetaMask/metamask-design-system/pull/1482), [#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))

**What Changed:**

- Updated shared `Icon` artwork to Phosphor-based glyphs for the brand migration
  - Existing `IconName` values, `viewBox="0 0 24 24"`, and `currentColor` fills are unchanged
  - `AppleLogo`, `Bridge`, and `MetamaskFoxOutline` are unchanged
- Bumped `@metamask/utils` from `^11.12.0` to `^11.12.1` ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))

**Impact:**

- Consumers will see Phosphor silhouettes and weights in `Icon` without API changes
- React and React Native should bump shared in the same upgrade

### 🌐 React Web Updates (0.40.0)

#### Changed

- Updated `Icon` artwork to Phosphor-based glyphs for the brand migration, keeping existing `IconName` values, `viewBox="0 0 24 24"`, and `currentColor` fills ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475), [#1482](https://github.com/MetaMask/metamask-design-system/pull/1482), [#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
  - `AppleLogo`, `Bridge`, and `MetamaskFoxOutline` are unchanged
- Bumped `@metamask/utils` from `^11.12.0` to `^11.12.1` ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))

### 📱 React Native Updates (0.44.0)

#### Changed

- Updated `Icon` artwork to Phosphor-based glyphs for the brand migration, keeping existing `IconName` values, `viewBox="0 0 24 24"`, and `currentColor` fills ([#1475](https://github.com/MetaMask/metamask-design-system/pull/1475), [#1482](https://github.com/MetaMask/metamask-design-system/pull/1482), [#1493](https://github.com/MetaMask/metamask-design-system/pull/1493))
  - `AppleLogo`, `Bridge`, and `MetamaskFoxOutline` are unchanged
- Bumped `@metamask/utils` from `^11.12.0` to `^11.12.1` ([#1492](https://github.com/MetaMask/metamask-design-system/pull/1492))

### ⚠️ Breaking Changes

None. This is a visual update only; `IconName` and the `Icon` API are unchanged.

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-system-shared: minor (`0.35.0 → 0.36.0`) — Phosphor icon artwork (pre-1.0)
  - [x] design-system-react: minor (`0.39.0 → 0.40.0`) — Phosphor icon artwork (pre-1.0)
  - [x] design-system-react-native: minor (`0.43.0 → 0.44.0`) — Phosphor icon artwork (pre-1.0)
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples (if breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs


Made with [Cursor](https://cursor.com)