### PR TITLE
Release 66.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "65.0.0",
+  "version": "66.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.0]
+
 ### Uncategorized
 
 - feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
@@ -745,7 +747,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.44.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.45.0...HEAD
+[0.45.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.44.0...@metamask/design-system-react-native@0.45.0
 [0.44.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.43.0...@metamask/design-system-react-native@0.44.0
 [0.43.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.1...@metamask/design-system-react-native@0.43.0
 [0.42.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.42.0...@metamask/design-system-react-native@0.42.1

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.45.0]
 
-### Uncategorized
+### Changed
 
-- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
-- revert: Revert telegram icon to official logo design ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))
+- **BREAKING:** Default typeface is now Inter instead of Geist ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+  - `FontFamily.Default` and the `Text` API are unchanged; twrnc default font names changed from `Geist-*` to `Inter-*`
+  - Peer dependencies updated to `@metamask/design-tokens@^11.0.0` and `@metamask/design-system-twrnc-preset@^0.11.0`
+  - Re-register Inter `.ttf` files under the new PostScript names or text falls back to the system font
+  - See [Migration Guide](./MIGRATION.md#from-version-0440-to-0450)
+- Restored the Telegram `Icon` artwork to the official logo ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))
 
 ## [0.44.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+- revert: Revert telegram icon to official logo design ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))
+
 ## [0.44.0]
 
 ### Changed

--- a/packages/design-system-react-native/MIGRATION.md
+++ b/packages/design-system-react-native/MIGRATION.md
@@ -4,6 +4,7 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Table of Contents
 
