### PR TITLE
refactor(HeaderSubpage): remove ListItem dependency

### DIFF
--- a/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -89,7 +89,7 @@ describe('HeaderSubpage', () => {
     });
 
     describe('when testID is provided', () => {
-      it('forwards testID to root ListItem', () => {
+      it('forwards testID to root Box', () => {
         const { getByTestId } = render(
           <HeaderSubpage title="Test Title" testID={CONTAINER_TEST_ID} />,
         );
@@ -412,7 +412,7 @@ describe('HeaderSubpage', () => {
   });
 
   describe('twClassName', () => {
-    it('merges default header shell classes on root ListItem', () => {
+    it('merges default header shell classes on root Box', () => {
       const { getByTestId } = render(
         <HeaderSubpage title="Title" testID={CONTAINER_TEST_ID} />,
       );
@@ -442,7 +442,7 @@ describe('HeaderSubpage', () => {
   });
 
   describe('style', () => {
-    it('merges caller style with root ListItem styles', () => {
+    it('merges caller style with root Box styles', () => {
       const customStyle = { backgroundColor: 'red' };
       const { getByTestId } = render(
         <HeaderSubpage

--- a/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.tsx
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.tsx
@@ -1,15 +1,20 @@
 // Third party dependencies.
-import { mergeTwClassName } from '@metamask/design-system-shared';
+import {
+  BoxAlignItems,
+  mergeTwClassName,
+} from '@metamask/design-system-shared';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // External dependencies.
+import { Box } from '../Box';
+import { BoxRow } from '../BoxRow';
 import { ButtonIcon, ButtonIconSize } from '../ButtonIcon';
 import type { ButtonIconProps } from '../ButtonIcon';
+import { Content } from '../Content';
 import { IconName } from '../Icon';
-import { ListItem } from '../ListItem';
 
 // Internal dependencies.
 import type { HeaderSubpageProps } from './HeaderSubpage.types';
@@ -43,7 +48,25 @@ export const HeaderSubpage: React.FC<HeaderSubpageProps> = ({
   style,
   accessoryGap = 2,
   testID,
-  ...listItemProps
+  variant,
+  avatar,
+  title,
+  titleProps,
+  titleStartAccessory,
+  titleEndAccessory,
+  description,
+  descriptionProps,
+  descriptionStartAccessory,
+  descriptionEndAccessory,
+  value,
+  valueProps,
+  valueStartAccessory,
+  valueEndAccessory,
+  subvalue,
+  subvalueProps,
+  subvalueStartAccessory,
+  subvalueEndAccessory,
+  ...boxProps
 }) => {
   const tw = useTailwind();
   const insets = useSafeAreaInsets();
@@ -107,19 +130,64 @@ export const HeaderSubpage: React.FC<HeaderSubpageProps> = ({
     return undefined;
   }, [endAccessory, resolvedEndButtonIconProps, tw]);
 
-  return (
-    <ListItem
-      {...listItemProps}
-      testID={testID}
+  const hasRowAccessories =
+    Boolean(resolvedStartAccessory) || Boolean(resolvedEndAccessory);
+
+  const content = (
+    <Content
+      twClassName={hasRowAccessories ? 'flex-1 min-w-0' : undefined}
+      variant={variant}
+      avatar={avatar}
+      title={title}
+      titleProps={titleProps}
+      titleStartAccessory={titleStartAccessory}
+      titleEndAccessory={titleEndAccessory}
+      description={description}
+      descriptionProps={descriptionProps}
+      descriptionStartAccessory={descriptionStartAccessory}
+      descriptionEndAccessory={descriptionEndAccessory}
+      value={value}
+      valueProps={valueProps}
+      valueStartAccessory={valueStartAccessory}
+      valueEndAccessory={valueEndAccessory}
+      subvalue={subvalue}
+      subvalueProps={subvalueProps}
+      subvalueStartAccessory={subvalueStartAccessory}
+      subvalueEndAccessory={subvalueEndAccessory}
+    />
+  );
+
+  const headerContent = hasRowAccessories ? (
+    <BoxRow
       startAccessory={resolvedStartAccessory}
       endAccessory={resolvedEndAccessory}
-      accessoryGap={accessoryGap}
-      twClassName={mergeTwClassName(
-        'h-14 px-2 py-0 justify-center',
-        twClassName,
-      )}
-      style={[includesTopInset && { marginTop: insets.top }, style]}
-    />
+      alignItems={BoxAlignItems.Center}
+      gap={accessoryGap}
+    >
+      {content}
+    </BoxRow>
+  ) : (
+    content
+  );
+
+  const rootTwClassName = mergeTwClassName(
+    'h-14 px-2 py-0 justify-center',
+    twClassName,
+  );
+
+  return (
+    <Box
+      {...boxProps}
+      testID={testID}
+      twClassName={rootTwClassName}
+      style={[
+        tw.style(rootTwClassName),
+        includesTopInset && { marginTop: insets.top },
+        style,
+      ]}
+    >
+      {headerContent}
+    </Box>
   );
 };
 

--- a/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -1,63 +1,90 @@
 import type { ReactNode } from 'react';
 
+import type { BoxProps } from '../Box';
 import type { ButtonIconProps } from '../ButtonIcon';
-import type { ListItemProps } from '../ListItem';
+import type { ContentProps } from '../Content';
 
 /**
  * HeaderSubpage component props.
  *
- * Subpage navigation row built on {@link ListItem} with optional back/close
- * shortcuts matching {@link HeaderStandard}.
+ * Subpage navigation row with optional back/close shortcuts matching
+ * {@link HeaderStandard}. Uses Box and Content directly for a lightweight
+ * header without ListItem's padding and min-height defaults.
  */
-export type HeaderSubpageProps = Omit<
-  ListItemProps,
-  'startAccessory' | 'endAccessory' | 'isInteractive' | 'children'
-> & {
-  /**
-   * Callback when the back button is pressed.
-   * If provided, a back button will be rendered as the start accessory.
-   */
-  onBack?: () => void;
-  /**
-   * Additional props to pass to the back ButtonIcon.
-   * If provided, a back button will be rendered with these props spread.
-   */
-  backButtonProps?: Omit<ButtonIconProps, 'iconName'>;
-  /**
-   * Callback when the close button is pressed.
-   * If provided, a close button will be added to the end accessories.
-   */
-  onClose?: () => void;
-  /**
-   * Additional props to pass to the close ButtonIcon.
-   * If provided, a close button will be added with these props spread.
-   */
-  closeButtonProps?: Omit<ButtonIconProps, 'iconName'>;
-  /**
-   * Optional ButtonIcon props to render as the start accessory.
-   * Only used if `startAccessory` is not provided.
-   */
-  startButtonIconProps?: ButtonIconProps;
-  /**
-   * Optional array of ButtonIcon props to render as additional end accessories.
-   * Rendered in reverse order (first item appears rightmost).
-   * Only used if `endAccessory` is not provided.
-   */
-  endButtonIconProps?: ButtonIconProps[];
-  /**
-   * Optional content before the ListItem content row.
-   * Takes priority over `startButtonIconProps` and back shortcuts.
-   */
-  startAccessory?: ReactNode;
-  /**
-   * Optional content after the ListItem content row.
-   * Takes priority over `endButtonIconProps` and close shortcuts.
-   */
-  endAccessory?: ReactNode;
-  /**
-   * When true, applies top safe-area inset as `marginTop` on the root ListItem.
-   *
-   * @default false
-   */
-  includesTopInset?: boolean;
-};
+export type HeaderSubpageProps = Omit<BoxProps, 'children'> &
+  Pick<
+    ContentProps,
+    | 'variant'
+    | 'avatar'
+    | 'title'
+    | 'titleProps'
+    | 'titleStartAccessory'
+    | 'titleEndAccessory'
+    | 'description'
+    | 'descriptionProps'
+    | 'descriptionStartAccessory'
+    | 'descriptionEndAccessory'
+    | 'value'
+    | 'valueProps'
+    | 'valueStartAccessory'
+    | 'valueEndAccessory'
+    | 'subvalue'
+    | 'subvalueProps'
+    | 'subvalueStartAccessory'
+    | 'subvalueEndAccessory'
+  > & {
+    /**
+     * Gap between row shell accessories and inner content.
+     * Uses design-system spacing tokens (`BoxSpacing`); `2` is 8px.
+     *
+     * @default 2
+     */
+    accessoryGap?: BoxProps['gap'];
+    /**
+     * Callback when the back button is pressed.
+     * If provided, a back button will be rendered as the start accessory.
+     */
+    onBack?: () => void;
+    /**
+     * Additional props to pass to the back ButtonIcon.
+     * If provided, a back button will be rendered with these props spread.
+     */
+    backButtonProps?: Omit<ButtonIconProps, 'iconName'>;
+    /**
+     * Callback when the close button is pressed.
+     * If provided, a close button will be added to the end accessories.
+     */
+    onClose?: () => void;
+    /**
+     * Additional props to pass to the close ButtonIcon.
+     * If provided, a close button will be added with these props spread.
+     */
+    closeButtonProps?: Omit<ButtonIconProps, 'iconName'>;
+    /**
+     * Optional ButtonIcon props to render as the start accessory.
+     * Only used if `startAccessory` is not provided.
+     */
+    startButtonIconProps?: ButtonIconProps;
+    /**
+     * Optional array of ButtonIcon props to render as additional end accessories.
+     * Rendered in reverse order (first item appears rightmost).
+     * Only used if `endAccessory` is not provided.
+     */
+    endButtonIconProps?: ButtonIconProps[];
+    /**
+     * Optional content before the content row.
+     * Takes priority over `startButtonIconProps` and back shortcuts.
+     */
+    startAccessory?: ReactNode;
+    /**
+     * Optional content after the content row.
+     * Takes priority over `endButtonIconProps` and close shortcuts.
+     */
+    endAccessory?: ReactNode;
+    /**
+     * When true, applies top safe-area inset as `marginTop` on the root Box.
+     *
+     * @default false
+     */
+    includesTopInset?: boolean;
+  };

--- a/packages/design-system-react-native/src/components/HeaderSubpage/README.md
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/README.md
@@ -1,6 +1,6 @@
 # HeaderSubpage
 
-HeaderSubpage is a subpage navigation row with optional back and close actions. It composes [ListItem](../ListItem/README.md) for left-aligned identity content (avatar, title, description) and applies header shell styling (`h-14`, optional safe-area inset). Use [HeaderStandard](../HeaderStandard/README.md) for centered-title headers. Use [TitleSubpage](../TitleSubpage/README.md) for the rich title block below this row (amount, bottom label, and similar).
+HeaderSubpage is a subpage navigation row with optional back and close actions. It composes [Content](../Content/README.md) for left-aligned identity content (avatar, title, description) with [BoxRow](../BoxRow/README.md) for row accessories, and applies header shell styling (`h-14`, optional safe-area inset). Use [HeaderStandard](../HeaderStandard/README.md) for centered-title headers. Use [TitleSubpage](../TitleSubpage/README.md) for the rich title block below this row (amount, bottom label, and similar).
 
 ```tsx
 import {
@@ -20,7 +20,7 @@ import {
 
 ## Props
 
-Inherits [ListItem](../ListItem/README.md) / [Content](../Content/README.md) props (`value`, `variant`, `testID`, and other root `View` props). `isInteractive` and `children` are not supported. Secondary text uses **`description`** (ListItem), not `subtitle` ([HeaderStandard](../HeaderStandard/README.md) / [TitleSubpage](../TitleSubpage/README.md)).
+Inherits [Box](../Box/README.md) and [Content](../Content/README.md) props (`value`, `variant`, `testID`, and other root `View` props). Secondary text uses **`description`** (Content), not `subtitle` ([HeaderStandard](../HeaderStandard/README.md) / [TitleSubpage](../TitleSubpage/README.md)).
 
 ### `title`
 
@@ -227,7 +227,7 @@ Custom end content. Takes priority over `endButtonIconProps` and close shortcuts
 
 ### `includesTopInset`
 
-When `true`, applies the device top safe-area inset as `marginTop` on the root ListItem so the header clears the notch.
+When `true`, applies the device top safe-area inset as `marginTop` on the root Box so the header clears the notch.
 
 | TYPE      | REQUIRED | DEFAULT |
 | --------- | -------- | ------- |
@@ -256,7 +256,7 @@ Use the `twClassName` prop to add Tailwind CSS classes to the component. These c
 - Add new styles that don't exist in the default component
 - Override the component's default styles when needed
 
-Default shell classes include `h-14 px-2 py-0 justify-center` (overriding ListItem padding for header density).
+Default shell classes include `h-14 px-2 py-0 justify-center`.
 
 | TYPE     | REQUIRED | DEFAULT     |
 | -------- | -------- | ----------- |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

This PR refactors the `HeaderSubpage` component in `@metamask/design-system-react-native` to remove its dependency on `ListItem`, using `Box`, `BoxRow`, and `Content` directly instead.

### What changed:

1. **Component implementation**: Replaced `ListItem` composition with direct `Box` (root), `BoxRow` (accessory layout), and `Content` (title/description/avatar) usage
2. **Types**: Updated `HeaderSubpageProps` to extend `BoxProps` and pick from `ContentProps` instead of extending `ListItemProps`
3. **Documentation**: Updated README to reference `Box` and `Content` instead of `ListItem`
4. **Tests**: Updated test descriptions to reference `Box` instead of `ListItem`

### Why this change:

This provides a more lightweight header component without inheriting ListItem's padding and min-height defaults, giving more control over the header's styling.

## **Related issues**

N/A

## **Manual testing steps**

1. Run `yarn workspace @metamask/design-system-react-native run jest HeaderSubpage --no-coverage`
2. All 31 tests should pass
3. Open Storybook and verify HeaderSubpage stories render correctly

## **Screenshots/Recordings**

N/A - Internal refactor with no visual changes

### **Before**

Component used ListItem internally

### **After**

Component uses Box, BoxRow, and Content directly

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C0BRAHB1KNK/p1789051118847109?thread_ts=1789051118.847109&cid=C0BRAHB1KNK)

<div><a href="https://cursor.com/agents/bc-5080461d-5409-5347-bdc4-bc09ba6a89c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5080461d-5409-5347-bdc4-bc09ba6a89c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

