### PR TITLE
feat(react): add HeaderSubpage component

### DIFF
--- a/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react-native/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { HeaderSubpagePropsShared } from '@metamask/design-system-shared';
 
 import type { ButtonIconProps } from '../ButtonIcon';
 import type { ListItemProps } from '../ListItem';
@@ -11,53 +11,38 @@ import type { ListItemProps } from '../ListItem';
  */
 export type HeaderSubpageProps = Omit<
   ListItemProps,
-  'startAccessory' | 'endAccessory' | 'isInteractive' | 'children'
-> & {
-  /**
-   * Callback when the back button is pressed.
-   * If provided, a back button will be rendered as the start accessory.
-   */
-  onBack?: () => void;
-  /**
-   * Additional props to pass to the back ButtonIcon.
-   * If provided, a back button will be rendered with these props spread.
-   */
-  backButtonProps?: Omit<ButtonIconProps, 'iconName'>;
-  /**
-   * Callback when the close button is pressed.
-   * If provided, a close button will be added to the end accessories.
-   */
-  onClose?: () => void;
-  /**
-   * Additional props to pass to the close ButtonIcon.
-   * If provided, a close button will be added with these props spread.
-   */
-  closeButtonProps?: Omit<ButtonIconProps, 'iconName'>;
-  /**
-   * Optional ButtonIcon props to render as the start accessory.
-   * Only used if `startAccessory` is not provided.
-   */
-  startButtonIconProps?: ButtonIconProps;
-  /**
-   * Optional array of ButtonIcon props to render as additional end accessories.
-   * Rendered in reverse order (first item appears rightmost).
-   * Only used if `endAccessory` is not provided.
-   */
-  endButtonIconProps?: ButtonIconProps[];
-  /**
-   * Optional content before the ListItem content row.
-   * Takes priority over `startButtonIconProps` and back shortcuts.
-   */
-  startAccessory?: ReactNode;
-  /**
-   * Optional content after the ListItem content row.
-   * Takes priority over `endButtonIconProps` and close shortcuts.
-   */
-  endAccessory?: ReactNode;
-  /**
-   * When true, applies top safe-area inset as `marginTop` on the root ListItem.
-   *
-   * @default false
-   */
-  includesTopInset?: boolean;
-};
+  | 'startAccessory'
+  | 'endAccessory'
+  | 'isInteractive'
+  | 'children'
+  | keyof HeaderSubpagePropsShared
+> &
+  HeaderSubpagePropsShared & {
+    /**
+     * Additional props to pass to the back ButtonIcon.
+     * If provided, a back button will be rendered with these props spread.
+     */
+    backButtonProps?: Omit<ButtonIconProps, 'iconName'>;
+    /**
+     * Additional props to pass to the close ButtonIcon.
+     * If provided, a close button will be added with these props spread.
+     */
+    closeButtonProps?: Omit<ButtonIconProps, 'iconName'>;
+    /**
+     * Optional ButtonIcon props to render as the start accessory.
+     * Only used if `startAccessory` is not provided.
+     */
+    startButtonIconProps?: ButtonIconProps;
+    /**
+     * Optional array of ButtonIcon props to render as additional end accessories.
+     * Rendered in reverse order (first item appears rightmost).
+     * Only used if `endAccessory` is not provided.
+     */
+    endButtonIconProps?: ButtonIconProps[];
+    /**
+     * When true, applies top safe-area inset as `marginTop` on the root ListItem.
+     *
+     * @default false
+     */
+    includesTopInset?: boolean;
+  };

--- a/packages/design-system-react/src/components/Box/index.ts
+++ b/packages/design-system-react/src/components/Box/index.ts
@@ -10,4 +10,3 @@ export {
 } from '@metamask/design-system-shared';
 export { Box } from './Box';
 export type { BoxProps } from './Box.types';
-export { TWCLASSMAP_BOX_GAP } from './Box.constants';

--- a/packages/design-system-react/src/components/Box/index.ts
+++ b/packages/design-system-react/src/components/Box/index.ts
@@ -10,3 +10,4 @@ export {
 } from '@metamask/design-system-shared';
 export { Box } from './Box';
 export type { BoxProps } from './Box.types';