+- [From version 0.44.0 to 0.45.0](#from-version-0440-to-0450)
 - [From version 0.42.1 to 0.43.0](#from-version-0421-to-0430)
 - [From version 0.41.0 to 0.42.0](#from-version-0410-to-0420)
 - [From version 0.37.0 to 0.38.0](#from-version-0370-to-0380)
@@ -51,6 +52,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TabEmptyState Component](#tabemptystate-component)
   - [Toast Component](#toast-component)
 - [Version Updates](#version-updates)
+  - [From version 0.44.0 to 0.45.0](#from-version-0440-to-0450)
   - [From version 0.42.1 to 0.43.0](#from-version-0421-to-0430)
   - [From version 0.41.0 to 0.42.0](#from-version-0410-to-0420)
   - [From version 0.37.0 to 0.38.0](#from-version-0370-to-0380)
@@ -74,9 +76,9 @@ This guide provides detailed instructions for migrating your project from one ve
 
 ## Version Updates
 
-### From version 0.42.1 to 0.43.0
+### From version 0.44.0 to 0.45.0
 
-<a id="from-version-0421-to-0430"></a>
+<a id="from-version-0440-to-0450"></a>
 
 <a id="default-typeface-geist-to-inter"></a>
 
@@ -102,7 +104,9 @@ Copy the six Inter `.ttf` files from [`apps/storybook-react-native/fonts/Inter`]
 Inter is available under the [SIL Open Font License](https://github.com/rsms/inter).
 
 ```tsx
-// Before
+// Before (0.44.0)
+import { useFonts } from 'expo-font';
+
 useFonts({
   'Geist-Regular': require('./fonts/Geist/Geist-Regular.otf'),
   'Geist-RegularItalic': require('./fonts/Geist/Geist-RegularItalic.otf'),
@@ -114,7 +118,9 @@ useFonts({
 ```
 
 ```tsx
-// After
+// After (0.45.0)
+import { useFonts } from 'expo-font';
+
 useFonts({
   'Inter-Regular': require('./fonts/Inter/Inter-Regular.ttf'),
   'Inter-RegularItalic': require('./fonts/Inter/Inter-RegularItalic.ttf'),
@@ -126,6 +132,10 @@ useFonts({
 ```
 
 **Impact:** Text renders with the system fallback until the fonts are re-registered under the new names, so this must ship together with the asset swap. Expect minor reflow, since Inter's metrics differ slightly from Geist's.
+
+### From version 0.42.1 to 0.43.0
+
+<a id="from-version-0421-to-0430"></a>
 
 <a id="iconname-unused-icons-removed"></a>
 

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",
@@ -90,8 +90,8 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-twrnc-preset": "^0.10.0",
-    "@metamask/design-tokens": "^10.0.0",
+    "@metamask/design-system-twrnc-preset": "^0.11.0",
+    "@metamask/design-tokens": "^11.0.0",
     "@metamask/utils": "^11.12.1",
     "expo-image": ">=3.0.0",
     "lodash": "^4.17.21",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+- revert: Revert telegram icon to official logo design ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))
+
 ## [0.40.0]
 
 ### Changed

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0]
+
 ### Uncategorized
 
 - feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
@@ -545,7 +547,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.40.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.41.0...HEAD
+[0.41.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.40.0...@metamask/design-system-react@0.41.0
 [0.40.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.39.0...@metamask/design-system-react@0.40.0
 [0.39.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.1...@metamask/design-system-react@0.39.0
 [0.38.1]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.38.0...@metamask/design-system-react@0.38.1

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.41.0]
 
-### Uncategorized
+### Changed
 
-- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
-- revert: Revert telegram icon to official logo design ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))
+- **BREAKING:** Default typeface is now Inter instead of Geist ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+  - `FontFamily.Default`, the `font-default` utility, and `Text` props are unchanged; only the typeface behind them changed
+  - Peer dependencies updated to `@metamask/design-tokens@^11.0.0` and `@metamask/design-system-tailwind-preset@^0.13.0`
+  - Swap Geist `@font-face` files for Inter; expect minor reflow from metric differences
+  - See [Migration Guide](./MIGRATION.md#from-version-0400-to-0410)
+- Restored the Telegram `Icon` artwork to the official logo ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))
 
 ## [0.40.0]
 

--- a/packages/design-system-react/MIGRATION.md
+++ b/packages/design-system-react/MIGRATION.md
@@ -48,6 +48,7 @@ This guide provides detailed instructions for migrating your project from one ve
   - [TextFieldSearch Component](#textfieldsearch-component)
   - [FormTextField Component](#formtextfield-component)
 - [Version Updates](#version-updates)
+  - [From version 0.40.0 to 0.41.0](#from-version-0400-to-0410)
   - [From version 0.38.1 to 0.39.0](#from-version-0381-to-0390)
   - [From version 0.36.0 to 0.37.0](#from-version-0360-to-0370)
   - [From version 0.34.0 to 0.35.0](#from-version-0340-to-0350)
@@ -3630,9 +3631,9 @@ The new `TextFieldSearch` reuses `TextField`'s Tailwind chrome instead of the `m
 
 ## Version Updates
 
-### From version 0.38.1 to 0.39.0
+### From version 0.40.0 to 0.41.0
 
-<a id="from-version-0381-to-0390"></a>
+<a id="from-version-0400-to-0410"></a>
 
 <a id="default-typeface-geist-to-inter"></a>
 
@@ -3645,7 +3646,7 @@ The new `TextFieldSearch` reuses `TextField`'s Tailwind chrome instead of the `m
 Copy the Inter `.woff2` files from [`apps/storybook-react/fonts/Inter`](../../apps/storybook-react/fonts/Inter) and update your `@font-face` declarations to declare the family as `'Inter'`. Six cuts are required: regular, medium, and semibold, each with an italic. Inter is available under the [SIL Open Font License](https://github.com/rsms/inter).
 
 ```css
-/* Before */
+/* Before (0.40.0) */
 @font-face {
   font-family: 'Geist';
   font-style: normal;
@@ -3655,7 +3656,7 @@ Copy the Inter `.woff2` files from [`apps/storybook-react/fonts/Inter`](../../ap
 ```
 
 ```css
-/* After */
+/* After (0.41.0) */
 @font-face {
   font-family: 'Inter';
   font-style: normal;
@@ -3666,7 +3667,11 @@ Copy the Inter `.woff2` files from [`apps/storybook-react/fonts/Inter`](../../ap
 
 See the [design tokens migration guide](../design-tokens/MIGRATION.md#from-version-10x-to-1100) for the full cut list.
 
-**Impact:** No code changes are required beyond swapping the font assets. Expect minor reflow, since Inter's metrics differ slightly from Geist's and text may wrap differently at tight widths.
+**Impact:** No component code changes are required beyond swapping the font assets. Expect minor reflow, since Inter's metrics differ slightly from Geist's and text may wrap differently at tight widths.
+
+### From version 0.38.1 to 0.39.0
+
+<a id="from-version-0381-to-0390"></a>
 
 <a id="iconname-unused-icons-removed"></a>
 

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",
@@ -83,8 +83,8 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-system-tailwind-preset": "^0.12.0",
-    "@metamask/design-tokens": "^10.0.0",
+    "@metamask/design-system-tailwind-preset": "^0.13.0",
+    "@metamask/design-tokens": "^11.0.0",
     "@metamask/utils": "^11.12.1",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+- revert: Revert telegram icon to official logo design ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))
+
 ## [0.36.0]
 
 ### Changed

--- a/packages/design-system-shared/CHANGELOG.md
+++ b/packages/design-system-shared/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
-- revert: Revert telegram icon to official logo design ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))
-
 ## [0.36.0]
 
 ### Changed

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.0]
 
+### Changed
+
+- **BREAKING:** Updated peer dependency to `@metamask/design-tokens@^11.0.0` ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+  - Required coordination bump with `@metamask/design-tokens@11.0.0`; preset utilities are unchanged
+  - Default typeface change is in design-tokens (`--font-family-default` is now Inter)
+  - See [design-tokens Migration Guide](../design-tokens/MIGRATION.md#from-version-10x-to-1100)
+
 ## [0.12.0]
 
 ### Changed

--- a/packages/design-system-tailwind-preset/CHANGELOG.md
+++ b/packages/design-system-tailwind-preset/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+
 ## [0.12.0]
 
 ### Changed
@@ -111,7 +113,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.12.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.13.0...HEAD
+[0.13.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.12.0...@metamask/design-system-tailwind-preset@0.13.0
 [0.12.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.11.0...@metamask/design-system-tailwind-preset@0.12.0
 [0.11.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.10.0...@metamask/design-system-tailwind-preset@0.11.0
 [0.10.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-tailwind-preset@0.9.0...@metamask/design-system-tailwind-preset@0.10.0

--- a/packages/design-system-tailwind-preset/package.json
+++ b/packages/design-system-tailwind-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-tailwind-preset",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Design System Tailwind CSS preset for MetaMask projects",
   "keywords": [
     "MetaMask",
@@ -57,7 +57,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^10.0.0",
+    "@metamask/design-tokens": "^11.0.0",
     "tailwindcss": "^3.0.0"
   },
   "engines": {

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+
 ## [0.10.0]
 
 ### Changed

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0]
+
 ### Uncategorized
 
 - feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
@@ -114,7 +116,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MetaMask design token integration for React Native
 - TWRNC preset configuration with MetaMask styling utilities
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.10.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.11.0...HEAD
+[0.11.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.10.0...@metamask/design-system-twrnc-preset@0.11.0
 [0.10.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.9.0...@metamask/design-system-twrnc-preset@0.10.0
 [0.9.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.8.0...@metamask/design-system-twrnc-preset@0.9.0
 [0.8.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-twrnc-preset@0.7.0...@metamask/design-system-twrnc-preset@0.8.0

--- a/packages/design-system-twrnc-preset/CHANGELOG.md
+++ b/packages/design-system-twrnc-preset/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0]
 
-### Uncategorized
+### Changed
 
-- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+- **BREAKING:** Default font PostScript names are now `Inter-*` instead of `Geist-*` ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+  - `font-default-regular` maps to `Inter-Regular`, with matching updates for medium, semibold, and italic cuts
+  - Peer dependency updated to `@metamask/design-tokens@^11.0.0`
+  - See [React Native Migration Guide](../design-system-react-native/MIGRATION.md#from-version-0440-to-0450)
 
 ## [0.10.0]
 

--- a/packages/design-system-twrnc-preset/package.json
+++ b/packages/design-system-twrnc-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-twrnc-preset",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Design System twrnc Preset",
   "keywords": [
     "MetaMask",
@@ -82,7 +82,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/design-tokens": "^10.0.0",
+    "@metamask/design-tokens": "^11.0.0",
     "react": ">=18.2.0"
   },
   "engines": {

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0]
+
 ### Uncategorized
 
 - feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
@@ -483,7 +485,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@10.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@11.0.0...HEAD
+[11.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@10.0.0...@metamask/design-tokens@11.0.0
 [10.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@9.0.0...@metamask/design-tokens@10.0.0
 [9.0.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.7.0...@metamask/design-tokens@9.0.0
 [8.7.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-tokens@8.6.0...@metamask/design-tokens@8.7.0

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [11.0.0]
 
-### Uncategorized
+### Changed
 
-- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+- **BREAKING:** Replaced Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+  - `--font-family-default` is now `'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif`
+  - `fontFamilies.default` is now `'Inter'`
+  - Accent (MM Sans) and hero (MM Poly) families are unchanged; font size, weight, line height, and letter spacing tokens are unchanged
+  - Consumers must bundle the Inter font files; the package does not ship font binaries
+  - See [Migration Guide](./MIGRATION.md#from-version-10x-to-1100)
 
 ## [10.0.0]
 

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: replace Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
+
 ## [10.0.0]
 
 ### Changed

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-tokens",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "description": "Design tokens to be used throughout MetaMask products",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,8 +3411,8 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-twrnc-preset": ^0.10.0
-    "@metamask/design-tokens": ^10.0.0
+    "@metamask/design-system-twrnc-preset": ^0.11.0
+    "@metamask/design-tokens": ^11.0.0
     "@metamask/utils": ^11.12.1
     expo-image: ">=3.0.0"
     lodash: ^4.17.21
@@ -3462,8 +3462,8 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-system-tailwind-preset": ^0.12.0
-    "@metamask/design-tokens": ^10.0.0
+    "@metamask/design-system-tailwind-preset": ^0.13.0
+    "@metamask/design-tokens": ^11.0.0
     "@metamask/utils": ^11.12.1
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3509,7 +3509,7 @@ __metadata:
     ts-jest: "npm:^29.2.5"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^10.0.0
+    "@metamask/design-tokens": ^11.0.0
     tailwindcss: ^3.0.0
   languageName: unknown
   linkType: soft
@@ -3541,7 +3541,7 @@ __metadata:
     twrnc: "npm:^4.5.1"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/design-tokens": ^10.0.0
+    "@metamask/design-tokens": ^11.0.0
     react: ">=18.2.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Release 66.0.0

This release replaces Geist with Inter as the default typeface. `--font-family-default` / `fontFamilies.default` are now Inter, and React Native twrnc default font names changed from `Geist-*` to `Inter-*`. Consumers must bundle the Inter font files. Accent (MM Sans) and hero (MM Poly) are unchanged.

Includes [#1489](https://github.com/MetaMask/metamask-design-system/pull/1489) (Inter default typeface) and [#1500](https://github.com/MetaMask/metamask-design-system/pull/1500) (Telegram icon revert).

### 📦 Package Versions

- `@metamask/design-tokens`: **11.0.0**
- `@metamask/design-system-react`: **0.41.0**
- `@metamask/design-system-react-native`: **0.45.0**
- `@metamask/design-system-tailwind-preset`: **0.13.0**
- `@metamask/design-system-twrnc-preset`: **0.11.0**

`@metamask/design-system-shared` is **not** published in this release (JSDoc-only typeface note; Telegram artwork is vendored in the platform packages).

### 🎨 Design Tokens (11.0.0)

#### Changed

- **BREAKING:** Replaced Geist with Inter as the default typeface ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
  - `--font-family-default` is now `'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif`
  - `fontFamilies.default` is now `'Inter'`
  - Size, weight, line height, and letter spacing tokens are unchanged
  - Migration: [design-tokens MIGRATION.md](./packages/design-tokens/MIGRATION.md#from-version-10x-to-1100)

### 🌐 React Web Updates (0.41.0)

#### Changed

- **BREAKING:** Default typeface is now Inter instead of Geist ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
  - `FontFamily.Default`, `font-default`, and `Text` props are unchanged
  - Peers updated to `@metamask/design-tokens@^11.0.0` and `@metamask/design-system-tailwind-preset@^0.13.0`
  - Migration: [React MIGRATION.md](./packages/design-system-react/MIGRATION.md#from-version-0400-to-0410)
- Restored the Telegram `Icon` artwork to the official logo ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))

### 📱 React Native Updates (0.45.0)

#### Changed

- **BREAKING:** Default typeface is now Inter instead of Geist ([#1489](https://github.com/MetaMask/metamask-design-system/pull/1489))
  - twrnc default font names changed from `Geist-*` to `Inter-*`
  - Peers updated to `@metamask/design-tokens@^11.0.0` and `@metamask/design-system-twrnc-preset@^0.11.0`
  - Migration: [React Native MIGRATION.md](./packages/design-system-react-native/MIGRATION.md#from-version-0440-to-0450)
- Restored the Telegram `Icon` artwork to the official logo ([#1500](https://github.com/MetaMask/metamask-design-system/pull/1500))

### ⚠️ Breaking Changes

#### Default typeface: Geist to Inter (both platforms)

**What Changed:**

- Token values: `--font-family-default` / `fontFamilies.default` are Inter
- React Native: `font-default-*` PostScript names are `Inter-*`
- Consumers must ship Inter font files (six cuts: regular / medium / semibold, each with italic)

**Migration (web):**

```css
/* Before (tokens 10.x / react 0.40.0) */
@font-face {
  font-family: 'Geist';
  font-style: normal;
  font-weight: 600;
  src: url('fonts/Geist/Geist-SemiBold.woff2') format('woff2');
}

/* After (tokens 11.0.0 / react 0.41.0) */
@font-face {
  font-family: 'Inter';
  font-style: normal;
  font-weight: 600;
  src: url('fonts/Inter/Inter-SemiBold.woff2') format('woff2');
}
```

**Migration (React Native):**

```tsx
import { useFonts } from 'expo-font';

// After (0.45.0)
useFonts({
  'Inter-Regular': require('./fonts/Inter/Inter-Regular.ttf'),
  'Inter-RegularItalic': require('./fonts/Inter/Inter-RegularItalic.ttf'),
  'Inter-Medium': require('./fonts/Inter/Inter-Medium.ttf'),
  'Inter-MediumItalic': require('./fonts/Inter/Inter-MediumItalic.ttf'),
  'Inter-SemiBold': require('./fonts/Inter/Inter-SemiBold.ttf'),
  'Inter-SemiBoldItalic': require('./fonts/Inter/Inter-SemiBoldItalic.ttf'),
});
```

**Impact:**

- Web: swap `@font-face` assets; no component API changes
- React Native: re-register fonts under the new names or text falls back to the system font
- Expect minor reflow from Inter vs Geist metrics

See migration guides:

- [design-tokens](./packages/design-tokens/MIGRATION.md#from-version-10x-to-1100)
- [React](./packages/design-system-react/MIGRATION.md#from-version-0400-to-0410)
- [React Native](./packages/design-system-react-native/MIGRATION.md#from-version-0440-to-0450)

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] design-tokens: major (`10.0.0 → 11.0.0`) — breaking default typeface (post-1.0)
  - [x] design-system-react: minor (`0.40.0 → 0.41.0`) — breaking default typeface (pre-1.0)
  - [x] design-system-react-native: minor (`0.44.0 → 0.45.0`) — breaking default typeface (pre-1.0)
  - [x] design-system-tailwind-preset: minor (`0.12.0 → 0.13.0`) — peer `@metamask/design-tokens@^11.0.0` (pre-1.0)
  - [x] design-system-twrnc-preset: minor (`0.10.0 → 0.11.0`) — Inter PostScript names (pre-1.0)
  - [x] design-system-shared: skipped — no consumer-facing publish in this release
- [x] Breaking changes documented with migration guidance
- [x] Migration guides updated with before/after examples (if breaking changes)
- [x] PR references included in changelog entries

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've reviewed the [Release Workflow](./.cursor/rules/release-workflow.md) cursor rule
- [x] All tests pass (`yarn build && yarn test && yarn lint`)
- [x] Changelog validation passes (`yarn changelog:validate`)

## **Pre-merge reviewer checklist**

- [ ] I've reviewed the [Reviewing Release PRs](./docs/reviewing-release-prs.md) guide
- [ ] Package versions follow semantic versioning
- [ ] Changelog entries are consumer-facing (not commit message regurgitation)
- [ ] Breaking changes are documented in MIGRATION.md with examples
- [ ] All unreleased changes are accounted for in changelogs

Made with [Cursor](https://cursor.com)