### PR TITLE
test: add Maskicon ColorPairs stories grouped by hue

### DIFF
--- a/packages/design-system-react-native/src/components/temp-components/Maskicon/Maskicon.stories.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/Maskicon/Maskicon.stories.tsx
@@ -5,12 +5,24 @@ import {
 } from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-native';
 import { ScrollView } from 'react-native';
+import { SvgXml } from 'react-native-svg';
 
 import { Box } from '../../Box';
 import { Text, TextVariant, TextColor, FontWeight } from '../../Text';
 
 import { Maskicon } from './Maskicon';
 import type { MaskiconProps } from './Maskicon.types';
+import {
+  createMaskiconSVG,
+  getMaskiconColorFamily,
+  MASKICON_COLOR_FAMILY_NAMES,
+  MASKICON_COMPLEMENTARY_PAIRS,
+  MASKICON_NEUTRAL_PAIRS,
+  MASKICON_TONAL_PAIRS,
+  sdbmHash,
+  seedToString,
+} from './Maskicon.utilities';
+import type { MaskiconColorFamilyName } from './Maskicon.utilities';
 
 const meta: Meta<MaskiconProps> = {
   title: 'Temp Components/Maskicon',
@@ -269,5 +281,90 @@ export const Size: Story = {
       <Maskicon address={sampleAccountAddresses[3]} size={48} />
       <Maskicon address={sampleAccountAddresses[4]} size={64} />
     </Box>
+  ),
+};
+
+const ALL_MASKICON_COLOR_PAIRS = [
+  ...MASKICON_NEUTRAL_PAIRS,
+  ...MASKICON_TONAL_PAIRS,
+  ...MASKICON_COMPLEMENTARY_PAIRS,
+];
+
+function findSeedForColorPairIndex(index: number): number {
+  for (let seed = 0; seed < 100000; seed++) {
+    const hashVal = sdbmHash(seedToString(seed));
+    if (Math.abs(hashVal) % ALL_MASKICON_COLOR_PAIRS.length === index) {
+      return seed;
+    }
+  }
+  throw new Error(`No seed found for Maskicon color pair index ${index}`);
+}
+
+function hexRelativeLuminance(hex: string): number {
+  const channel = (offset: number): number => {
+    const value = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  };
+
+  return 0.2126 * channel(1) + 0.7152 * channel(3) + 0.0722 * channel(5);
+}
+
+function buildColorPairRow(familyName: MaskiconColorFamilyName) {
+  return ALL_MASKICON_COLOR_PAIRS.flatMap(([background, foreground], index) => {
+    if (getMaskiconColorFamily(background, foreground) !== familyName) {
+      return [];
+    }
+
+    const seed = findSeedForColorPairIndex(index);
+    return [
+      {
+        index,
+        background,
+        foreground,
+        svg: createMaskiconSVG(seed, 64),
+      },
+    ];
+  }).sort(
+    (a, b) =>
+      hexRelativeLuminance(b.background) - hexRelativeLuminance(a.background),
+  );
+}
+
+const COLOR_PAIR_ROWS = MASKICON_COLOR_FAMILY_NAMES.map((name) => ({
+  name,
+  items: buildColorPairRow(name),
+}));
+
+function ColorPairRow({
+  items,
+}: {
+  items: ReturnType<typeof buildColorPairRow>;
+}) {
+  return (
+    <ScrollView horizontal>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Start}
+        gap={4}
+      >
+        {items.map((item) => (
+          <Box key={item.index} alignItems={BoxAlignItems.Center} gap={2}>
+            <SvgXml xml={item.svg} width={64} height={64} />
+          </Box>
+        ))}
+      </Box>
+    </ScrollView>
+  );
+}
+
+export const ColorPairs: Story = {
+  render: () => (
+    <ScrollView>
+      <Box padding={4} gap={6}>
+        {COLOR_PAIR_ROWS.map((row) => (
+          <ColorPairRow key={row.name} items={row.items} />
+        ))}
+      </Box>
+    </ScrollView>
   ),
 };

