### PR TITLE
fix(react): stop ButtonIcon shrinking in flex containers

### DIFF
--- a/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/design-system-react/src/components/ButtonIcon/ButtonIcon.tsx
@@ -32,7 +32,7 @@ export const ButtonIcon = forwardRef<HTMLButtonElement, ButtonIconProps>(
 
     const mergedClassName = twMerge(
       // Base styles
-      'inline-flex items-center justify-center p-0',
+      'inline-flex shrink-0 items-center justify-center p-0',
       // Size styles
       TWCLASSMAP_BUTTONICON_SIZE_DIMENSION[size],
       // Variant styles


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

`ButtonIcon` sets its dimensions with `h-8 w-8` but never opts out of flex shrinking. The CSS default is `flex-shrink: 1`, so whenever the button is a flex item in a row that overflows, it is the element that absorbs the overflow and stops being square. On the `Filled` and `Floating` variants, which are `rounded-full`, the squashed box renders as an ellipse rather than a circle.

This is what happens in the Extension onboarding "Create password" screen (MetaMask/metamask-extension#46163): `FormTextField` is `inline-flex`, and `.mm-text-field__input` has `width: 100%` + `flex-grow: 1`, so the input's flex basis alone fills the container. The row overflows by the width of the accessory, and the show/hide eye `ButtonIcon` shrinks from 32px to ~28px wide while staying 32px tall.

The fix adds `shrink-0` to the base classes, matching what `AvatarBase` already does for the same reason:

```
'inline-flex shrink-0 items-center justify-center p-0'
```

Because it is in the base class list and goes through `twMerge`, consumers that genuinely want a shrinkable icon button can still pass `shrink` via `className`.

This PR is deliberately scoped to that one line. It is now based on `main` rather than on the pill-shape branch, so it carries no other changes and can land independently of MetaMask/metamask-design-system#1494.

**React Native was checked and needs no change.** Yoga's default is `flexShrink: 0`, and neither `ButtonIcon` nor the underlying `ButtonAnimated` sets a shrink value, so the RN component already keeps its square dimensions inside a row.

## **Related issues**

Related: MetaMask/metamask-extension#46163

## **Manual testing steps**

1. Render a `ButtonIcon` as the end accessory of an `inline-flex` container whose input has `width: 100%` and `flex-grow: 1` (the Extension `FormTextField` layout).
2. Before this change the button measures 27.97 x 32; after it measures 32 x 32.
3. `yarn workspace @metamask/design-system-react run test` — all suites pass.

No test was added, since `shrink-0` is a default style like the rest of the base classes.

## **Screenshots/Recordings**

Reproduced in Storybook using the real `ButtonIcon` (`Filled` variant) in the Extension `FormTextField` layout, magnified 2x. The "before" row is the same component with `shrink` re-enabled via `className`, which reproduces the pre-fix computed style exactly.

<img width="2364" height="1656" alt="image" src="https://github.com/user-attachments/assets/909c7d3e-6bbb-42e1-84d5-0ea8adf0eeec" />

### **Before**

27.97 x 32 — oval.

<img width="84" height="96" alt="image" src="https://github.com/user-attachments/assets/aad789c6-ad75-45a3-95fd-a2d37ee4ecc5" />

### **After**

32 x 32 — circle.

<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/e4827776-556e-4371-80b0-4ac52d13f8e8" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb292a5d-20ef-4c60-a10b-8e041044a3e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb292a5d-20ef-4c60-a10b-8e041044a3e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