+export { TWCLASSMAP_BOX_GAP } from './Box.constants';

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
@@ -1,0 +1,148 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+
+import { AvatarToken, AvatarTokenSize } from '../AvatarToken';
+import { Box, BoxAlignItems } from '../Box';
+import { IconName } from '../Icon';
+import { Text, TextVariant, FontWeight, TextColor } from '../Text';
+
+import { HeaderSubpage } from './HeaderSubpage';
+import type { HeaderSubpageProps } from './HeaderSubpage.types';
+import README from './README.mdx';
+
+const ETH_TITLE = 'Ethereum';
+const ETH_DESCRIPTION = 'ETH';
+
+const StoryHeaderContent = ({
+  title,
+  description,
+}: {
+  title: string;
+  description?: string;
+}) => (
+  <Box className="flex flex-row items-center gap-3">
+    <AvatarToken
+      src="https://cryptologos.cc/logos/ethereum-eth-logo.svg"
+      size={AvatarTokenSize.Lg}
+      name={title}
+    />
+    <Box>
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        {title}
+      </Text>
+      {description && (
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Normal}
+          color={TextColor.TextAlternative}
+        >
+          {description}
+        </Text>
+      )}
+    </Box>
+  </Box>
+);
+
+const meta: Meta<HeaderSubpageProps> = {
+  title: 'React Components/HeaderSubpage',
+  component: HeaderSubpage,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  args: {
+    children: <StoryHeaderContent title={ETH_TITLE} />,
+  },
+  decorators: [
+    (Story) => (
+      <Box className="w-full bg-background-default">
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<HeaderSubpageProps>;
+
+export const Default: Story = {};
+
+export const WithDescription: Story = {
+  args: {
+    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+  },
+};
+
+export const OnBack: Story = {
+  args: {
+    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    onBack: () => console.log('Back pressed'),
+  },
+};
+
+export const OnClose: Story = {
+  args: {
+    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    onClose: () => console.log('Close pressed'),
+  },
+};
+
+export const BackAndClose: Story = {
+  args: {
+    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    onBack: () => console.log('Back pressed'),
+    onClose: () => console.log('Close pressed'),
+  },
+};
+
+export const EndButtonIconProps: Story = {
+  args: {
+    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    onBack: () => console.log('Back pressed'),
+    onClose: () => console.log('Close pressed'),
+    endButtonIconProps: [
+      {
+        iconName: IconName.Search,
+        ariaLabel: 'Search',
+        onClick: () => console.log('Search pressed'),
+      },
+    ],
+  },
+};
+
+export const CustomStartAccessory: Story = {
+  args: {
+    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    startAccessory: (
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        Custom
+      </Text>
+    ),
+    onClose: () => console.log('Close pressed'),
+  },
+};
+
+export const CustomEndAccessory: Story = {
+  args: {
+    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    onBack: () => console.log('Back pressed'),
+    endAccessory: (
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        Done
+      </Text>
+    ),
+  },
+};
+
+export const TitleOnly: Story = {
+  args: {
+    children: (
+      <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Bold}>
+        Settings
+      </Text>
+    ),
+    onBack: () => console.log('Back pressed'),
+  },
+};

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
@@ -32,6 +32,24 @@ const meta: Meta<HeaderSubpageProps> = {
     docs: {
       page: README,
     },
+    a11y: {
+      config: {
+        rules: [
+          {
+            id: 'landmark-no-duplicate-banner',
+            // Storybook renders light + dark themes simultaneously,
+            // duplicating the <header> "banner" landmark. A single
+            // HeaderSubpage is correct in production.
+            enabled: false,
+          },
+          {
+            id: 'landmark-unique',
+            // Same reason — duplicated by the theme decorator.
+            enabled: false,
+          },
+        ],
+      },
+    },
   },
   args: {
     avatar: ETH_AVATAR,

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 import { AvatarToken, AvatarTokenSize } from '../AvatarToken';
-import { Box, BoxAlignItems } from '../Box';
+import { Box } from '../Box';
 import { IconName } from '../Icon';
 import { Text, TextVariant, FontWeight, TextColor } from '../Text';
 
@@ -71,27 +71,35 @@ export const Default: Story = {};
 
 export const WithDescription: Story = {
   args: {
-    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    children: (
+      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
+    ),
   },
 };
 
 export const OnBack: Story = {
   args: {
-    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    children: (
+      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
+    ),
     onBack: () => console.log('Back pressed'),
   },
 };
 
 export const OnClose: Story = {
   args: {
-    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    children: (
+      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
+    ),
     onClose: () => console.log('Close pressed'),
   },
 };
 
 export const BackAndClose: Story = {
   args: {
-    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    children: (
+      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
+    ),
     onBack: () => console.log('Back pressed'),
     onClose: () => console.log('Close pressed'),
   },
@@ -99,7 +107,9 @@ export const BackAndClose: Story = {
 
 export const EndButtonIconProps: Story = {
   args: {
-    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    children: (
+      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
+    ),
     onBack: () => console.log('Back pressed'),
     onClose: () => console.log('Close pressed'),
     endButtonIconProps: [
@@ -114,7 +124,9 @@ export const EndButtonIconProps: Story = {
 
 export const CustomStartAccessory: Story = {
   args: {
-    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    children: (
+      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
+    ),
     startAccessory: (
       <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
         Custom
@@ -126,7 +138,9 @@ export const CustomStartAccessory: Story = {
 
 export const CustomEndAccessory: Story = {
   args: {
-    children: <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />,
+    children: (
+      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
+    ),
     onBack: () => console.log('Back pressed'),
     endAccessory: (
       <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
@@ -98,21 +98,21 @@ export const EndButtonIconProps: Story = {
   },
 };
 
-export const CustomStartAccessory: Story = {
+export const StartAccessory: Story = {
   args: {
     avatar: ETH_AVATAR,
     title: ETH_TITLE,
     description: ETH_DESCRIPTION,
     startAccessory: (
       <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-        Custom
+        Edit
       </Text>
     ),
     onClose: () => console.log('Close pressed'),
   },
 };
 
-export const CustomEndAccessory: Story = {
+export const EndAccessory: Story = {
   args: {
     avatar: ETH_AVATAR,
     title: ETH_TITLE,
@@ -120,7 +120,7 @@ export const CustomEndAccessory: Story = {
     onBack: () => console.log('Back pressed'),
     endAccessory: (
       <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-        Done
+        Save
       </Text>
     ),
   },

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
@@ -1,10 +1,15 @@
+import {
+  AvatarTokenSize,
+  FontWeight,
+  IconName,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-shared';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
-import { AvatarToken, AvatarTokenSize } from '../AvatarToken';
-import { Box } from '../Box';
-import { IconName } from '../Icon';
-import { Text, TextVariant, FontWeight, TextColor } from '../Text';
+import { AvatarToken } from '../AvatarToken';
+import { Text } from '../Text';
 
 import { HeaderSubpage } from './HeaderSubpage';
 import type { HeaderSubpageProps } from './HeaderSubpage.types';
@@ -12,35 +17,12 @@ import README from './README.mdx';
 
 const ETH_TITLE = 'Ethereum';
 const ETH_DESCRIPTION = 'ETH';
-
-const StoryHeaderContent = ({
-  title,
-  description,
-}: {
-  title: string;
-  description?: string;
-}) => (
-  <Box className="flex flex-row items-center gap-3">
-    <AvatarToken
-      src="https://cryptologos.cc/logos/ethereum-eth-logo.svg"
-      size={AvatarTokenSize.Lg}
-      name={title}
-    />
-    <Box>
-      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-        {title}
-      </Text>
-      {description && (
-        <Text
-          variant={TextVariant.BodySm}
-          fontWeight={FontWeight.Normal}
-          color={TextColor.TextAlternative}
-        >
-          {description}
-        </Text>
-      )}
-    </Box>
-  </Box>
+const ETH_AVATAR = (
+  <AvatarToken
+    src="https://cryptologos.cc/logos/ethereum-eth-logo.svg"
+    size={AvatarTokenSize.Lg}
+    name={ETH_TITLE}
+  />
 );
 
 const meta: Meta<HeaderSubpageProps> = {
@@ -52,15 +34,9 @@ const meta: Meta<HeaderSubpageProps> = {
     },
   },
   args: {
-    children: <StoryHeaderContent title={ETH_TITLE} />,
+    avatar: ETH_AVATAR,
+    title: ETH_TITLE,
   },
-  decorators: [
-    (Story) => (
-      <Box className="w-full bg-background-default">
-        <Story />
-      </Box>
-    ),
-  ],
 };
 
 export default meta;
@@ -69,37 +45,37 @@ type Story = StoryObj<HeaderSubpageProps>;
 
 export const Default: Story = {};
 
-export const WithDescription: Story = {
+export const Description: Story = {
   args: {
-    children: (
-      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
-    ),
+    avatar: ETH_AVATAR,
+    title: ETH_TITLE,
+    description: ETH_DESCRIPTION,
   },
 };
 
 export const OnBack: Story = {
   args: {
-    children: (
-      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
-    ),
+    avatar: ETH_AVATAR,
+    title: ETH_TITLE,
+    description: ETH_DESCRIPTION,
     onBack: () => console.log('Back pressed'),
   },
 };
 
 export const OnClose: Story = {
   args: {
-    children: (
-      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
-    ),
+    avatar: ETH_AVATAR,
+    title: ETH_TITLE,
+    description: ETH_DESCRIPTION,
     onClose: () => console.log('Close pressed'),
   },
 };
 
 export const BackAndClose: Story = {
   args: {
-    children: (
-      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
-    ),
+    avatar: ETH_AVATAR,
+    title: ETH_TITLE,
+    description: ETH_DESCRIPTION,
     onBack: () => console.log('Back pressed'),
     onClose: () => console.log('Close pressed'),
   },
@@ -107,9 +83,9 @@ export const BackAndClose: Story = {
 
 export const EndButtonIconProps: Story = {
   args: {
-    children: (
-      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
-    ),
+    avatar: ETH_AVATAR,
+    title: ETH_TITLE,
+    description: ETH_DESCRIPTION,
     onBack: () => console.log('Back pressed'),
     onClose: () => console.log('Close pressed'),
     endButtonIconProps: [
@@ -124,9 +100,9 @@ export const EndButtonIconProps: Story = {
 
 export const CustomStartAccessory: Story = {
   args: {
-    children: (
-      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
-    ),
+    avatar: ETH_AVATAR,
+    title: ETH_TITLE,
+    description: ETH_DESCRIPTION,
     startAccessory: (
       <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
         Custom
@@ -138,9 +114,9 @@ export const CustomStartAccessory: Story = {
 
 export const CustomEndAccessory: Story = {
   args: {
-    children: (
-      <StoryHeaderContent title={ETH_TITLE} description={ETH_DESCRIPTION} />
-    ),
+    avatar: ETH_AVATAR,
+    title: ETH_TITLE,
+    description: ETH_DESCRIPTION,
     onBack: () => console.log('Back pressed'),
     endAccessory: (
       <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
@@ -152,11 +128,33 @@ export const CustomEndAccessory: Story = {
 
 export const TitleOnly: Story = {
   args: {
-    children: (
-      <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Bold}>
-        Settings
+    title: 'Settings',
+    onBack: () => console.log('Back pressed'),
+  },
+};
+
+export const TitleEndAccessory: Story = {
+  args: {
+    avatar: ETH_AVATAR,
+    title: ETH_TITLE,
+    description: ETH_DESCRIPTION,
+    titleEndAccessory: (
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.TextAlternative}
+      >
+        Badge
       </Text>
     ),
     onBack: () => console.log('Back pressed'),
+    onClose: () => console.log('Close pressed'),
+  },
+};
+
+export const NoContent: Story = {
+  args: {
+    onBack: () => console.log('Back pressed'),
+    onClose: () => console.log('Close pressed'),
   },
 };

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.stories.tsx
@@ -128,6 +128,7 @@ export const CustomEndAccessory: Story = {
 
 export const TitleOnly: Story = {
   args: {
+    avatar: undefined,
     title: 'Settings',
     onBack: () => console.log('Back pressed'),
   },
@@ -154,6 +155,8 @@ export const TitleEndAccessory: Story = {
 
 export const NoContent: Story = {
   args: {
+    avatar: undefined,
+    title: undefined,
     onBack: () => console.log('Back pressed'),
     onClose: () => console.log('Close pressed'),
   },

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { IconName } from '../Icon';
 
@@ -455,10 +455,7 @@ describe('HeaderSubpage', () => {
   describe('accessoryGap', () => {
     it('uses default gap of 2 (8px)', () => {
       render(
-        <HeaderSubpage
-          onBack={jest.fn()}
-          data-testid={CONTAINER_TEST_ID}
-        >
+        <HeaderSubpage onBack={jest.fn()} data-testid={CONTAINER_TEST_ID}>
           Title
         </HeaderSubpage>,
       );
@@ -498,7 +495,7 @@ describe('HeaderSubpage', () => {
 
   describe('ref forwarding', () => {
     it('forwards ref to root element', () => {
-      const ref = React.createRef<HTMLDivElement>();
+      const ref = createRef<HTMLDivElement>();
       render(
         <HeaderSubpage ref={ref} data-testid={CONTAINER_TEST_ID}>
           Title

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -1,0 +1,475 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { IconName } from '../Icon';
+
+import { HeaderSubpage } from './HeaderSubpage';
+
+const CONTAINER_TEST_ID = 'header-subpage-container';
+const BACK_BUTTON_TEST_ID = 'header-subpage-back-button';
+const CLOSE_BUTTON_TEST_ID = 'header-subpage-close-button';
+const START_ACCESSORY_TEST_ID = 'header-subpage-start-accessory';
+const END_ACCESSORY_TEST_ID = 'header-subpage-end-accessory';
+const CUSTOM_START_BUTTON_TEST_ID = 'header-subpage-custom-start-button';
+const END_SEARCH_BUTTON_TEST_ID = 'header-subpage-end-search';
+
+describe('HeaderSubpage', () => {
+  describe('content', () => {
+    describe('when children are provided', () => {
+      it('renders children correctly', () => {
+        render(<HeaderSubpage>Test Title</HeaderSubpage>);
+
+        expect(screen.getByText('Test Title')).toBeInTheDocument();
+      });
+    });
+
+    describe('when data-testid is provided', () => {
+      it('forwards data-testid to root element', () => {
+        render(
+          <HeaderSubpage data-testid={CONTAINER_TEST_ID}>
+            Test Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(CONTAINER_TEST_ID)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('resolvedStartAccessory', () => {
+    describe('when onBack is provided', () => {
+      it('renders back ButtonIcon', () => {
+        render(
+          <HeaderSubpage
+            onBack={jest.fn()}
+            backButtonProps={{ 'data-testid': BACK_BUTTON_TEST_ID }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(BACK_BUTTON_TEST_ID)).toBeInTheDocument();
+      });
+
+      it('calls onBack on click', () => {
+        const onBack = jest.fn();
+        render(
+          <HeaderSubpage
+            onBack={onBack}
+            backButtonProps={{ 'data-testid': BACK_BUTTON_TEST_ID }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        fireEvent.click(screen.getByTestId(BACK_BUTTON_TEST_ID));
+
+        expect(onBack).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when backButtonProps is provided', () => {
+      it('renders back ButtonIcon', () => {
+        render(
+          <HeaderSubpage
+            backButtonProps={{
+              onClick: jest.fn(),
+              'data-testid': BACK_BUTTON_TEST_ID,
+            }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(BACK_BUTTON_TEST_ID)).toBeInTheDocument();
+      });
+
+      it('calls backButtonProps.onClick on click', () => {
+        const onClick = jest.fn();
+        render(
+          <HeaderSubpage
+            backButtonProps={{ onClick, 'data-testid': BACK_BUTTON_TEST_ID }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        fireEvent.click(screen.getByTestId(BACK_BUTTON_TEST_ID));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+      });
+
+      it('prefers backButtonProps.onClick over onBack', () => {
+        const onBack = jest.fn();
+        const onClick = jest.fn();
+        render(
+          <HeaderSubpage
+            onBack={onBack}
+            backButtonProps={{ onClick, 'data-testid': BACK_BUTTON_TEST_ID }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        fireEvent.click(screen.getByTestId(BACK_BUTTON_TEST_ID));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(onBack).not.toHaveBeenCalled();
+      });
+
+      it('uses custom ariaLabel when provided', () => {
+        render(
+          <HeaderSubpage
+            backButtonProps={{
+              ariaLabel: 'Navigate back',
+              'data-testid': BACK_BUTTON_TEST_ID,
+            }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(BACK_BUTTON_TEST_ID)).toHaveAttribute(
+          'aria-label',
+          'Navigate back',
+        );
+      });
+
+      it('uses default ariaLabel when not provided', () => {
+        render(
+          <HeaderSubpage
+            onBack={jest.fn()}
+            backButtonProps={{ 'data-testid': BACK_BUTTON_TEST_ID }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(BACK_BUTTON_TEST_ID)).toHaveAttribute(
+          'aria-label',
+          'Go back',
+        );
+      });
+    });
+
+    describe('when startButtonIconProps is provided', () => {
+      it('renders custom start ButtonIcon', () => {
+        render(
+          <HeaderSubpage
+            startButtonIconProps={{
+              iconName: IconName.Menu,
+              ariaLabel: 'Menu',
+              onClick: jest.fn(),
+              'data-testid': CUSTOM_START_BUTTON_TEST_ID,
+            }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(
+          screen.getByTestId(CUSTOM_START_BUTTON_TEST_ID),
+        ).toBeInTheDocument();
+      });
+
+      it('takes priority over onBack', () => {
+        render(
+          <HeaderSubpage
+            onBack={jest.fn()}
+            backButtonProps={{ 'data-testid': BACK_BUTTON_TEST_ID }}
+            startButtonIconProps={{
+              iconName: IconName.Menu,
+              ariaLabel: 'Menu',
+              onClick: jest.fn(),
+              'data-testid': CUSTOM_START_BUTTON_TEST_ID,
+            }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(
+          screen.getByTestId(CUSTOM_START_BUTTON_TEST_ID),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByTestId(BACK_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when startAccessory is provided', () => {
+      it('takes priority over startButtonIconProps', () => {
+        render(
+          <HeaderSubpage
+            startAccessory={
+              <span data-testid={START_ACCESSORY_TEST_ID}>Start</span>
+            }
+            startButtonIconProps={{
+              iconName: IconName.Menu,
+              ariaLabel: 'Menu',
+              onClick: jest.fn(),
+              'data-testid': CUSTOM_START_BUTTON_TEST_ID,
+            }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(START_ACCESSORY_TEST_ID)).toBeInTheDocument();
+        expect(
+          screen.queryByTestId(CUSTOM_START_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when no start props are provided', () => {
+      it('omits start accessory', () => {
+        render(<HeaderSubpage>Title</HeaderSubpage>);
+
+        expect(
+          screen.queryByTestId(BACK_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId(CUSTOM_START_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId(START_ACCESSORY_TEST_ID),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('resolvedEndAccessory', () => {
+    describe('when onClose is provided', () => {
+      it('renders close ButtonIcon', () => {
+        render(
+          <HeaderSubpage
+            onClose={jest.fn()}
+            closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toBeInTheDocument();
+      });
+
+      it('calls onClose on click', () => {
+        const onClose = jest.fn();
+        render(
+          <HeaderSubpage
+            onClose={onClose}
+            closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        fireEvent.click(screen.getByTestId(CLOSE_BUTTON_TEST_ID));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when closeButtonProps is provided', () => {
+      it('renders close ButtonIcon', () => {
+        render(
+          <HeaderSubpage
+            closeButtonProps={{
+              onClick: jest.fn(),
+              'data-testid': CLOSE_BUTTON_TEST_ID,
+            }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toBeInTheDocument();
+      });
+
+      it('prefers closeButtonProps.onClick over onClose', () => {
+        const onClose = jest.fn();
+        const onClick = jest.fn();
+        render(
+          <HeaderSubpage
+            onClose={onClose}
+            closeButtonProps={{ onClick, 'data-testid': CLOSE_BUTTON_TEST_ID }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        fireEvent.click(screen.getByTestId(CLOSE_BUTTON_TEST_ID));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(onClose).not.toHaveBeenCalled();
+      });
+
+      it('uses custom ariaLabel when provided', () => {
+        render(
+          <HeaderSubpage
+            closeButtonProps={{
+              ariaLabel: 'Dismiss',
+              'data-testid': CLOSE_BUTTON_TEST_ID,
+            }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toHaveAttribute(
+          'aria-label',
+          'Dismiss',
+        );
+      });
+
+      it('uses default ariaLabel when not provided', () => {
+        render(
+          <HeaderSubpage
+            onClose={jest.fn()}
+            closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toHaveAttribute(
+          'aria-label',
+          'Close',
+        );
+      });
+    });
+
+    describe('when endButtonIconProps is provided', () => {
+      it('renders end ButtonIcons', () => {
+        render(
+          <HeaderSubpage
+            endButtonIconProps={[
+              {
+                iconName: IconName.Search,
+                ariaLabel: 'Search',
+                onClick: jest.fn(),
+                'data-testid': END_SEARCH_BUTTON_TEST_ID,
+              },
+            ]}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(
+          screen.getByTestId(END_SEARCH_BUTTON_TEST_ID),
+        ).toBeInTheDocument();
+      });
+
+      it('appends icons after close shortcut', () => {
+        render(
+          <HeaderSubpage
+            onClose={jest.fn()}
+            closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
+            endButtonIconProps={[
+              {
+                iconName: IconName.Search,
+                ariaLabel: 'Search',
+                onClick: jest.fn(),
+                'data-testid': END_SEARCH_BUTTON_TEST_ID,
+              },
+            ]}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toBeInTheDocument();
+        expect(
+          screen.getByTestId(END_SEARCH_BUTTON_TEST_ID),
+        ).toBeInTheDocument();
+      });
+
+      it('omits end accessory when array is empty', () => {
+        render(<HeaderSubpage endButtonIconProps={[]}>Title</HeaderSubpage>);
+
+        expect(
+          screen.queryByTestId(CLOSE_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId(END_SEARCH_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when endAccessory is provided', () => {
+      it('takes priority over close shortcuts', () => {
+        render(
+          <HeaderSubpage
+            onClose={jest.fn()}
+            closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
+            endAccessory={<span data-testid={END_ACCESSORY_TEST_ID}>End</span>}
+          >
+            Title
+          </HeaderSubpage>,
+        );
+
+        expect(screen.getByTestId(END_ACCESSORY_TEST_ID)).toBeInTheDocument();
+        expect(
+          screen.queryByTestId(CLOSE_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when no end props are provided', () => {
+      it('omits end accessory', () => {
+        render(<HeaderSubpage>Title</HeaderSubpage>);
+
+        expect(
+          screen.queryByTestId(CLOSE_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId(END_ACCESSORY_TEST_ID),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('className', () => {
+    it('merges caller classes with default classes', () => {
+      render(
+        <HeaderSubpage
+          className="border-b border-muted"
+          data-testid={CONTAINER_TEST_ID}
+        >
+          Title
+        </HeaderSubpage>,
+      );
+
+      const container = screen.getByTestId(CONTAINER_TEST_ID);
+      expect(container).toHaveClass('h-14', 'px-2', 'border-b', 'border-muted');
+    });
+  });
+
+  describe('style', () => {
+    it('applies inline styles to root element', () => {
+      const customStyle = { backgroundColor: 'red' };
+      render(
+        <HeaderSubpage style={customStyle} data-testid={CONTAINER_TEST_ID}>
+          Title
+        </HeaderSubpage>,
+      );
+
+      expect(screen.getByTestId(CONTAINER_TEST_ID)).toHaveStyle(customStyle);
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('forwards ref to root element', () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(
+        <HeaderSubpage ref={ref} data-testid={CONTAINER_TEST_ID}>
+          Title
+        </HeaderSubpage>,
+      );
+
+      expect(ref.current).toBe(screen.getByTestId(CONTAINER_TEST_ID));
+    });
+  });
+});

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -588,7 +588,7 @@ describe('HeaderSubpage', () => {
 
   describe('ref forwarding', () => {
     it('forwards ref to root element', () => {
-      const ref = createRef<HTMLDivElement>();
+      const ref = createRef<HTMLElement>();
       render(
         <HeaderSubpage
           title="Title"

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -1,8 +1,4 @@
-import {
-  IconName,
-  TextColor,
-  TextVariant,
-} from '@metamask/design-system-shared';
+import { IconName } from '@metamask/design-system-shared';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React, { createRef } from 'react';
 
@@ -35,12 +31,11 @@ describe('HeaderSubpage', () => {
         render(
           <HeaderSubpage
             title="Test Title"
-            titleProps={{ color: TextColor.TextAlternative }}
+            titleProps={{ 'data-testid': 'custom-title' }}
           />,
         );
 
-        const title = screen.getByText('Test Title');
-        expect(title).toHaveClass('text-alternative');
+        expect(screen.getByTestId('custom-title')).toBeInTheDocument();
       });
     });
 
@@ -67,12 +62,11 @@ describe('HeaderSubpage', () => {
           <HeaderSubpage
             title="Title"
             description="Test Description"
-            descriptionProps={{ variant: TextVariant.BodyMd }}
+            descriptionProps={{ 'data-testid': 'custom-description' }}
           />,
         );
 
-        const description = screen.getByText('Test Description');
-        expect(description).toHaveClass('text-s-body-md');
+        expect(screen.getByTestId('custom-description')).toBeInTheDocument();
       });
     });
 
@@ -596,9 +590,11 @@ describe('HeaderSubpage', () => {
     it('forwards ref to root element', () => {
       const ref = createRef<HTMLDivElement>();
       render(
-        <HeaderSubpage title="Title" ref={ref} data-testid={CONTAINER_TEST_ID}>
-          Title
-        </HeaderSubpage>,
+        <HeaderSubpage
+          title="Title"
+          ref={ref}
+          data-testid={CONTAINER_TEST_ID}
+        />,
       );
 
       expect(ref.current).toBe(screen.getByTestId(CONTAINER_TEST_ID));

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -272,11 +272,7 @@ describe('HeaderSubpage', () => {
 
       it('renders close ButtonIcon without closeButtonProps', () => {
         const onClose = jest.fn();
-        render(
-          <HeaderSubpage onClose={onClose}>
-            Title
-          </HeaderSubpage>,
-        );
+        render(<HeaderSubpage onClose={onClose}>Title</HeaderSubpage>);
 
         const closeButton = screen.getByRole('button', { name: 'Close' });
         expect(closeButton).toBeInTheDocument();

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -269,6 +269,21 @@ describe('HeaderSubpage', () => {
 
         expect(onClose).toHaveBeenCalledTimes(1);
       });
+
+      it('renders close ButtonIcon without closeButtonProps', () => {
+        const onClose = jest.fn();
+        render(
+          <HeaderSubpage onClose={onClose}>
+            Title
+          </HeaderSubpage>,
+        );
+
+        const closeButton = screen.getByRole('button', { name: 'Close' });
+        expect(closeButton).toBeInTheDocument();
+
+        fireEvent.click(closeButton);
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe('when closeButtonProps is provided', () => {

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -1,7 +1,10 @@
+import {
+  IconName,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-shared';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React, { createRef } from 'react';
-
-import { IconName } from '../Icon';
 
 import { HeaderSubpage } from './HeaderSubpage';
 
@@ -14,25 +17,127 @@ const CUSTOM_START_BUTTON_TEST_ID = 'header-subpage-custom-start-button';
 const END_SEARCH_BUTTON_TEST_ID = 'header-subpage-end-search';
 
 describe('HeaderSubpage', () => {
-  describe('content', () => {
-    describe('when children are provided', () => {
-      it('renders children correctly', () => {
-        render(<HeaderSubpage>Test Title</HeaderSubpage>);
+  describe('identity content', () => {
+    describe('when title is provided', () => {
+      it('renders title as string', () => {
+        render(<HeaderSubpage title="Test Title" />);
 
         expect(screen.getByText('Test Title')).toBeInTheDocument();
+      });
+
+      it('renders title as node', () => {
+        render(<HeaderSubpage title={<span>Custom Title Node</span>} />);
+
+        expect(screen.getByText('Custom Title Node')).toBeInTheDocument();
+      });
+
+      it('applies titleProps to string title', () => {
+        render(
+          <HeaderSubpage
+            title="Test Title"
+            titleProps={{ color: TextColor.TextAlternative }}
+          />,
+        );
+
+        const title = screen.getByText('Test Title');
+        expect(title).toHaveClass('text-alternative');
+      });
+    });
+
+    describe('when description is provided', () => {
+      it('renders description as string', () => {
+        render(<HeaderSubpage title="Title" description="Test Description" />);
+
+        expect(screen.getByText('Test Description')).toBeInTheDocument();
+      });
+
+      it('renders description as node', () => {
+        render(
+          <HeaderSubpage
+            title="Title"
+            description={<span>Custom Description Node</span>}
+          />,
+        );
+
+        expect(screen.getByText('Custom Description Node')).toBeInTheDocument();
+      });
+
+      it('applies descriptionProps to string description', () => {
+        render(
+          <HeaderSubpage
+            title="Title"
+            description="Test Description"
+            descriptionProps={{ variant: TextVariant.BodyMd }}
+          />,
+        );
+
+        const description = screen.getByText('Test Description');
+        expect(description).toHaveClass('text-s-body-md');
+      });
+    });
+
+    describe('when avatar is provided', () => {
+      it('renders avatar', () => {
+        render(
+          <HeaderSubpage
+            avatar={<span data-testid="avatar">Avatar</span>}
+            title="Title"
+          />,
+        );
+
+        expect(screen.getByTestId('avatar')).toBeInTheDocument();
+      });
+    });
+
+    describe('when titleEndAccessory is provided', () => {
+      it('renders titleEndAccessory after title', () => {
+        render(
+          <HeaderSubpage
+            title="Title"
+            titleEndAccessory={<span data-testid="badge">Badge</span>}
+          />,
+        );
+
+        expect(screen.getByTestId('badge')).toBeInTheDocument();
+        expect(screen.getByText('Title')).toBeInTheDocument();
+      });
+
+      it('renders titleEndAccessory without title when description is provided', () => {
+        render(
+          <HeaderSubpage
+            description="Description"
+            titleEndAccessory={<span data-testid="badge">Badge</span>}
+          />,
+        );
+
+        expect(screen.getByTestId('badge')).toBeInTheDocument();
+        expect(screen.getByText('Description')).toBeInTheDocument();
       });
     });
 
     describe('when data-testid is provided', () => {
       it('forwards data-testid to root element', () => {
-        render(
-          <HeaderSubpage data-testid={CONTAINER_TEST_ID}>
-            Test Title
-          </HeaderSubpage>,
-        );
+        render(<HeaderSubpage title="Title" data-testid={CONTAINER_TEST_ID} />);
 
         expect(screen.getByTestId(CONTAINER_TEST_ID)).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('flex spacer behavior', () => {
+    it('maintains layout when no identity content is provided', () => {
+      render(
+        <HeaderSubpage
+          onBack={jest.fn()}
+          onClose={jest.fn()}
+          data-testid={CONTAINER_TEST_ID}
+        />,
+      );
+
+      const backButton = screen.getByRole('button', { name: 'Go back' });
+      const closeButton = screen.getByRole('button', { name: 'Close' });
+      expect(backButton).toBeInTheDocument();
+      expect(closeButton).toBeInTheDocument();
     });
   });
 
@@ -41,11 +146,10 @@ describe('HeaderSubpage', () => {
       it('renders back ButtonIcon', () => {
         render(
           <HeaderSubpage
+            title="Title"
             onBack={jest.fn()}
             backButtonProps={{ 'data-testid': BACK_BUTTON_TEST_ID }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(BACK_BUTTON_TEST_ID)).toBeInTheDocument();
@@ -55,11 +159,10 @@ describe('HeaderSubpage', () => {
         const onBack = jest.fn();
         render(
           <HeaderSubpage
+            title="Title"
             onBack={onBack}
             backButtonProps={{ 'data-testid': BACK_BUTTON_TEST_ID }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         fireEvent.click(screen.getByTestId(BACK_BUTTON_TEST_ID));
@@ -72,13 +175,12 @@ describe('HeaderSubpage', () => {
       it('renders back ButtonIcon', () => {
         render(
           <HeaderSubpage
+            title="Title"
             backButtonProps={{
               onClick: jest.fn(),
               'data-testid': BACK_BUTTON_TEST_ID,
             }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(BACK_BUTTON_TEST_ID)).toBeInTheDocument();
@@ -88,10 +190,9 @@ describe('HeaderSubpage', () => {
         const onClick = jest.fn();
         render(
           <HeaderSubpage
+            title="Title"
             backButtonProps={{ onClick, 'data-testid': BACK_BUTTON_TEST_ID }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         fireEvent.click(screen.getByTestId(BACK_BUTTON_TEST_ID));
@@ -104,11 +205,10 @@ describe('HeaderSubpage', () => {
         const onClick = jest.fn();
         render(
           <HeaderSubpage
+            title="Title"
             onBack={onBack}
             backButtonProps={{ onClick, 'data-testid': BACK_BUTTON_TEST_ID }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         fireEvent.click(screen.getByTestId(BACK_BUTTON_TEST_ID));
@@ -120,13 +220,12 @@ describe('HeaderSubpage', () => {
       it('uses custom ariaLabel when provided', () => {
         render(
           <HeaderSubpage
+            title="Title"
             backButtonProps={{
               ariaLabel: 'Navigate back',
               'data-testid': BACK_BUTTON_TEST_ID,
             }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(BACK_BUTTON_TEST_ID)).toHaveAttribute(
@@ -138,11 +237,10 @@ describe('HeaderSubpage', () => {
       it('uses default ariaLabel when not provided', () => {
         render(
           <HeaderSubpage
+            title="Title"
             onBack={jest.fn()}
             backButtonProps={{ 'data-testid': BACK_BUTTON_TEST_ID }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(BACK_BUTTON_TEST_ID)).toHaveAttribute(
@@ -156,15 +254,14 @@ describe('HeaderSubpage', () => {
       it('renders custom start ButtonIcon', () => {
         render(
           <HeaderSubpage
+            title="Title"
             startButtonIconProps={{
               iconName: IconName.Menu,
               ariaLabel: 'Menu',
               onClick: jest.fn(),
               'data-testid': CUSTOM_START_BUTTON_TEST_ID,
             }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(
@@ -175,6 +272,7 @@ describe('HeaderSubpage', () => {
       it('takes priority over onBack', () => {
         render(
           <HeaderSubpage
+            title="Title"
             onBack={jest.fn()}
             backButtonProps={{ 'data-testid': BACK_BUTTON_TEST_ID }}
             startButtonIconProps={{
@@ -183,9 +281,7 @@ describe('HeaderSubpage', () => {
               onClick: jest.fn(),
               'data-testid': CUSTOM_START_BUTTON_TEST_ID,
             }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(
@@ -201,6 +297,7 @@ describe('HeaderSubpage', () => {
       it('takes priority over startButtonIconProps', () => {
         render(
           <HeaderSubpage
+            title="Title"
             startAccessory={
               <span data-testid={START_ACCESSORY_TEST_ID}>Start</span>
             }
@@ -210,9 +307,7 @@ describe('HeaderSubpage', () => {
               onClick: jest.fn(),
               'data-testid': CUSTOM_START_BUTTON_TEST_ID,
             }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(START_ACCESSORY_TEST_ID)).toBeInTheDocument();
@@ -224,7 +319,7 @@ describe('HeaderSubpage', () => {
 
     describe('when no start props are provided', () => {
       it('omits start accessory', () => {
-        render(<HeaderSubpage>Title</HeaderSubpage>);
+        render(<HeaderSubpage title="Title" />);
 
         expect(
           screen.queryByTestId(BACK_BUTTON_TEST_ID),
@@ -244,11 +339,10 @@ describe('HeaderSubpage', () => {
       it('renders close ButtonIcon', () => {
         render(
           <HeaderSubpage
+            title="Title"
             onClose={jest.fn()}
             closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toBeInTheDocument();
@@ -258,11 +352,10 @@ describe('HeaderSubpage', () => {
         const onClose = jest.fn();
         render(
           <HeaderSubpage
+            title="Title"
             onClose={onClose}
             closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         fireEvent.click(screen.getByTestId(CLOSE_BUTTON_TEST_ID));
@@ -272,7 +365,7 @@ describe('HeaderSubpage', () => {
 
       it('renders close ButtonIcon without closeButtonProps', () => {
         const onClose = jest.fn();
-        render(<HeaderSubpage onClose={onClose}>Title</HeaderSubpage>);
+        render(<HeaderSubpage title="Title" onClose={onClose} />);
 
         const closeButton = screen.getByRole('button', { name: 'Close' });
         expect(closeButton).toBeInTheDocument();
@@ -286,13 +379,12 @@ describe('HeaderSubpage', () => {
       it('renders close ButtonIcon', () => {
         render(
           <HeaderSubpage
+            title="Title"
             closeButtonProps={{
               onClick: jest.fn(),
               'data-testid': CLOSE_BUTTON_TEST_ID,
             }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toBeInTheDocument();
@@ -303,11 +395,10 @@ describe('HeaderSubpage', () => {
         const onClick = jest.fn();
         render(
           <HeaderSubpage
+            title="Title"
             onClose={onClose}
             closeButtonProps={{ onClick, 'data-testid': CLOSE_BUTTON_TEST_ID }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         fireEvent.click(screen.getByTestId(CLOSE_BUTTON_TEST_ID));
@@ -319,13 +410,12 @@ describe('HeaderSubpage', () => {
       it('uses custom ariaLabel when provided', () => {
         render(
           <HeaderSubpage
+            title="Title"
             closeButtonProps={{
               ariaLabel: 'Dismiss',
               'data-testid': CLOSE_BUTTON_TEST_ID,
             }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toHaveAttribute(
@@ -337,11 +427,10 @@ describe('HeaderSubpage', () => {
       it('uses default ariaLabel when not provided', () => {
         render(
           <HeaderSubpage
+            title="Title"
             onClose={jest.fn()}
             closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toHaveAttribute(
@@ -355,6 +444,7 @@ describe('HeaderSubpage', () => {
       it('renders end ButtonIcons', () => {
         render(
           <HeaderSubpage
+            title="Title"
             endButtonIconProps={[
               {
                 iconName: IconName.Search,
@@ -363,9 +453,7 @@ describe('HeaderSubpage', () => {
                 'data-testid': END_SEARCH_BUTTON_TEST_ID,
               },
             ]}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(
@@ -376,6 +464,7 @@ describe('HeaderSubpage', () => {
       it('appends icons after close shortcut', () => {
         render(
           <HeaderSubpage
+            title="Title"
             onClose={jest.fn()}
             closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
             endButtonIconProps={[
@@ -386,9 +475,7 @@ describe('HeaderSubpage', () => {
                 'data-testid': END_SEARCH_BUTTON_TEST_ID,
               },
             ]}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(CLOSE_BUTTON_TEST_ID)).toBeInTheDocument();
@@ -398,7 +485,7 @@ describe('HeaderSubpage', () => {
       });
 
       it('omits end accessory when array is empty', () => {
-        render(<HeaderSubpage endButtonIconProps={[]}>Title</HeaderSubpage>);
+        render(<HeaderSubpage title="Title" endButtonIconProps={[]} />);
 
         expect(
           screen.queryByTestId(CLOSE_BUTTON_TEST_ID),
@@ -413,12 +500,11 @@ describe('HeaderSubpage', () => {
       it('takes priority over close shortcuts', () => {
         render(
           <HeaderSubpage
+            title="Title"
             onClose={jest.fn()}
             closeButtonProps={{ 'data-testid': CLOSE_BUTTON_TEST_ID }}
             endAccessory={<span data-testid={END_ACCESSORY_TEST_ID}>End</span>}
-          >
-            Title
-          </HeaderSubpage>,
+          />,
         );
 
         expect(screen.getByTestId(END_ACCESSORY_TEST_ID)).toBeInTheDocument();
@@ -430,7 +516,7 @@ describe('HeaderSubpage', () => {
 
     describe('when no end props are provided', () => {
       it('omits end accessory', () => {
-        render(<HeaderSubpage>Title</HeaderSubpage>);
+        render(<HeaderSubpage title="Title" />);
 
         expect(
           screen.queryByTestId(CLOSE_BUTTON_TEST_ID),
@@ -446,11 +532,10 @@ describe('HeaderSubpage', () => {
     it('merges caller classes with default classes', () => {
       render(
         <HeaderSubpage
+          title="Title"
           className="border-b border-muted"
           data-testid={CONTAINER_TEST_ID}
-        >
-          Title
-        </HeaderSubpage>,
+        />,
       );
 
       const container = screen.getByTestId(CONTAINER_TEST_ID);
@@ -466,9 +551,11 @@ describe('HeaderSubpage', () => {
   describe('accessoryGap', () => {
     it('uses default gap of 2 (8px)', () => {
       render(
-        <HeaderSubpage onBack={jest.fn()} data-testid={CONTAINER_TEST_ID}>
-          Title
-        </HeaderSubpage>,
+        <HeaderSubpage
+          title="Title"
+          onBack={jest.fn()}
+          data-testid={CONTAINER_TEST_ID}
+        />,
       );
 
       const container = screen.getByTestId(CONTAINER_TEST_ID);
@@ -478,12 +565,11 @@ describe('HeaderSubpage', () => {
     it('allows custom gap value', () => {
       render(
         <HeaderSubpage
+          title="Title"
           onBack={jest.fn()}
           accessoryGap={4}
           data-testid={CONTAINER_TEST_ID}
-        >
-          Title
-        </HeaderSubpage>,
+        />,
       );
 
       const container = screen.getByTestId(CONTAINER_TEST_ID);
@@ -495,9 +581,11 @@ describe('HeaderSubpage', () => {
     it('applies inline styles to root element', () => {
       const customStyle = { backgroundColor: 'red' };
       render(
-        <HeaderSubpage style={customStyle} data-testid={CONTAINER_TEST_ID}>
-          Title
-        </HeaderSubpage>,
+        <HeaderSubpage
+          title="Title"
+          style={customStyle}
+          data-testid={CONTAINER_TEST_ID}
+        />,
       );
 
       expect(screen.getByTestId(CONTAINER_TEST_ID)).toHaveStyle(customStyle);
@@ -508,7 +596,7 @@ describe('HeaderSubpage', () => {
     it('forwards ref to root element', () => {
       const ref = createRef<HTMLDivElement>();
       render(
-        <HeaderSubpage ref={ref} data-testid={CONTAINER_TEST_ID}>
+        <HeaderSubpage title="Title" ref={ref} data-testid={CONTAINER_TEST_ID}>
           Title
         </HeaderSubpage>,
       );

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.test.tsx
@@ -443,7 +443,43 @@ describe('HeaderSubpage', () => {
       );
 
       const container = screen.getByTestId(CONTAINER_TEST_ID);
-      expect(container).toHaveClass('h-14', 'px-2', 'border-b', 'border-muted');
+      expect(container).toHaveClass(
+        'min-h-14',
+        'px-2',
+        'border-b',
+        'border-muted',
+      );
+    });
+  });
+
+  describe('accessoryGap', () => {
+    it('uses default gap of 2 (8px)', () => {
+      render(
+        <HeaderSubpage
+          onBack={jest.fn()}
+          data-testid={CONTAINER_TEST_ID}
+        >
+          Title
+        </HeaderSubpage>,
+      );
+
+      const container = screen.getByTestId(CONTAINER_TEST_ID);
+      expect(container).toHaveClass('gap-2');
+    });
+
+    it('allows custom gap value', () => {
+      render(
+        <HeaderSubpage
+          onBack={jest.fn()}
+          accessoryGap={4}
+          data-testid={CONTAINER_TEST_ID}
+        >
+          Title
+        </HeaderSubpage>,
+      );
+
+      const container = screen.getByTestId(CONTAINER_TEST_ID);
+      expect(container).toHaveClass('gap-4');
     });
   });
 

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
@@ -1,0 +1,131 @@
+import React, { forwardRef, useMemo } from 'react';
+
+import { twMerge } from '../../utils/tw-merge';
+import { Box } from '../Box';
+import { ButtonIcon, ButtonIconSize } from '../ButtonIcon';
+import type { ButtonIconProps } from '../ButtonIcon';
+import { HeaderBase } from '../HeaderBase';
+import { IconName } from '../Icon';
+
+import type { HeaderSubpageProps } from './HeaderSubpage.types';
+
+const renderEndButtonIcons = (endButtonIconProps: ButtonIconProps[]) =>
+  endButtonIconProps
+    .map((iconProps, originalIndex) => ({
+      iconProps,
+      originalIndex,
+    }))
+    .reverse()
+    .map(({ iconProps, originalIndex }) => (
+      <ButtonIcon
+        key={`end-button-icon-${originalIndex}`}
+        size={ButtonIconSize.Md}
+        {...iconProps}
+      />
+    ));
+
+export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
+  (
+    {
+      onBack,
+      backButtonProps,
+      onClose,
+      closeButtonProps,
+      startButtonIconProps,
+      endButtonIconProps,
+      startAccessory,
+      endAccessory,
+      className,
+      children,
+      childrenWrapperProps,
+      startAccessoryWrapperProps,
+      endAccessoryWrapperProps,
+      ...props
+    },
+    ref,
+  ) => {
+    const resolvedStartAccessory = useMemo(() => {
+      if (startAccessory) {
+        return startAccessory;
+      }
+
+      if (startButtonIconProps) {
+        return (
+          <ButtonIcon size={ButtonIconSize.Md} {...startButtonIconProps} />
+        );
+      }
+
+      if (onBack || backButtonProps) {
+        const { ariaLabel, onClick, ...restBackButtonProps } =
+          backButtonProps ?? {};
+        return (
+          <ButtonIcon
+            iconName={IconName.ArrowLeft}
+            size={ButtonIconSize.Md}
+            ariaLabel={ariaLabel ?? 'Go back'}
+            onClick={onClick ?? onBack}
+            {...restBackButtonProps}
+          />
+        );
+      }
+
+      return undefined;
+    }, [startAccessory, startButtonIconProps, onBack, backButtonProps]);
+
+    const resolvedEndButtonIconProps = useMemo(() => {
+      const iconProps: ButtonIconProps[] = [];
+
+      if (onClose || closeButtonProps) {
+        const { ariaLabel, onClick, ...restCloseButtonProps } =
+          closeButtonProps ?? {};
+        iconProps.push({
+          iconName: IconName.Close,
+          ariaLabel: ariaLabel ?? 'Close',
+          onClick: onClick ?? onClose,
+          ...restCloseButtonProps,
+        });
+      }
+
+      if (endButtonIconProps) {
+        iconProps.push(...endButtonIconProps);
+      }
+
+      return iconProps.length > 0 ? iconProps : undefined;
+    }, [endButtonIconProps, onClose, closeButtonProps]);
+
+    const resolvedEndAccessory = useMemo(() => {
+      if (endAccessory) {
+        return endAccessory;
+      }
+
+      if (resolvedEndButtonIconProps && resolvedEndButtonIconProps.length > 0) {
+        const icons = renderEndButtonIcons(resolvedEndButtonIconProps);
+
+        if (resolvedEndButtonIconProps.length > 1) {
+          return <Box className="flex flex-row gap-2">{icons}</Box>;
+        }
+
+        return icons;
+      }
+
+      return undefined;
+    }, [endAccessory, resolvedEndButtonIconProps]);
+
+    return (
+      <HeaderBase
+        ref={ref}
+        className={twMerge('h-14 px-2', className)}
+        startAccessory={resolvedStartAccessory}
+        endAccessory={resolvedEndAccessory}
+        childrenWrapperProps={childrenWrapperProps}
+        startAccessoryWrapperProps={startAccessoryWrapperProps}
+        endAccessoryWrapperProps={endAccessoryWrapperProps}
+        {...props}
+      >
+        {children}
+      </HeaderBase>
+    );
+  },
+);
+
+HeaderSubpage.displayName = 'HeaderSubpage';

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
@@ -10,7 +10,7 @@ import {
 import React, { forwardRef, useMemo } from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
-import { Box } from '../Box';
+import { Box, TWCLASSMAP_BOX_GAP } from '../Box';
 import { ButtonIcon } from '../ButtonIcon';
 import type { ButtonIconProps } from '../ButtonIcon';
 import { Text } from '../Text';
@@ -32,7 +32,7 @@ const renderEndButtonIcons = (endButtonIconProps: ButtonIconProps[]) =>
       />
     ));
 
-export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
+export const HeaderSubpage = forwardRef<HTMLElement, HeaderSubpageProps>(
   (
     {
       avatar,
@@ -169,12 +169,13 @@ export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
     const hasIdentityContent = avatar || title || description;
 
     return (
-      <Box
+      <header
         ref={ref}
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        gap={accessoryGap}
-        className={twMerge('min-h-14 px-2', className)}
+        className={twMerge(
+          'flex min-h-14 flex-row items-center px-2',
+          TWCLASSMAP_BOX_GAP[accessoryGap],
+          className,
+        )}
         {...props}
       >
         {resolvedStartAccessory}
@@ -205,7 +206,7 @@ export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
           )}
         </Box>
         {resolvedEndAccessory}
-      </Box>
+      </header>
     );
   },
 );

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
@@ -10,7 +10,8 @@ import {
 import React, { forwardRef, useMemo } from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
-import { Box, TWCLASSMAP_BOX_GAP } from '../Box';
+import { Box } from '../Box';
+import { TWCLASSMAP_BOX_GAP } from '../Box/Box.constants';
 import { ButtonIcon } from '../ButtonIcon';
 import type { ButtonIconProps } from '../ButtonIcon';
 import { Text } from '../Text';

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
@@ -1,10 +1,9 @@
 import React, { forwardRef, useMemo } from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
-import { Box } from '../Box';
+import { Box, BoxAlignItems, BoxFlexDirection } from '../Box';
 import { ButtonIcon, ButtonIconSize } from '../ButtonIcon';
 import type { ButtonIconProps } from '../ButtonIcon';
-import { HeaderBase } from '../HeaderBase';
 import { IconName } from '../Icon';
 
 import type { HeaderSubpageProps } from './HeaderSubpage.types';
@@ -35,11 +34,9 @@ export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
       endButtonIconProps,
       startAccessory,
       endAccessory,
+      accessoryGap = 2,
       className,
       children,
-      childrenWrapperProps,
-      startAccessoryWrapperProps,
-      endAccessoryWrapperProps,
       ...props
     },
     ref,
@@ -112,18 +109,18 @@ export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
     }, [endAccessory, resolvedEndButtonIconProps]);
 
     return (
-      <HeaderBase
+      <Box
         ref={ref}
-        className={twMerge('h-14 px-2', className)}
-        startAccessory={resolvedStartAccessory}
-        endAccessory={resolvedEndAccessory}
-        childrenWrapperProps={childrenWrapperProps}
-        startAccessoryWrapperProps={startAccessoryWrapperProps}
-        endAccessoryWrapperProps={endAccessoryWrapperProps}
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={accessoryGap}
+        className={twMerge('min-h-14 px-2', className)}
         {...props}
       >
-        {children}
-      </HeaderBase>
+        {resolvedStartAccessory}
+        {children && <div className="min-w-0 flex-1">{children}</div>}
+        {resolvedEndAccessory}
+      </Box>
     );
   },
 );

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.tsx
@@ -1,10 +1,19 @@
+import {
+  BoxAlignItems,
+  BoxFlexDirection,
+  ButtonIconSize,
+  FontWeight,
+  IconName,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-shared';
 import React, { forwardRef, useMemo } from 'react';
 
 import { twMerge } from '../../utils/tw-merge';
-import { Box, BoxAlignItems, BoxFlexDirection } from '../Box';
-import { ButtonIcon, ButtonIconSize } from '../ButtonIcon';
+import { Box } from '../Box';
+import { ButtonIcon } from '../ButtonIcon';
 import type { ButtonIconProps } from '../ButtonIcon';
-import { IconName } from '../Icon';
+import { Text } from '../Text';
 
 import type { HeaderSubpageProps } from './HeaderSubpage.types';
 
@@ -26,6 +35,12 @@ const renderEndButtonIcons = (endButtonIconProps: ButtonIconProps[]) =>
 export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
   (
     {
+      avatar,
+      title,
+      titleProps,
+      titleEndAccessory,
+      description,
+      descriptionProps,
       onBack,
       backButtonProps,
       onClose,
@@ -36,7 +51,6 @@ export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
       endAccessory,
       accessoryGap = 2,
       className,
-      children,
       ...props
     },
     ref,
@@ -108,6 +122,52 @@ export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
       return undefined;
     }, [endAccessory, resolvedEndButtonIconProps]);
 
+    const renderTitle = () => {
+      if (!title) {
+        return null;
+      }
+
+      if (typeof title === 'string') {
+        return (
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+            ellipsis
+            {...titleProps}
+          >
+            {title}
+          </Text>
+        );
+      }
+
+      return title;
+    };
+
+    const renderDescription = () => {
+      if (!description) {
+        return null;
+      }
+
+      if (typeof description === 'string') {
+        return (
+          <Text
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
+            ellipsis
+            {...descriptionProps}
+          >
+            {description}
+          </Text>
+        );
+      }
+
+      return description;
+    };
+
+    const hasIdentityContent = avatar || title || description;
+
     return (
       <Box
         ref={ref}
@@ -118,7 +178,32 @@ export const HeaderSubpage = forwardRef<HTMLDivElement, HeaderSubpageProps>(
         {...props}
       >
         {resolvedStartAccessory}
-        {children && <div className="min-w-0 flex-1">{children}</div>}
+        <Box className="min-w-0 flex-1">
+          {hasIdentityContent && (
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={4}
+            >
+              {avatar}
+              {(title || description) && (
+                <Box className="min-w-0 flex-1">
+                  {(title || titleEndAccessory) && (
+                    <Box
+                      flexDirection={BoxFlexDirection.Row}
+                      alignItems={BoxAlignItems.Center}
+                      gap={2}
+                    >
+                      {renderTitle()}
+                      {titleEndAccessory}
+                    </Box>
+                  )}
+                  {renderDescription()}
+                </Box>
+              )}
+            </Box>
+          )}
+        </Box>
         {resolvedEndAccessory}
       </Box>
     );

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -1,7 +1,7 @@
 import type { ComponentProps, ReactNode } from 'react';
 
+import type { BoxProps } from '../Box';
 import type { ButtonIconProps } from '../ButtonIcon';
-import type { HeaderBaseProps } from '../HeaderBase';
 
 /**
  * Props for back/close ButtonIcons that override iconName and make ariaLabel optional.
@@ -16,66 +16,74 @@ type NavigationButtonIconProps = Partial<
 /**
  * HeaderSubpage component props.
  *
- * Subpage navigation header built on {@link HeaderBase} with optional back/close
- * button shortcuts. Provides a consistent header pattern for secondary screens
- * and modal-style navigation flows.
+ * Subpage navigation header with optional back/close button shortcuts.
+ * Provides a consistent header pattern for secondary screens and modal-style
+ * navigation flows. Content is left-aligned after the start accessory.
  */
-export type HeaderSubpageProps = Omit<
-  HeaderBaseProps,
-  'startAccessory' | 'endAccessory'
-> &
-  ComponentProps<'div'> & {
-    /**
-     * Callback when the back button is pressed.
-     * If provided, a back button will be rendered as the start accessory.
-     */
-    onBack?: () => void;
-    /**
-     * Additional props to pass to the back ButtonIcon.
-     * If provided, a back button will be rendered with these props spread.
-     */
-    backButtonProps?: NavigationButtonIconProps;
-    /**
-     * Callback when the close button is pressed.
-     * If provided, a close button will be added to the end accessories.
-     */
-    onClose?: () => void;
-    /**
-     * Additional props to pass to the close ButtonIcon.
-     * If provided, a close button will be added with these props spread.
-     */
-    closeButtonProps?: NavigationButtonIconProps;
-    /**
-     * Optional ButtonIcon props to render as the start accessory.
-     * Only used if `startAccessory` is not provided.
-     */
-    startButtonIconProps?: ButtonIconProps & {
-      [key: `data-${string}`]: string | undefined;
-    };
-    /**
-     * Optional array of ButtonIcon props to render as additional end accessories.
-     * Rendered in reverse order (first item appears rightmost).
-     * Only used if `endAccessory` is not provided.
-     */
-    endButtonIconProps?: (ButtonIconProps & {
-      [key: `data-${string}`]: string | undefined;
-    })[];
-    /**
-     * Optional content before the children content.
-     * Takes priority over `startButtonIconProps` and back shortcuts.
-     */
-    startAccessory?: ReactNode;
-    /**
-     * Optional content after the children content.
-     * Takes priority over `endButtonIconProps` and close shortcuts.
-     */
-    endAccessory?: ReactNode;
-    /**
-     * Optional prop for additional CSS classes to be applied to the HeaderSubpage component.
-     */
-    className?: string;
-    /**
-     * Optional CSS styles to be applied to the component.
-     */
-    style?: React.CSSProperties;
+export type HeaderSubpageProps = ComponentProps<'div'> & {
+  /**
+   * The content rendered in the header row. Takes up remaining space after
+   * start/end accessories and is left-aligned.
+   */
+  children?: ReactNode;
+  /**
+   * Callback when the back button is pressed.
+   * If provided, a back button will be rendered as the start accessory.
+   */
+  onBack?: () => void;
+  /**
+   * Additional props to pass to the back ButtonIcon.
+   * If provided, a back button will be rendered with these props spread.
+   */
+  backButtonProps?: NavigationButtonIconProps;
+  /**
+   * Callback when the close button is pressed.
+   * If provided, a close button will be added to the end accessories.
+   */
+  onClose?: () => void;
+  /**
+   * Additional props to pass to the close ButtonIcon.
+   * If provided, a close button will be added with these props spread.
+   */
+  closeButtonProps?: NavigationButtonIconProps;
+  /**
+   * Optional ButtonIcon props to render as the start accessory.
+   * Only used if `startAccessory` is not provided.
+   */
+  startButtonIconProps?: ButtonIconProps & {
+    [key: `data-${string}`]: string | undefined;
   };
+  /**
+   * Optional array of ButtonIcon props to render as additional end accessories.
+   * Rendered in reverse order (first item appears rightmost).
+   * Only used if `endAccessory` is not provided.
+   */
+  endButtonIconProps?: (ButtonIconProps & {
+    [key: `data-${string}`]: string | undefined;
+  })[];
+  /**
+   * Optional content before the children content.
+   * Takes priority over `startButtonIconProps` and back shortcuts.
+   */
+  startAccessory?: ReactNode;
+  /**
+   * Optional content after the children content.
+   * Takes priority over `endButtonIconProps` and close shortcuts.
+   */
+  endAccessory?: ReactNode;
+  /**
+   * Gap between start/end accessories and the content.
+   * Uses spacing scale (1 = 4px, 2 = 8px, etc.).
+   *
+   * @default 2
+   */
+  accessoryGap?: BoxProps['gap'];
+  /**
+   * Optional prop for additional CSS classes to be applied to the HeaderSubpage component.
+   */
+  className?: string;
+  /**
+   * Optional CSS styles to be applied to the component.
+   */
+  style?: React.CSSProperties;
+};

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -1,4 +1,5 @@
-import type { ComponentProps, ReactNode } from 'react';
+import type { HeaderSubpagePropsShared } from '@metamask/design-system-shared';
+import type { ComponentProps } from 'react';
 
 import type { BoxProps } from '../Box';
 import type { ButtonIconProps } from '../ButtonIcon';
@@ -17,96 +18,59 @@ type NavigationButtonIconProps = Partial<Omit<ButtonIconProps, 'iconName'>> & {
  *
  * Subpage navigation header with optional back/close button shortcuts.
  * Provides a consistent header pattern for secondary screens and modal-style
- * navigation flows. Matches the React Native HeaderSubpage identity API.
+ * navigation flows.
  */
 export type HeaderSubpageProps = Omit<
   ComponentProps<'header'>,
   'title' | 'children'
-> & {
-  /**
-   * Optional leading visual (e.g. avatar), rendered before the title stack.
-   */
-  avatar?: ReactNode;
-  /**
-   * Optional title (string or node).
-   * Default text styling: BodyMd, Medium, TextDefault.
-   */
-  title?: ReactNode;
-  /**
-   * Props passed to the title Text component when title is a string.
-   */
-  titleProps?: Partial<TextProps>;
-  /**
-   * Optional node rendered after the title (e.g. badges).
-   */
-  titleEndAccessory?: ReactNode;
-  /**
-   * Optional description (string or node).
-   * Default text styling: BodySm, Medium, TextAlternative.
-   */
-  description?: ReactNode;
-  /**
-   * Props passed to the description Text component when description is a string.
-   */
-  descriptionProps?: Partial<TextProps>;
-  /**
-   * Callback when the back button is pressed.
-   * If provided, a back button will be rendered as the start accessory.
-   */
-  onBack?: () => void;
-  /**
-   * Additional props to pass to the back ButtonIcon.
-   * If provided, a back button will be rendered with these props spread.
-   */
-  backButtonProps?: NavigationButtonIconProps;
-  /**
-   * Callback when the close button is pressed.
-   * If provided, a close button will be added to the end accessories.
-   */
-  onClose?: () => void;
-  /**
-   * Additional props to pass to the close ButtonIcon.
-   * If provided, a close button will be added with these props spread.
-   */
-  closeButtonProps?: NavigationButtonIconProps;
-  /**
-   * Optional ButtonIcon props to render as the start accessory.
-   * Only used if `startAccessory` is not provided.
-   */
-  startButtonIconProps?: ButtonIconProps & {
-    [key: `data-${string}`]: string | undefined;
+> &
+  HeaderSubpagePropsShared & {
+    /**
+     * Props passed to the title Text component when title is a string.
+     */
+    titleProps?: Partial<TextProps>;
+    /**
+     * Props passed to the description Text component when description is a string.
+     */
+    descriptionProps?: Partial<TextProps>;
+    /**
+     * Additional props to pass to the back ButtonIcon.
+     * If provided, a back button will be rendered with these props spread.
+     */
+    backButtonProps?: NavigationButtonIconProps;
+    /**
+     * Additional props to pass to the close ButtonIcon.
+     * If provided, a close button will be added with these props spread.
+     */
+    closeButtonProps?: NavigationButtonIconProps;
+    /**
+     * Optional ButtonIcon props to render as the start accessory.
+     * Only used if `startAccessory` is not provided.
+     */
+    startButtonIconProps?: ButtonIconProps & {
+      [key: `data-${string}`]: string | undefined;
+    };
+    /**
+     * Optional array of ButtonIcon props to render as additional end accessories.
+     * Rendered in reverse order (first item appears rightmost).
+     * Only used if `endAccessory` is not provided.
+     */
+    endButtonIconProps?: (ButtonIconProps & {
+      [key: `data-${string}`]: string | undefined;
+    })[];
+    /**
+     * Gap between start/end accessories and the content.
+     * Uses spacing scale (1 = 4px, 2 = 8px, etc.).
+     *
+     * @default 2
+     */
+    accessoryGap?: BoxProps['gap'];
+    /**
+     * Optional prop for additional CSS classes to be applied to the HeaderSubpage component.
+     */
+    className?: string;
+    /**
+     * Optional CSS styles to be applied to the component.
+     */
+    style?: React.CSSProperties;
   };
-  /**
-   * Optional array of ButtonIcon props to render as additional end accessories.
-   * Rendered in reverse order (first item appears rightmost).
-   * Only used if `endAccessory` is not provided.
-   */
-  endButtonIconProps?: (ButtonIconProps & {
-    [key: `data-${string}`]: string | undefined;
-  })[];
-  /**
-   * Optional content before the identity content.
-   * Takes priority over `startButtonIconProps` and back shortcuts.
-   */
-  startAccessory?: ReactNode;
-  /**
-   * Optional content after the identity content.
-   * Takes priority over `endButtonIconProps` and close shortcuts.
-   */
-  endAccessory?: ReactNode;
-  /**
-   * Gap between start/end accessories and the content.
-   * Uses spacing scale (1 = 4px, 2 = 8px, etc.).
-   *
-   * @default 2
-   */
-  accessoryGap?: BoxProps['gap'];
-  /**
-   * Optional prop for additional CSS classes to be applied to the HeaderSubpage component.
-   */
-  className?: string;
-  /**
-   * Optional CSS styles to be applied to the component.
-   */
-  style?: React.CSSProperties;
-};

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -7,9 +7,7 @@ import type { ButtonIconProps } from '../ButtonIcon';
  * Props for back/close ButtonIcons that override iconName and make ariaLabel optional.
  * The component provides default ariaLabels ("Go back", "Close").
  */
-type NavigationButtonIconProps = Partial<
-  Omit<ButtonIconProps, 'iconName'>
-> & {
+type NavigationButtonIconProps = Partial<Omit<ButtonIconProps, 'iconName'>> & {
   [key: `data-${string}`]: string | undefined;
 };
 

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -2,6 +2,7 @@ import type { ComponentProps, ReactNode } from 'react';
 
 import type { BoxProps } from '../Box';
 import type { ButtonIconProps } from '../ButtonIcon';
+import type { TextProps } from '../Text';
 
 /**
  * Props for back/close ButtonIcons that override iconName and make ariaLabel optional.
@@ -16,14 +17,35 @@ type NavigationButtonIconProps = Partial<Omit<ButtonIconProps, 'iconName'>> & {
  *
  * Subpage navigation header with optional back/close button shortcuts.
  * Provides a consistent header pattern for secondary screens and modal-style
- * navigation flows. Content is left-aligned after the start accessory.
+ * navigation flows. Matches the React Native HeaderSubpage identity API.
  */
-export type HeaderSubpageProps = ComponentProps<'div'> & {
+export type HeaderSubpageProps = Omit<ComponentProps<'div'>, 'title'> & {
   /**
-   * The content rendered in the header row. Takes up remaining space after
-   * start/end accessories and is left-aligned.
+   * Optional leading visual (e.g. avatar), rendered before the title stack.
    */
-  children?: ReactNode;
+  avatar?: ReactNode;
+  /**
+   * Optional title (string or node).
+   * Default text styling: BodyMd, Medium, TextDefault.
+   */
+  title?: ReactNode;
+  /**
+   * Props passed to the title Text component when title is a string.
+   */
+  titleProps?: Partial<TextProps>;
+  /**
+   * Optional node rendered after the title (e.g. badges).
+   */
+  titleEndAccessory?: ReactNode;
+  /**
+   * Optional description (string or node).
+   * Default text styling: BodySm, Medium, TextAlternative.
+   */
+  description?: ReactNode;
+  /**
+   * Props passed to the description Text component when description is a string.
+   */
+  descriptionProps?: Partial<TextProps>;
   /**
    * Callback when the back button is pressed.
    * If provided, a back button will be rendered as the start accessory.
@@ -60,12 +82,12 @@ export type HeaderSubpageProps = ComponentProps<'div'> & {
     [key: `data-${string}`]: string | undefined;
   })[];
   /**
-   * Optional content before the children content.
+   * Optional content before the identity content.
    * Takes priority over `startButtonIconProps` and back shortcuts.
    */
   startAccessory?: ReactNode;
   /**
-   * Optional content after the children content.
+   * Optional content after the identity content.
    * Takes priority over `endButtonIconProps` and close shortcuts.
    */
   endAccessory?: ReactNode;

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -19,7 +19,10 @@ type NavigationButtonIconProps = Partial<Omit<ButtonIconProps, 'iconName'>> & {
  * Provides a consistent header pattern for secondary screens and modal-style
  * navigation flows. Matches the React Native HeaderSubpage identity API.
  */
-export type HeaderSubpageProps = Omit<ComponentProps<'div'>, 'title'> & {
+export type HeaderSubpageProps = Omit<
+  ComponentProps<'div'>,
+  'title' | 'children'
+> & {
   /**
    * Optional leading visual (e.g. avatar), rendered before the title stack.
    */

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -1,0 +1,81 @@
+import type { ComponentProps, ReactNode } from 'react';
+
+import type { ButtonIconProps } from '../ButtonIcon';
+import type { HeaderBaseProps } from '../HeaderBase';
+
+/**
+ * Props for back/close ButtonIcons that override iconName and make ariaLabel optional.
+ * The component provides default ariaLabels ("Go back", "Close").
+ */
+type NavigationButtonIconProps = Partial<
+  Omit<ButtonIconProps, 'iconName'>
+> & {
+  [key: `data-${string}`]: string | undefined;
+};
+
+/**
+ * HeaderSubpage component props.
+ *
+ * Subpage navigation header built on {@link HeaderBase} with optional back/close
+ * button shortcuts. Provides a consistent header pattern for secondary screens
+ * and modal-style navigation flows.
+ */
+export type HeaderSubpageProps = Omit<
+  HeaderBaseProps,
+  'startAccessory' | 'endAccessory'
+> &
+  ComponentProps<'div'> & {
+    /**
+     * Callback when the back button is pressed.
+     * If provided, a back button will be rendered as the start accessory.
+     */
+    onBack?: () => void;
+    /**
+     * Additional props to pass to the back ButtonIcon.
+     * If provided, a back button will be rendered with these props spread.
+     */
+    backButtonProps?: NavigationButtonIconProps;
+    /**
+     * Callback when the close button is pressed.
+     * If provided, a close button will be added to the end accessories.
+     */
+    onClose?: () => void;
+    /**
+     * Additional props to pass to the close ButtonIcon.
+     * If provided, a close button will be added with these props spread.
+     */
+    closeButtonProps?: NavigationButtonIconProps;
+    /**
+     * Optional ButtonIcon props to render as the start accessory.
+     * Only used if `startAccessory` is not provided.
+     */
+    startButtonIconProps?: ButtonIconProps & {
+      [key: `data-${string}`]: string | undefined;
+    };
+    /**
+     * Optional array of ButtonIcon props to render as additional end accessories.
+     * Rendered in reverse order (first item appears rightmost).
+     * Only used if `endAccessory` is not provided.
+     */
+    endButtonIconProps?: (ButtonIconProps & {
+      [key: `data-${string}`]: string | undefined;
+    })[];
+    /**
+     * Optional content before the children content.
+     * Takes priority over `startButtonIconProps` and back shortcuts.
+     */
+    startAccessory?: ReactNode;
+    /**
+     * Optional content after the children content.
+     * Takes priority over `endButtonIconProps` and close shortcuts.
+     */
+    endAccessory?: ReactNode;
+    /**
+     * Optional prop for additional CSS classes to be applied to the HeaderSubpage component.
+     */
+    className?: string;
+    /**
+     * Optional CSS styles to be applied to the component.
+     */
+    style?: React.CSSProperties;
+  };

--- a/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-react/src/components/HeaderSubpage/HeaderSubpage.types.ts
@@ -20,7 +20,7 @@ type NavigationButtonIconProps = Partial<Omit<ButtonIconProps, 'iconName'>> & {
  * navigation flows. Matches the React Native HeaderSubpage identity API.
  */
 export type HeaderSubpageProps = Omit<
-  ComponentProps<'div'>,
+  ComponentProps<'header'>,
   'title' | 'children'
 > & {
   /**

--- a/packages/design-system-react/src/components/HeaderSubpage/README.mdx
+++ b/packages/design-system-react/src/components/HeaderSubpage/README.mdx
@@ -4,7 +4,7 @@ import * as HeaderSubpageStories from './HeaderSubpage.stories';
 
 # HeaderSubpage
 
-Subpage navigation header built on `HeaderBase` with optional back/close button shortcuts. Provides a consistent header pattern for secondary screens and modal-style navigation flows.
+Subpage navigation header with optional back/close button shortcuts. Provides a consistent header pattern for secondary screens and modal-style navigation flows. Content is left-aligned after the start accessory.
 
 ```tsx
 import { HeaderSubpage } from '@metamask/design-system-react';
@@ -298,5 +298,5 @@ The `style` prop should primarily be used for dynamic inline styles that cannot 
 
 ## References
 
-- [HeaderBase](/docs/react-components-headerbase--docs) - The underlying layout component
 - [ButtonIcon](/docs/react-components-buttonicon--docs) - Used for back/close buttons
+- [Box](/docs/react-components-box--docs) - Used for layout

--- a/packages/design-system-react/src/components/HeaderSubpage/README.mdx
+++ b/packages/design-system-react/src/components/HeaderSubpage/README.mdx
@@ -229,18 +229,6 @@ Callback when the close button is pressed. If provided, a close button will be a
 
 <Canvas of={HeaderSubpageStories.OnClose} />
 
-### Back and close together
-
-You can use both `onBack` and `onClose` together to provide navigation controls on both sides of the header.
-
-<Canvas of={HeaderSubpageStories.BackAndClose} />
-
-### No content
-
-When no identity content is provided, the header maintains proper layout with back/close buttons on opposite edges.
-
-<Canvas of={HeaderSubpageStories.NoContent} />
-
 ### `backButtonProps`
 
 Additional props to pass to the back ButtonIcon. If provided (even without `onBack`), a back button will be rendered with these props spread.

--- a/packages/design-system-react/src/components/HeaderSubpage/README.mdx
+++ b/packages/design-system-react/src/components/HeaderSubpage/README.mdx
@@ -4,7 +4,7 @@ import * as HeaderSubpageStories from './HeaderSubpage.stories';
 
 # HeaderSubpage
 
-Subpage navigation header with optional back/close button shortcuts. Provides a consistent header pattern for secondary screens and modal-style navigation flows. Matches the React Native HeaderSubpage identity API.
+A left-aligned navigation header for secondary pages that need identity content such as an avatar, title, or description alongside navigation actions. Use HeaderSubpage for subpage headers; use HeaderBase or ModalHeader when the title should be centered.
 
 ```tsx
 import { HeaderSubpage } from '@metamask/design-system-react';
@@ -125,6 +125,56 @@ Optional node rendered after the title (e.g. badges).
 
 <Canvas of={HeaderSubpageStories.TitleEndAccessory} />
 
+### `titleProps`
+
+Props passed to the title Text component when `title` is a string. Useful for passing `data-testid` and other supported Text props.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>Partial&lt;TextProps&gt;</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `descriptionProps`
+
+Props passed to the description Text component when `description` is a string. Useful for passing `data-testid` and other supported Text props.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>Partial&lt;TextProps&gt;</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ### `onBack`
 
 Callback when the back button is pressed. If provided, a back button will be rendered as the start accessory.
@@ -241,6 +291,31 @@ Additional props to pass to the close ButtonIcon. If provided (even without `onC
   </tbody>
 </table>
 
+### `startButtonIconProps`
+
+Optional ButtonIcon props to render as the start accessory. Only used if `startAccessory` is not provided and no back button shortcuts are active.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ButtonIconProps</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ### `endButtonIconProps`
 
 Optional array of ButtonIcon props to render as additional end accessories. Rendered in reverse order (first item appears rightmost). Only used if `endAccessory` is not provided.
@@ -270,7 +345,7 @@ Optional array of ButtonIcon props to render as additional end accessories. Rend
 
 ### `startAccessory`
 
-Optional content before the identity content. Takes priority over `startButtonIconProps` and back shortcuts.
+Optional content before the identity content. Takes priority over `startButtonIconProps` and back shortcuts. Use this escape hatch when you need complete control over the start slot content.
 
 <table>
   <thead>
@@ -297,7 +372,7 @@ Optional content before the identity content. Takes priority over `startButtonIc
 
 ### `endAccessory`
 
-Optional content after the identity content. Takes priority over `endButtonIconProps` and close shortcuts.
+Optional content after the identity content. Takes priority over `endButtonIconProps` and close shortcuts. Use this escape hatch when you need complete control over the end slot content.
 
 <table>
   <thead>
@@ -321,6 +396,31 @@ Optional content after the identity content. Takes priority over `endButtonIconP
 </table>
 
 <Canvas of={HeaderSubpageStories.CustomEndAccessory} />
+
+### `accessoryGap`
+
+Gap between start/end accessories and the content. Uses spacing scale (1 = 4px, 2 = 8px, etc.).
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>number</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>2</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### `className`
 

--- a/packages/design-system-react/src/components/HeaderSubpage/README.mdx
+++ b/packages/design-system-react/src/components/HeaderSubpage/README.mdx
@@ -4,23 +4,26 @@ import * as HeaderSubpageStories from './HeaderSubpage.stories';
 
 # HeaderSubpage
 
-Subpage navigation header with optional back/close button shortcuts. Provides a consistent header pattern for secondary screens and modal-style navigation flows. Content is left-aligned after the start accessory.
+Subpage navigation header with optional back/close button shortcuts. Provides a consistent header pattern for secondary screens and modal-style navigation flows. Matches the React Native HeaderSubpage identity API.
 
 ```tsx
 import { HeaderSubpage } from '@metamask/design-system-react';
 
-<HeaderSubpage onBack={() => navigate(-1)}>
-  <Text variant={TextVariant.HeadingSm}>Page title</Text>
-</HeaderSubpage>;
+<HeaderSubpage
+  avatar={<AvatarToken src="..." name="Ethereum" />}
+  title="Ethereum"
+  description="ETH"
+  onBack={() => navigate(-1)}
+/>;
 ```
 
 <Canvas of={HeaderSubpageStories.Default} />
 
 ## Props
 
-### `children`
+### `avatar`
 
-The content rendered in the center column of the header. Typically a title or title with description.
+Optional leading visual (e.g. avatar), rendered before the title stack.
 
 <table>
   <thead>
@@ -43,7 +46,86 @@ The content rendered in the center column of the header. Typically a title or ti
   </tbody>
 </table>
 
-<Canvas of={HeaderSubpageStories.WithDescription} />
+### `title`
+
+Optional title (string or node). When a string is provided, default text styling is applied: BodyMd, Medium, TextDefault.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HeaderSubpageStories.TitleOnly} />
+
+### `description`
+
+Optional description (string or node). When a string is provided, default text styling is applied: BodySm, Medium, TextAlternative.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HeaderSubpageStories.Description} />
+
+### `titleEndAccessory`
+
+Optional node rendered after the title (e.g. badges).
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HeaderSubpageStories.TitleEndAccessory} />
 
 ### `onBack`
 
@@ -104,6 +186,12 @@ Callback when the close button is pressed. If provided, a close button will be a
 You can use both `onBack` and `onClose` together to provide navigation controls on both sides of the header.
 
 <Canvas of={HeaderSubpageStories.BackAndClose} />
+
+### No content
+
+When no identity content is provided, the header maintains proper layout with back/close buttons on opposite edges.
+
+<Canvas of={HeaderSubpageStories.NoContent} />
 
 ### `backButtonProps`
 
@@ -184,7 +272,7 @@ Optional array of ButtonIcon props to render as additional end accessories. Rend
 
 ### `startAccessory`
 
-Optional content before the children content. Takes priority over `startButtonIconProps` and back shortcuts.
+Optional content before the identity content. Takes priority over `startButtonIconProps` and back shortcuts.
 
 <table>
   <thead>
@@ -211,7 +299,7 @@ Optional content before the children content. Takes priority over `startButtonIc
 
 ### `endAccessory`
 
-Optional content after the children content. Takes priority over `endButtonIconProps` and close shortcuts.
+Optional content after the identity content. Takes priority over `endButtonIconProps` and close shortcuts.
 
 <table>
   <thead>
@@ -262,9 +350,7 @@ Use the `className` prop to add custom CSS classes to the component. These class
 </table>
 
 ```tsx
-<HeaderSubpage className="border-b border-muted" onBack={() => {}}>
-  Title
-</HeaderSubpage>
+<HeaderSubpage className="border-b border-muted" title="Settings" onBack={() => {}} />
 ```
 
 ### `style`
@@ -300,3 +386,4 @@ The `style` prop should primarily be used for dynamic inline styles that cannot 
 
 - [ButtonIcon](/docs/react-components-buttonicon--docs) - Used for back/close buttons
 - [Box](/docs/react-components-box--docs) - Used for layout
+- [Text](/docs/react-components-text--docs) - Used for title and description text

--- a/packages/design-system-react/src/components/HeaderSubpage/README.mdx
+++ b/packages/design-system-react/src/components/HeaderSubpage/README.mdx
@@ -10,10 +10,8 @@ Subpage navigation header with optional back/close button shortcuts. Provides a 
 import { HeaderSubpage } from '@metamask/design-system-react';
 
 <HeaderSubpage
-  avatar={<AvatarToken src="..." name="Ethereum" />}
+  avatar={<AvatarToken src="..." size={AvatarTokenSize.Lg} name="Ethereum" />}
   title="Ethereum"
-  description="ETH"
-  onBack={() => navigate(-1)}
 />;
 ```
 

--- a/packages/design-system-react/src/components/HeaderSubpage/README.mdx
+++ b/packages/design-system-react/src/components/HeaderSubpage/README.mdx
@@ -177,7 +177,7 @@ Props passed to the description Text component when `description` is a string. U
 
 ### `onBack`
 
-Callback when the back button is pressed. If provided, a back button will be rendered as the start accessory.
+Callback when the back button is pressed. If provided, a back button will be rendered as the start accessory. The button uses a default English `ariaLabel` of "Go back"; override via `backButtonProps.ariaLabel` for localization.
 
 <table>
   <thead>
@@ -204,7 +204,7 @@ Callback when the back button is pressed. If provided, a back button will be ren
 
 ### `onClose`
 
-Callback when the close button is pressed. If provided, a close button will be added to the end accessories.
+Callback when the close button is pressed. If provided, a close button will be added to the end accessories. The button uses a default English `ariaLabel` of "Close"; override via `closeButtonProps.ariaLabel` for localization.
 
 <table>
   <thead>
@@ -368,7 +368,7 @@ Optional content before the identity content. Takes priority over `startButtonIc
   </tbody>
 </table>
 
-<Canvas of={HeaderSubpageStories.CustomStartAccessory} />
+<Canvas of={HeaderSubpageStories.StartAccessory} />
 
 ### `endAccessory`
 
@@ -395,7 +395,7 @@ Optional content after the identity content. Takes priority over `endButtonIconP
   </tbody>
 </table>
 
-<Canvas of={HeaderSubpageStories.CustomEndAccessory} />
+<Canvas of={HeaderSubpageStories.EndAccessory} />
 
 ### `accessoryGap`
 

--- a/packages/design-system-react/src/components/HeaderSubpage/README.mdx
+++ b/packages/design-system-react/src/components/HeaderSubpage/README.mdx
@@ -1,0 +1,302 @@
+import { Controls, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as HeaderSubpageStories from './HeaderSubpage.stories';
+
+# HeaderSubpage
+
+Subpage navigation header built on `HeaderBase` with optional back/close button shortcuts. Provides a consistent header pattern for secondary screens and modal-style navigation flows.
+
+```tsx
+import { HeaderSubpage } from '@metamask/design-system-react';
+
+<HeaderSubpage onBack={() => navigate(-1)}>
+  <Text variant={TextVariant.HeadingSm}>Page title</Text>
+</HeaderSubpage>;
+```
+
+<Canvas of={HeaderSubpageStories.Default} />
+
+## Props
+
+### `children`
+
+The content rendered in the center column of the header. Typically a title or title with description.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HeaderSubpageStories.WithDescription} />
+
+### `onBack`
+
+Callback when the back button is pressed. If provided, a back button will be rendered as the start accessory.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>() =&gt; void</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HeaderSubpageStories.OnBack} />
+
+### `onClose`
+
+Callback when the close button is pressed. If provided, a close button will be added to the end accessories.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>() =&gt; void</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HeaderSubpageStories.OnClose} />
+
+### Back and close together
+
+You can use both `onBack` and `onClose` together to provide navigation controls on both sides of the header.
+
+<Canvas of={HeaderSubpageStories.BackAndClose} />
+
+### `backButtonProps`
+
+Additional props to pass to the back ButtonIcon. If provided (even without `onBack`), a back button will be rendered with these props spread.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>Omit&lt;ButtonIconProps, 'iconName' | 'ariaLabel'&gt; & {'{'} ariaLabel?: string {'}'}</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `closeButtonProps`
+
+Additional props to pass to the close ButtonIcon. If provided (even without `onClose`), a close button will be added with these props spread.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>Omit&lt;ButtonIconProps, 'iconName' | 'ariaLabel'&gt; & {'{'} ariaLabel?: string {'}'}</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### `endButtonIconProps`
+
+Optional array of ButtonIcon props to render as additional end accessories. Rendered in reverse order (first item appears rightmost). Only used if `endAccessory` is not provided.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ButtonIconProps[]</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HeaderSubpageStories.EndButtonIconProps} />
+
+### `startAccessory`
+
+Optional content before the children content. Takes priority over `startButtonIconProps` and back shortcuts.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HeaderSubpageStories.CustomStartAccessory} />
+
+### `endAccessory`
+
+Optional content after the children content. Takes priority over `endButtonIconProps` and close shortcuts.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>ReactNode</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={HeaderSubpageStories.CustomEndAccessory} />
+
+### `className`
+
+Use the `className` prop to add custom CSS classes to the component. These classes will be merged with the component's default classes using `twMerge`.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>string</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+```tsx
+<HeaderSubpage className="border-b border-muted" onBack={() => {}}>
+  Title
+</HeaderSubpage>
+```
+
+### `style`
+
+The `style` prop should primarily be used for dynamic inline styles that cannot be achieved with `className` alone.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">TYPE</th>
+      <th align="left">REQUIRED</th>
+      <th align="left">DEFAULT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">
+        <code>React.CSSProperties</code>
+      </td>
+      <td align="left">No</td>
+      <td align="left">
+        <code>undefined</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Component API
+
+<Controls of={HeaderSubpageStories.Default} />
+
+## References
+
+- [HeaderBase](/docs/react-components-headerbase--docs) - The underlying layout component
+- [ButtonIcon](/docs/react-components-buttonicon--docs) - Used for back/close buttons

--- a/packages/design-system-react/src/components/HeaderSubpage/index.ts
+++ b/packages/design-system-react/src/components/HeaderSubpage/index.ts
@@ -1,0 +1,2 @@
+export { HeaderSubpage } from './HeaderSubpage';
+export type { HeaderSubpageProps } from './HeaderSubpage.types';

--- a/packages/design-system-react/src/components/index.ts
+++ b/packages/design-system-react/src/components/index.ts
@@ -177,3 +177,6 @@ export type { ButtonFilterProps } from './ButtonFilter';
 
 export { Toast, Toaster, toast, ToastSeverity } from './Toast';
 export type { ToastOptions, ToastProps, ToasterProps } from './Toast';
+
+export { HeaderSubpage } from './HeaderSubpage';
+export type { HeaderSubpageProps } from './HeaderSubpage';

--- a/packages/design-system-shared/src/index.ts
+++ b/packages/design-system-shared/src/index.ts
@@ -281,3 +281,6 @@ export { type SectionHeaderPropsShared } from './types/SectionHeader';
 
 // Toast types (ADR-0003 + ADR-0004)
 export { ToastSeverity, type ToastPropsShared } from './types/Toast';
+
+// HeaderSubpage types (ADR-0004)
+export { type HeaderSubpagePropsShared } from './types/HeaderSubpage';

--- a/packages/design-system-shared/src/types/HeaderSubpage/HeaderSubpage.types.ts
+++ b/packages/design-system-shared/src/types/HeaderSubpage/HeaderSubpage.types.ts
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+
+/**
+ * HeaderSubpage shared props (ADR-0004).
+ * Platform-independent properties shared across React and React Native.
+ */
+export type HeaderSubpagePropsShared = {
+  /**
+   * Optional leading visual (e.g. avatar), rendered before the title stack.
+   */
+  avatar?: ReactNode;
+  /**
+   * Optional title (string or node).
+   * Default text styling: BodyMd, Medium, TextDefault.
+   */
+  title?: ReactNode;
+  /**
+   * Optional node rendered after the title (e.g. badges).
+   */
+  titleEndAccessory?: ReactNode;
+  /**
+   * Optional description (string or node).
+   * Default text styling: BodySm, Medium, TextAlternative.
+   */
+  description?: ReactNode;
+  /**
+   * Callback when the back button is pressed.
+   * If provided, a back button will be rendered as the start accessory.
+   */
+  onBack?: () => void;
+  /**
+   * Callback when the close button is pressed.
+   * If provided, a close button will be added to the end accessories.
+   */
+  onClose?: () => void;
+  /**
+   * Optional content before the identity content.
+   * Takes priority over `startButtonIconProps` and back shortcuts.
+   */
+  startAccessory?: ReactNode;
+  /**
+   * Optional content after the identity content.
+   * Takes priority over `endButtonIconProps` and close shortcuts.
+   */
+  endAccessory?: ReactNode;
+};

--- a/packages/design-system-shared/src/types/HeaderSubpage/index.ts
+++ b/packages/design-system-shared/src/types/HeaderSubpage/index.ts
@@ -1,0 +1,1 @@
+export { type HeaderSubpagePropsShared } from './HeaderSubpage.types';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Port HeaderSubpage from React Native to React, without needing `ListItem` dependency.

**Reason for change:** The React package needs a HeaderSubpage component similar to the React Native version, but without the ListItem dependency since ListItem hasn't been ported to React yet.

**Solution:** Build HeaderSubpage using a flex row layout (matching RN's BoxRow/ListItem pattern), providing the same identity API as the RN version with `avatar`, `title`, `description`, `titleEndAccessory` props instead of generic `children`.

### Features
- **Identity API matching RN:** `avatar`, `title`, `description`, `titleProps`, `descriptionProps`, `titleEndAccessory`
- Back/close button shortcuts via `onBack`/`onClose` callbacks
- Optional `backButtonProps`/`closeButtonProps` for customization
- `startButtonIconProps`/`endButtonIconProps` for additional icons
- `startAccessory`/`endAccessory` for custom content
- `accessoryGap` prop to control spacing (default: 2 = 8px)
- Content is left-aligned after start accessory (matches RN behavior)
- Uses `min-h-14` (56px) to match RN styling
- Flex spacer always mounted to maintain layout even without identity content

### Layout
```
[startAccessory] [avatar | title stack] [endAccessory]
```

### Changes from bugbot/cursor review
- Replaced `children` with RN-style identity API (`avatar`, `title`, `description`, etc.)
- Import shared constants from `@metamask/design-system-shared`
- Removed unnecessary story decorator background wrapper
- Always mount flex spacer to keep back/close buttons on opposite edges

## **Related issues**

N/A - New component port

## **Manual testing steps**

1. Run `yarn storybook`
2. Navigate to React Components > HeaderSubpage
3. Test the various stories (Default, Description, OnBack, OnClose, BackAndClose, TitleEndAccessory, NoContent)
4. Verify content is left-aligned after the back button
5. Verify back/close button clicks work as expected
6. Verify NoContent story shows back/close on opposite edges

## **Screenshots/Recordings**

### **After**

<img width="1207" height="178" alt="Screenshot 2026-09-10 at 1 23 44 PM" src="https://github.com/user-attachments/assets/67bdd3b0-5d51-4891-a5ef-1a9d9c9f9f73" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C0BRAHB1KNK/p1789052229194589?thread_ts=1789052229.194589&cid=C0BRAHB1KNK)

<div><a href="https://cursor.com/agents/bc-1e4f3c6e-9770-5027-8b53-c6b9c302053d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e4f3c6e-9770-5027-8b53-c6b9c302053d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