--- a/packages/design-system-react-native/src/components/temp-components/Maskicon/Maskicon.test.tsx
+++ b/packages/design-system-react-native/src/components/temp-components/Maskicon/Maskicon.test.tsx
@@ -105,4 +105,25 @@ describe('Maskicon Utilities', () => {
     expect(firstCall).toBe(secondCall);
     expect(firstCall).toContain('<svg');
   });
+
+  it('getMaskiconColorFamily groups single-hue pairs by color', () => {
+    expect(MaskiconUtilities.getMaskiconColorFamily('#FF5C16', '#FCFCFC')).toBe(
+      'Orange',
+    );
+    expect(MaskiconUtilities.getMaskiconColorFamily('#D075FF', '#3D065F')).toBe(
+      'Purple',
+    );
+    expect(MaskiconUtilities.getMaskiconColorFamily('#BAF24A', '#013330')).toBe(
+      'Lime',
+    );
+    expect(MaskiconUtilities.getMaskiconColorFamily('#89B0FF', '#190066')).toBe(
+      'Blue',
+    );
+  });
+
+  it('getMaskiconColorFamily returns Mixed for complementary hues', () => {
+    expect(MaskiconUtilities.getMaskiconColorFamily('#EAC2FF', '#013330')).toBe(
+      'Mixed',
+    );
+  });
 });

--- a/packages/design-system-react-native/src/components/temp-components/Maskicon/Maskicon.utilities.ts
+++ b/packages/design-system-react-native/src/components/temp-components/Maskicon/Maskicon.utilities.ts
@@ -11,7 +11,7 @@ import {
 // Maskicon SVG Creation
 // /////////////////////////////////////////////////////
 // Color Palettes
-const neutralPairs = [
+export const MASKICON_NEUTRAL_PAIRS = [
   ['#FF5C16', '#FCFCFC'],
   ['#FF5C16', '#131416'],
   ['#D075FF', '#FCFCFC'],
@@ -30,7 +30,7 @@ const neutralPairs = [
   ['#131416', '#89B0FF'],
 ];
 
-const tonalPairs = [
+export const MASKICON_TONAL_PAIRS = [
   ['#FFA680', '#FF5C16'],
   ['#661800', '#FF5C16'],
   ['#EAC2FF', '#D075FF'],
@@ -57,7 +57,7 @@ const tonalPairs = [
   ['#CCE7FF', '#190066'],
 ];
 
-const complementaryPairs = [
+export const MASKICON_COMPLEMENTARY_PAIRS = [
   ['#EAC2FF', '#013330'],
   ['#013330', '#EAC2FF'],
   ['#CCE7FF', '#661800'],
@@ -70,7 +70,48 @@ const complementaryPairs = [
   ['#013330', '#CCE7FF'],
 ];
 
-const colorPairs = neutralPairs.concat(tonalPairs).concat(complementaryPairs);
+const colorPairs = MASKICON_NEUTRAL_PAIRS.concat(MASKICON_TONAL_PAIRS).concat(
+  MASKICON_COMPLEMENTARY_PAIRS,
+);
+
+const MASKICON_COLOR_FAMILY_HEXES = {
+  Orange: new Set(['#FF5C16', '#FFA680', '#661800']),
+  Purple: new Set(['#D075FF', '#EAC2FF', '#3D065F']),
+  Lime: new Set(['#BAF24A', '#E5FFC3', '#013330']),
+  Blue: new Set(['#89B0FF', '#CCE7FF', '#190066']),
+} as const;
+
+export const MASKICON_COLOR_FAMILY_NAMES = [
+  'Orange',
+  'Purple',
+  'Lime',
+  'Blue',
+  'Mixed',
+] as const;
+
+export type MaskiconColorFamilyName =
+  (typeof MASKICON_COLOR_FAMILY_NAMES)[number];
+
+const MASKICON_HUE_FAMILY_NAMES = ['Orange', 'Purple', 'Lime', 'Blue'] as const;
+
+/**
+ * Returns the hue family for a Maskicon color pair.
+ *
+ * @param background Background hex color
+ * @param foreground Foreground hex color
+ * @returns The matching family name, or Mixed when two hues are combined
+ */
+export function getMaskiconColorFamily(
+  background: string,
+  foreground: string,
+): MaskiconColorFamilyName {
+  const families = MASKICON_HUE_FAMILY_NAMES.filter((name) => {
+    const hexes = MASKICON_COLOR_FAMILY_HEXES[name];
+    return hexes.has(background) || hexes.has(foreground);
+  });
+
+  return families.length === 1 ? families[0] : 'Mixed';
+}
 
 /**
  * SDBM hash function

--- a/packages/design-system-react-native/src/components/temp-components/Maskicon/README.md
+++ b/packages/design-system-react-native/src/components/temp-components/Maskicon/README.md
@@ -34,6 +34,10 @@ The size (width and height) of the Maskicon.
 <Maskicon address="0x360507dfEC4Bf0c03495f91154A78C672599F308" size={48} />
 ```
 
+## Color pairs
+
+Maskicon uses a fixed palette of background and foreground color pairs. The ColorPairs story shows every combination, one row per hue, ordered from lightest to darkest background.
+
 ### `showBorder`
 
 Whether to show a border around the Maskicon.

--- a/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.stories.tsx
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.stories.tsx
@@ -11,6 +11,17 @@ import { Text } from '../../Text';
 
 import { Maskicon } from './Maskicon';
 import type { MaskiconProps } from './Maskicon.types';
+import {
+  createMaskiconSVG,
+  getMaskiconColorFamily,
+  MASKICON_COLOR_FAMILY_NAMES,
+  MASKICON_COMPLEMENTARY_PAIRS,
+  MASKICON_NEUTRAL_PAIRS,
+  MASKICON_TONAL_PAIRS,
+  sdbmHash,
+  seedToString,
+} from './Maskicon.utilities';
+import type { MaskiconColorFamilyName } from './Maskicon.utilities';
 import README from './README.mdx';
 
 const meta: Meta<MaskiconProps> = {
@@ -243,6 +254,95 @@ export const Size: Story = {
       <Maskicon address={sampleAccountAddresses[2]} size={32} />
       <Maskicon address={sampleAccountAddresses[3]} size={48} />
       <Maskicon address={sampleAccountAddresses[4]} size={64} />
+    </Box>
+  ),
+};
+
+const ALL_MASKICON_COLOR_PAIRS = [
+  ...MASKICON_NEUTRAL_PAIRS,
+  ...MASKICON_TONAL_PAIRS,
+  ...MASKICON_COMPLEMENTARY_PAIRS,
+];
+
+function findSeedForColorPairIndex(index: number): number {
+  for (let seed = 0; seed < 100000; seed++) {
+    const hashVal = sdbmHash(seedToString(seed));
+    if (Math.abs(hashVal) % ALL_MASKICON_COLOR_PAIRS.length === index) {
+      return seed;
+    }
+  }
+  throw new Error(`No seed found for Maskicon color pair index ${index}`);
+}
+
+function svgToDataUri(svg: string): string {
+  return `data:image/svg+xml,${encodeURIComponent(svg.replace(/\s+/gu, ' ').trim())}`;
+}
+
+function hexRelativeLuminance(hex: string): number {
+  const channel = (offset: number): number => {
+    const value = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  };
+
+  return 0.2126 * channel(1) + 0.7152 * channel(3) + 0.0722 * channel(5);
+}
+
+function buildColorPairRow(familyName: MaskiconColorFamilyName) {
+  return ALL_MASKICON_COLOR_PAIRS.flatMap(([background, foreground], index) => {
+    if (getMaskiconColorFamily(background, foreground) !== familyName) {
+      return [];
+    }
+
+    const seed = findSeedForColorPairIndex(index);
+    return [
+      {
+        index,
+        background,
+        foreground,
+        svg: createMaskiconSVG(seed, 64),
+      },
+    ];
+  }).sort(
+    (a, b) =>
+      hexRelativeLuminance(b.background) - hexRelativeLuminance(a.background),
+  );
+}
+
+const COLOR_PAIR_ROWS = MASKICON_COLOR_FAMILY_NAMES.map((name) => ({
+  name,
+  items: buildColorPairRow(name),
+}));
+
+function ColorPairRow({
+  items,
+}: {
+  items: ReturnType<typeof buildColorPairRow>;
+}) {
+  return (
+    <Box className="flex flex-row flex-nowrap items-start gap-4 overflow-x-auto">
+      {items.map((item) => (
+        <Box
+          key={item.index}
+          className="flex shrink-0 flex-col items-center gap-2"
+        >
+          <img
+            alt={`Maskicon color pair ${item.index + 1}`}
+            width={64}
+            height={64}
+            src={svgToDataUri(item.svg)}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+export const ColorPairs: Story = {
+  render: () => (
+    <Box className="flex flex-col gap-6">
+      {COLOR_PAIR_ROWS.map((row) => (
+        <ColorPairRow key={row.name} items={row.items} />
+      ))}
     </Box>
   ),
 };

--- a/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.test.tsx
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.test.tsx
@@ -109,4 +109,25 @@ describe('Maskicon Utilities', () => {
     expect(firstCall).toBe(secondCall);
     expect(firstCall).toContain('<svg');
   });
+
+  it('getMaskiconColorFamily groups single-hue pairs by color', () => {
+    expect(MaskiconUtilities.getMaskiconColorFamily('#FF5C16', '#FCFCFC')).toBe(
+      'Orange',
+    );
+    expect(MaskiconUtilities.getMaskiconColorFamily('#D075FF', '#3D065F')).toBe(
+      'Purple',
+    );
+    expect(MaskiconUtilities.getMaskiconColorFamily('#BAF24A', '#013330')).toBe(
+      'Lime',
+    );
+    expect(MaskiconUtilities.getMaskiconColorFamily('#89B0FF', '#190066')).toBe(
+      'Blue',
+    );
+  });
+
+  it('getMaskiconColorFamily returns Mixed for complementary hues', () => {
+    expect(MaskiconUtilities.getMaskiconColorFamily('#EAC2FF', '#013330')).toBe(
+      'Mixed',
+    );
+  });
 });

--- a/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.utilities.ts
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/Maskicon.utilities.ts
@@ -7,7 +7,7 @@ import {
 // Maskicon SVG Creation
 // /////////////////////////////////////////////////////
 // Color Palettes
-const neutralPairs = [
+export const MASKICON_NEUTRAL_PAIRS = [
   ['#FF5C16', '#FCFCFC'],
   ['#FF5C16', '#131416'],
   ['#D075FF', '#FCFCFC'],
@@ -26,7 +26,7 @@ const neutralPairs = [
   ['#131416', '#89B0FF'],
 ];
 
-const tonalPairs = [
+export const MASKICON_TONAL_PAIRS = [
   ['#FFA680', '#FF5C16'],
   ['#661800', '#FF5C16'],
   ['#EAC2FF', '#D075FF'],
@@ -53,7 +53,7 @@ const tonalPairs = [
   ['#CCE7FF', '#190066'],
 ];
 
-const complementaryPairs = [
+export const MASKICON_COMPLEMENTARY_PAIRS = [
   ['#EAC2FF', '#013330'],
   ['#013330', '#EAC2FF'],
   ['#CCE7FF', '#661800'],
@@ -66,7 +66,48 @@ const complementaryPairs = [
   ['#013330', '#CCE7FF'],
 ];
 
-const colorPairs = neutralPairs.concat(tonalPairs).concat(complementaryPairs);
+const colorPairs = MASKICON_NEUTRAL_PAIRS.concat(MASKICON_TONAL_PAIRS).concat(
+  MASKICON_COMPLEMENTARY_PAIRS,
+);
+
+const MASKICON_COLOR_FAMILY_HEXES = {
+  Orange: new Set(['#FF5C16', '#FFA680', '#661800']),
+  Purple: new Set(['#D075FF', '#EAC2FF', '#3D065F']),
+  Lime: new Set(['#BAF24A', '#E5FFC3', '#013330']),
+  Blue: new Set(['#89B0FF', '#CCE7FF', '#190066']),
+} as const;
+
+export const MASKICON_COLOR_FAMILY_NAMES = [
+  'Orange',
+  'Purple',
+  'Lime',
+  'Blue',
+  'Mixed',
+] as const;
+
+export type MaskiconColorFamilyName =
+  (typeof MASKICON_COLOR_FAMILY_NAMES)[number];
+
+const MASKICON_HUE_FAMILY_NAMES = ['Orange', 'Purple', 'Lime', 'Blue'] as const;
+
+/**
+ * Returns the hue family for a Maskicon color pair.
+ *
+ * @param background Background hex color
+ * @param foreground Foreground hex color
+ * @returns The matching family name, or Mixed when two hues are combined
+ */
+export function getMaskiconColorFamily(
+  background: string,
+  foreground: string,
+): MaskiconColorFamilyName {
+  const families = MASKICON_HUE_FAMILY_NAMES.filter((name) => {
+    const hexes = MASKICON_COLOR_FAMILY_HEXES[name];
+    return hexes.has(background) || hexes.has(foreground);
+  });
+
+  return families.length === 1 ? families[0] : 'Mixed';
+}
 
 /**
  * SDBM hash function

--- a/packages/design-system-react/src/components/temp-components/Maskicon/README.mdx
+++ b/packages/design-system-react/src/components/temp-components/Maskicon/README.mdx
@@ -77,6 +77,12 @@ The `size` prop controls the dimensions (both height and width) of the Maskicon 
 
 <Canvas of={MaskiconStories.Size} />
 
+## Color pairs
+
+Maskicon uses a fixed palette of background and foreground color pairs. The gallery below shows every combination, one row per hue, ordered from lightest to darkest background.
+
+<Canvas of={MaskiconStories.ColorPairs} />
+
 ### `className`
 
 Use the `className` prop to add custom CSS classes to the component.


### PR DESCRIPTION
## **Description**

Adds a ColorPairs Storybook gallery for Maskicon on React and React Native so every background/foreground pairing can be reviewed by hue.

### What is the reason for the change?

Maskicon color pairings live in a large hardcoded list, but Storybook had no way to render every pair as a real identicon. Design review of contrast and hue grouping had to happen from hex tables instead of generated icons. This branch keeps the current palette so the gallery can be tested independently of the brand accent update.

This is a test branch only for visualization purposes, to be used with `feat/update-maskicon-color-pairings`

### What are the improvements?

- **Every pair is visible as a Maskicon:** the new `ColorPairs` story generates a real SVG for each pairing instead of showing hex labels only.
- **Grouped by hue:** pairs are split into Orange, Purple, Lime, Blue, and Mixed rows, each sorted from lightest to darkest background, so related combinations sit together.
- **Palette data is shared with the stories:** `MASKICON_NEUTRAL_PAIRS`, `MASKICON_TONAL_PAIRS`, and `MASKICON_COMPLEMENTARY_PAIRS` are exported, and `getMaskiconColorFamily()` classifies pairs so stories and tests do not duplicate hex lists.
- **Parity across platforms:** React and React Native get the same helper, tests, story structure, and README notes.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-design-system/pull/1497

## **Manual testing steps**

1. Open the React Maskicon `ColorPairs` story.
2. Confirm five rows: Orange, Purple, Lime, Blue, then Mixed.
3. Confirm each row is ordered from lightest to darkest background.
4. Repeat in React Native Storybook.
5. Run the scoped Maskicon tests for both packages.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I’ve completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I’ve manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)