### PR TITLE
docs: add Storybook visual-regression skill for UI PRs

### DIFF
--- a/.cursor/rules/pr.mdc
+++ b/.cursor/rules/pr.mdc
@@ -18,7 +18,7 @@ When the user types `@pr`, automatically generate a comprehensive pull request d
    - Fill in the Description section with a clear summary
    - Identify any related issues if mentioned in commits
    - Suggest manual testing steps based on changes
-   - Note if screenshots/recordings would be helpful
+   - Collect Storybook before/after screenshots for visual UI changes (see Visual evidence below)
    - Pre-check relevant checklist items
 
 3. **Smart content generation**:
@@ -26,7 +26,7 @@ When the user types `@pr`, automatically generate a comprehensive pull request d
    - **Description**: Write 2-3 sentences explaining what changed and why
    - **Related issues**: Look for issue references in commit messages
    - **Manual testing steps**: Generate realistic testing steps based on the components changed
-   - **Screenshots/Recordings**: Suggest if UI/visual changes are detected
+   - **Screenshots/Recordings**: For visual UI changes, run `.cursor/skills/visual-regression-collect/SKILL.md` and embed GitHub-attached PNGs. Do not leave this section as a placeholder.
    - **Checklist items**: Auto-check items that are clearly satisfied
 
 4. **Component-specific intelligence**:
@@ -37,19 +37,27 @@ When the user types `@pr`, automatically generate a comprehensive pull request d
    - For build/config changes: Note infrastructure updates
    - For documentation: Mention docs updates
 
-5. **Create the PR using GitHub CLI**:
+5. **Visual evidence (required for UI changes)**:
+
+   - Follow `.cursor/skills/visual-regression-collect/SKILL.md` before considering the PR complete.
+   - Capture Storybook before/after for **every visual dependent**, not only files in the diff (primitives such as `ButtonBase` affect `Button`, `ButtonHero`, `ButtonFilter`, `SelectButton`, and so on; see [PR #1494](https://github.com/MetaMask/metamask-design-system/pull/1494)).
+   - Crop tightly around the changed UI (component bounding box + 8–16px). Do not attach a full-screen shot of a small component such as Badge.
+   - Attach PNGs with `gh --attach` (v2.99.0+). Never paste Cursor artifact URLs.
+   - If the PR already exists and UI changed, recapture and `gh pr edit --body-file ... --attach ...` so Screenshots/Recordings shows the latest set.
+
+6. **Create the PR using GitHub CLI**:
 
    - Generate a concise PR title based on the changes (e.g., "feat: add Avatar Figma Code Connect integration")
    - Create a secure temporary file with a unique name using a UUID or random string (e.g., `pr-description-[uuid].md`)
    - Ensure the `.cursor/temp/` directory exists, create it if needed
-   - Save the generated description to the temporary file
-   - Execute: `gh pr create --title "[generated-title]" --body-file .cursor/temp/pr-description-[unique-id].md --draft`
-   - If successful, display: "✅ Draft PR created successfully: [PR-URL]"
+   - Save the generated description to the temporary file (Markdown image refs must use the same local PNG paths passed to `--attach`)
+   - Execute: `gh pr create --title "[generated-title]" --body-file .cursor/temp/pr-description-[unique-id].md --draft` plus one `--attach 'path/to/file.png#Alt text'` per screenshot
+   - If successful, display: "Draft PR created successfully: [PR-URL]"
    - Provide next steps: "Review the description and run `gh pr ready` when ready for review"
    - Clean up temporary file after successful PR creation
    - If PR creation fails, ensure the temporary file is deleted to prevent accumulation
 
-6. **Display the generated description and PR creation status**:
+7. **Display the generated description and PR creation status**:
 
 ```markdown
 ## **Description**
@@ -66,7 +74,7 @@ When the user types `@pr`, automatically generate a comprehensive pull request d
 
 ## **Screenshots/Recordings**
 
-[Indicate if needed based on UI changes]
+[GitHub-attached before/after Storybook captures of every visual dependent, or "Not applicable" for non-visual PRs]
 
 ## **Pre-merge author checklist**
 
@@ -98,7 +106,7 @@ When the user types `@pr`, automatically generate a comprehensive pull request d
 - Always create PR as draft initially using `--draft` flag
 - Use semantic PR titles following conventional commits (feat:, fix:, chore:, etc.)
 - Generate unique temporary filenames using UUIDs or random strings to avoid conflicts
-- Show the GitHub CLI command being executed: `gh pr create --title "..." --body-file .cursor/temp/pr-description-[unique-id].md --draft`
+- Show the GitHub CLI command being executed: `gh pr create --title "..." --body-file .cursor/temp/pr-description-[unique-id].md --draft` with `--attach` flags when screenshots exist
 - After successful creation, display: "✅ Draft PR created successfully: [PR-URL]"
 - Provide next steps: "Review the description and run `gh pr ready` when ready for review"
 - If `gh` command fails, display the generated description and provide manual instructions

--- a/.cursor/rules/pr.mdc
+++ b/.cursor/rules/pr.mdc
@@ -42,7 +42,7 @@ When the user types `@pr`, automatically generate a comprehensive pull request d
    - Follow `.cursor/skills/visual-regression-collect/SKILL.md` before considering the PR complete.
    - Capture Storybook before/after for **every visual dependent**, not only files in the diff (primitives such as `ButtonBase` affect `Button`, `ButtonHero`, `ButtonFilter`, `SelectButton`, and so on; see [PR #1494](https://github.com/MetaMask/metamask-design-system/pull/1494)).
    - Crop tightly around the changed UI (component bounding box + 8–16px). Do not attach a full-screen shot of a small component such as Badge.
-   - Attach PNGs with `gh --attach` (v2.99.0+). Never paste Cursor artifact URLs.
+   - Attach PNGs with `gh --attach` (v2.99.0+, [changelog](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/)). Never paste Cursor artifact URLs.
    - If the PR already exists and UI changed, recapture and `gh pr edit --body-file ... --attach ...` so Screenshots/Recordings shows the latest set.
 
 6. **Create the PR using GitHub CLI**:

--- a/.cursor/skills/visual-regression-collect/SKILL.md
+++ b/.cursor/skills/visual-regression-collect/SKILL.md
@@ -27,7 +27,7 @@ Skip changelog-only, types-only, tests-only, docs-only, CI, and non-visual refac
 
 - **Never** put `cursor.com/agents/.../artifacts` (or any other Cursor-hosted image URL) in a PR, issue, or comment.
 - **Never** push a screenshots git branch or `raw.githubusercontent.com` image links.
-- **Always** attach local PNGs with `gh --attach` (`gh` >= 2.99.0). GitHub rewrites local Markdown paths to `user-attachments` URLs.
+- **Always** attach local PNGs with `gh --attach` (`gh` >= 2.99.0). This is the [GitHub CLI media upload](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/) shipped in CLI 2.99.0. GitHub rewrites local Markdown paths to `user-attachments` URLs.
 - **Never** screenshot only the files in the diff. Capture **every surface the change visually affects** (composition consumers, both platforms). See [Expand to dependents](#expand-to-dependents).
 - **Never** commit sandbox/showcase stories or PNGs to the feature branch.
 - **Always** crop tightly around the changed UI. Do not post a full-viewport or full-canvas screenshot of a small component. See [Tight crop](#tight-crop).
@@ -103,6 +103,8 @@ If the story’s default layout is a huge padded canvas, temporarily wrap the in
 Wrong: full page of one Badge. Right: Badge filling most of a ~200px-wide PNG, before and after side by side.
 
 ## Attach with GitHub CLI
+
+GitHub CLI 2.99.0 added a repeatable `--attach` flag that uploads local PNG/JPEG/GIF/WebP (and video) and rewrites matching Markdown paths to GitHub-hosted media. See [GitHub CLI: Media in issues, pull requests, and comments](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/) and [Attaching files with GitHub CLI](https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli).
 
 ```bash
 gh --version   # require >= 2.99.0; otherwise brew upgrade gh and stop

--- a/.cursor/skills/visual-regression-collect/SKILL.md
+++ b/.cursor/skills/visual-regression-collect/SKILL.md
@@ -45,14 +45,14 @@ Primitive and token changes leak into other components. Example: [PR #1494](http
    ```
 
 3. Include **both** React and React Native when the same primitive exists on both.
-4. Include stories that show **opt-outs** (e.g. `TextButton` still `rounded-none`) so reviewers see what did *not* change.
+4. Include stories that show **opt-outs** (e.g. `TextButton` still `rounded-none`) so reviewers see what did _not_ change.
 5. Token / global style changes: pick representative stories for the token category (color, radius, typography) plus any component whose stories document that token. Do not screenshot the entire Storybook.
 
 ### How many shots
 
-| Fan-out | What to capture |
-| --- | --- |
-| 1–8 affected components | Default story each (plus Size / Variant if that is what changed). Light and dark when the diff is color/token. |
+| Fan-out                                         | What to capture                                                                                                                                                                      |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1–8 affected components                         | Default story each (plus Size / Variant if that is what changed). Light and dark when the diff is color/token.                                                                       |
 | More than 8, or a primitive with many consumers | One **temporary showcase** story per platform that mounts all dependents in a grid (same layout on before and after), **plus** 1–2 detail stories for the primitive and any opt-out. |
 
 Showcase story path (delete after capture):
@@ -66,11 +66,11 @@ Use realistic default props from existing stories. Do not commit these files.
 
 Do **not** wait for PR Storybook CI.
 
-| Pass | Source |
-| --- | --- |
-| **Before** | Hosted main iframe: `https://metamask.github.io/metamask-design-system/iframe.html?id={storyId}&viewMode=story` and `/react-native/iframe.html?...` |
-| **After** | PR CloudFront preview **only if** the PR already has a Storybook Links comment with a live URL |
-| **After (default)** | Local `yarn storybook` (port 6006) and `yarn workspace @metamask/storybook-react-native storybook:web` (port 6007) |
+| Pass                | Source                                                                                                                                              |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Before**          | Hosted main iframe: `https://metamask.github.io/metamask-design-system/iframe.html?id={storyId}&viewMode=story` and `/react-native/iframe.html?...` |
+| **After**           | PR CloudFront preview **only if** the PR already has a Storybook Links comment with a live URL                                                      |
+| **After (default)** | Local `yarn storybook` (port 6006) and `yarn workspace @metamask/storybook-react-native storybook:web` (port 6007)                                  |
 
 Resolve story IDs from `index.json` / `stories.json` (hosted or `http://localhost:6006/index.json`). Do not invent IDs.
 

--- a/.cursor/skills/visual-regression-collect/SKILL.md
+++ b/.cursor/skills/visual-regression-collect/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: visual-regression-collect
+description: >-
+  Captures Storybook before/after screenshots for MMDS UI work, expands to
+  every visual dependent (not only files in the diff), and attaches PNGs as
+  GitHub media with gh --attach. Use when creating or updating a UI PR, when
+  the user asks for screenshots, before/after, visual assets, visual
+  representation, or Storybook captures, or when existing PR screenshots need
+  refreshing. Never post Cursor artifact URLs.
+---
+
+# Visual regression collect (MMDS)
+
+Capture Storybook **before/after** PNGs for visual UI work in this repo and attach them with GitHub CLI. Chromatic stays the React pixel merge gate; this skill is **GitHub-visible evidence** for React and React Native web.
+
+## When to run
+
+Run when **any** of these are true:
+
+1. Creating or updating a PR whose diff includes visual UI (`packages/design-system-react`, `packages/design-system-react-native`, `packages/design-tokens`, Storybook apps).
+2. The user asks for screenshots, before/after, visual assets, visual representation, or Storybook captures (even before a PR exists).
+3. UI changed after screenshots were posted, or the user asks to refresh visual assets.
+
+Skip changelog-only, types-only, tests-only, docs-only, CI, and non-visual refactors.
+
+## Critical rules
+
+- **Never** put `cursor.com/agents/.../artifacts` (or any other Cursor-hosted image URL) in a PR, issue, or comment.
+- **Never** push a screenshots git branch or `raw.githubusercontent.com` image links.
+- **Always** attach local PNGs with `gh --attach` (`gh` >= 2.99.0). GitHub rewrites local Markdown paths to `user-attachments` URLs.
+- **Never** screenshot only the files in the diff. Capture **every surface the change visually affects** (composition consumers, both platforms). See [Expand to dependents](#expand-to-dependents).
+- **Never** commit sandbox/showcase stories or PNGs to the feature branch.
+- **Always** crop tightly around the changed UI. Do not post a full-viewport or full-canvas screenshot of a small component. See [Tight crop](#tight-crop).
+- React Native captures use **web** Storybook (`storybook:web` / static `/react-native`), not iOS/Android simulators.
+
+## Expand to dependents
+
+Primitive and token changes leak into other components. Example: [PR #1494](https://github.com/MetaMask/metamask-design-system/pull/1494) changed `ButtonBase` / `ButtonIcon` radius; reviewers needed shots of `Button` variants, `ButtonHero`, `ButtonFilter`, `TextButton` (opt-out), `SelectButton`, and `SegmentedControl` — not just `ButtonBase.tsx`.
+
+1. Start from changed **implementation** files (`.tsx` components, token CSS/TS). Ignore tests, README, constants-only, and Figma connect unless they are the only signal.
+2. For each changed component, find importers in the same package (and the sibling platform package):
+
+   ```bash
+   rg -l "from ['\"].*/ButtonBase" packages/design-system-react/src packages/design-system-react-native/src
+   ```
+
+3. Include **both** React and React Native when the same primitive exists on both.
+4. Include stories that show **opt-outs** (e.g. `TextButton` still `rounded-none`) so reviewers see what did *not* change.
+5. Token / global style changes: pick representative stories for the token category (color, radius, typography) plus any component whose stories document that token. Do not screenshot the entire Storybook.
+
+### How many shots
+
+| Fan-out | What to capture |
+| --- | --- |
+| 1–8 affected components | Default story each (plus Size / Variant if that is what changed). Light and dark when the diff is color/token. |
+| More than 8, or a primitive with many consumers | One **temporary showcase** story per platform that mounts all dependents in a grid (same layout on before and after), **plus** 1–2 detail stories for the primitive and any opt-out. |
+
+Showcase story path (delete after capture):
+
+- React: `packages/design-system-react/src/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx`
+- RN: `packages/design-system-react-native/src/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx`
+
+Use realistic default props from existing stories. Do not commit these files.
+
+## Capture sources
+
+Do **not** wait for PR Storybook CI.
+
+| Pass | Source |
+| --- | --- |
+| **Before** | Hosted main iframe: `https://metamask.github.io/metamask-design-system/iframe.html?id={storyId}&viewMode=story` and `/react-native/iframe.html?...` |
+| **After** | PR CloudFront preview **only if** the PR already has a Storybook Links comment with a live URL |
+| **After (default)** | Local `yarn storybook` (port 6006) and `yarn workspace @metamask/storybook-react-native storybook:web` (port 6007) |
+
+Resolve story IDs from `index.json` / `stories.json` (hosted or `http://localhost:6006/index.json`). Do not invent IDs.
+
+Capture the **iframe** only (no Storybook chrome). Wait until `#storybook-root > *` exists. Then crop to the component — see [Tight crop](#tight-crop). Optional: outline the component (not the canvas) with `3px solid hotpink`.
+
+New stories (not on hosted main): after-only, labeled “new story”. Never post a broken before image.
+
+If pixel-diff vs before is empty (or below a tiny threshold), skip that story in the PR body.
+
+## Tight crop
+
+Reviewers must be able to see a 2px radius or 1px border change. A full-window shot of a small component (Badge, Avatar, ButtonIcon, Icon) hides that in empty canvas.
+
+**Do**
+
+- Screenshot the **component bounding box**, not the browser viewport and not the whole Storybook canvas.
+- Use `getBoundingClientRect()` on `#storybook-root > :first-child` (or the specific node that changed) and capture that rectangle plus **8–16px** padding.
+- Prefer an element screenshot from the browser tool when it can target that node.
+- Keep before and after **the same crop size and origin** so the pair is comparable.
+- For a showcase grid, crop to the grid’s bounding box plus the same small padding — not the leftover white page.
+
+**Do not**
+
+- Take a full-screen or full-iframe PNG of `BadgeNetwork` (or any similarly small control). A 24–32px badge in a 1440×900 frame makes a radius tweak invisible.
+- Include Storybook sidebar, toolbar, docs layout, or large empty `padded` canvas.
+- Scale the image down so much that the change disappears; crop in, do not shrink.
+
+If the story’s default layout is a huge padded canvas, temporarily wrap the instance in a hug-contents container in the sandbox story, or clip in the capture step. Delete any sandbox after.
+
+Wrong: full page of one Badge. Right: Badge filling most of a ~200px-wide PNG, before and after side by side.
+
+## Attach with GitHub CLI
+
+```bash
+gh --version   # require >= 2.99.0; otherwise brew upgrade gh and stop
+```
+
+`--attach` needs a user OAuth/PAT with repo **write** access. GitHub App `GITHUB_TOKEN` (`ghs_`) cannot upload. If attach fails, keep PNGs locally and say so — still do **not** use Cursor URLs.
+
+Write Markdown that references **local paths**. `gh` rewrites those paths when the same files are passed to `--attach`:
+
+```markdown
+## **Screenshots/Recordings**
+
+A showcase of every component this change visually affects (not only files in the diff), captured on hosted `main` (before) and this branch (after).
+
+### React web — consumers
+
+![Before React consumers](/tmp/vr/before/web-consumers.png)
+![After React consumers](/tmp/vr/after/web-consumers.png)
+
+### React Native web — consumers
+
+![Before RN consumers](/tmp/vr/before/rn-consumers.png)
+![After RN consumers](/tmp/vr/after/rn-consumers.png)
+
+### Detail
+
+![Before ButtonBase](/tmp/vr/before/buttonbase-default.png)
+![After ButtonBase](/tmp/vr/after/buttonbase-default.png)
+```
+
+Then:
+
+```bash
+# New PR (combine with the usual --draft --body-file from .cursor/rules/pr.mdc)
+gh pr create --title "..." --body-file pr-body.md --draft \
+  --attach '/tmp/vr/before/web-consumers.png#Before React consumers' \
+  --attach '/tmp/vr/after/web-consumers.png#After React consumers'
+
+# Existing PR: replace the Screenshots section with the latest set
+gh pr edit --body-file pr-body.md \
+  --attach '/tmp/vr/before/web-consumers.png#Before React consumers' \
+  --attach '/tmp/vr/after/web-consumers.png#After React consumers'
+```
+
+Repeat `--attach` for each PNG. Prefer the PR body **Screenshots/Recordings** section. Use `gh pr comment --body-file ... --attach ...` only for a refresh comment. Do not use `gh api` review comments for images (no `--attach`).
+
+On refresh: recapture, rewrite the section, re-attach. The body should show only the latest set.
+
+## No PR yet
+
+If the user asked for visuals before a PR exists, capture into `/tmp/vr/` (or `.cursor/temp/vr/`, gitignored). When the PR is created, attach those files. If the UI changed since capture, recapture first.
+
+## Local vs cloud agents
+
+Local agents do **not** get a Cloud Agent VM. Use the Cursor browser against hosted/local Storybook, then `gh --attach`.
+
+Cloud agents use the VM browser against GitHub Pages, PR preview, or Storybook in the VM. Same attach rules if `gh` auth supports `--attach`.
+
+## Golden path (PR #1494)
+
+Diff touched `ButtonBase` and `ButtonIcon` (and RN `SegmentedControl` to stay concentric). Correct capture set:
+
+- Web showcase: `ButtonBase`, `Button` variants/sizes, `ButtonHero`, `ButtonFilter`, `TextButton`, `ButtonIcon`
+- RN showcase: those plus `ButtonSemantic`, `SelectButton`, `SegmentedControl`
+- Detail: `ButtonBase` / `ButtonIcon`; RN `SegmentedControl` sizes
+
+Wrong: only `ButtonBase` Default on web, or a full-viewport PNG of a small control such as Badge.

--- a/.cursor/skills/visual-regression-collect/SKILL.md
+++ b/.cursor/skills/visual-regression-collect/SKILL.md
@@ -50,10 +50,15 @@ Primitive and token changes leak into other components. Example: [PR #1494](http
 
 ### How many shots
 
-| Fan-out                                         | What to capture                                                                                                                                                                         |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1–8 affected components                         | Default story each (plus Size / Variant if that is what changed). Light and dark when the diff is color/token. Hosted main works for **before** when those stories already exist.       |
-| More than 8, or a primitive with many consumers | One **temporary showcase** story per platform that mounts all dependents in a grid (identical file on before and after), **plus** 1–2 detail stories for the primitive and any opt-out. |
+**Default: use stories that already exist.** Resolve their IDs, capture hosted main (before) and local/PR preview (after). Do not invent a sandbox story for a single component or a small set of dependents — writing props, checking out base, and reloading Storybook costs more agent tokens than opening a few iframes.
+
+| Situation                                                                                                                                        | What to capture                                                                                                                                   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1–5 affected components with existing stories                                                                                                    | Those stories only (Default, plus Size / Variant if that is what changed). Light and dark when the diff is color/token.                           |
+| 6+ dependents, **or** a shared primitive/token where the review value is the blast radius, **or** the user asks for a composed / all-in-one shot | One **temporary showcase** grid per platform (identical sandbox on before and after), **plus** 1–2 detail shots of the primitive and any opt-out. |
+| Affected component has no story                                                                                                                  | Temporary sandbox for that component only (or after-only if it is brand new on the PR).                                                           |
+
+Showcase when the composed frame is worth more than N separate PNGs — e.g. [PR #1494](https://github.com/MetaMask/metamask-design-system/pull/1494) (`ButtonBase` radius) where reviewers needed `Button`, `ButtonHero`, `ButtonFilter`, `TextButton`, `SelectButton`, and `SegmentedControl` in one glance. Skip the showcase for a lone `BadgeNetwork` radius tweak; crop its existing story tightly instead.
 
 Showcase story path (delete after capture; never commit):
 
@@ -175,10 +180,10 @@ Cloud agents use the VM browser against GitHub Pages, PR preview, or Storybook i
 
 ## Golden path (PR #1494)
 
-Diff touched `ButtonBase` and `ButtonIcon` (and RN `SegmentedControl` to stay concentric). Correct capture set:
+Diff touched `ButtonBase` and `ButtonIcon` (and RN `SegmentedControl` to stay concentric). Many dependents → escalate to showcase (not one story per consumer):
 
 - Web showcase grid (local base → local PR head, same sandbox file): `ButtonBase`, `Button` variants/sizes, `ButtonHero`, `ButtonFilter`, `TextButton`, `ButtonIcon`
 - RN showcase grid (same local-base / local-head pattern): those plus `ButtonSemantic`, `SelectButton`, `SegmentedControl`
 - Detail: `ButtonBase` / `ButtonIcon` / RN `SegmentedControl` sizes — before may use hosted main for these existing stories
 
-Wrong: only `ButtonBase` Default on web; a full-viewport PNG of a small control such as Badge; or a showcase “before” from hosted main (the sandbox story is not published there).
+Wrong: only `ButtonBase` Default on web; a full-viewport PNG of a small control such as Badge; a showcase “before” from hosted main; or writing a sandbox when a few existing stories would have been enough.

--- a/.cursor/skills/visual-regression-collect/SKILL.md
+++ b/.cursor/skills/visual-regression-collect/SKILL.md
@@ -29,7 +29,7 @@ Skip changelog-only, types-only, tests-only, docs-only, CI, and non-visual refac
 - **Never** push a screenshots git branch or `raw.githubusercontent.com` image links.
 - **Always** attach local PNGs with `gh --attach` (`gh` >= 2.99.0). This is the [GitHub CLI media upload](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/) shipped in CLI 2.99.0. GitHub rewrites local Markdown paths to `user-attachments` URLs.
 - **Never** screenshot only the files in the diff. Capture **every surface the change visually affects** (composition consumers, both platforms). See [Expand to dependents](#expand-to-dependents).
-- **Never** commit sandbox/showcase stories or PNGs to the feature branch.
+- **Never** commit sandbox/showcase stories or PNGs to the feature branch. Sandbox **before** shots use local Storybook on the base branch — never hosted main (the story is not published there).
 - **Always** crop tightly around the changed UI. Do not post a full-viewport or full-canvas screenshot of a small component. See [Tight crop](#tight-crop).
 - React Native captures use **web** Storybook (`storybook:web` / static `/react-native`), not iOS/Android simulators.
 
@@ -50,33 +50,43 @@ Primitive and token changes leak into other components. Example: [PR #1494](http
 
 ### How many shots
 
-| Fan-out                                         | What to capture                                                                                                                                                                      |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1–8 affected components                         | Default story each (plus Size / Variant if that is what changed). Light and dark when the diff is color/token.                                                                       |
-| More than 8, or a primitive with many consumers | One **temporary showcase** story per platform that mounts all dependents in a grid (same layout on before and after), **plus** 1–2 detail stories for the primitive and any opt-out. |
+| Fan-out                                         | What to capture                                                                                                                                                                         |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1–8 affected components                         | Default story each (plus Size / Variant if that is what changed). Light and dark when the diff is color/token. Hosted main works for **before** when those stories already exist.       |
+| More than 8, or a primitive with many consumers | One **temporary showcase** story per platform that mounts all dependents in a grid (identical file on before and after), **plus** 1–2 detail stories for the primitive and any opt-out. |
 
-Showcase story path (delete after capture):
+Showcase story path (delete after capture; never commit):
 
 - React: `packages/design-system-react/src/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx`
 - RN: `packages/design-system-react-native/src/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx`
 
-Use realistic default props from existing stories. Do not commit these files.
+Use realistic default props from existing stories.
+
+**Showcase before cannot use hosted main.** That story is uncommitted, so it is absent from GitHub Pages. For showcase grids:
+
+1. Save the current branch name.
+2. Check out the PR base (`main`), write the sandbox story, start local Storybook, capture **before**.
+3. Check out the PR head, write the **same** sandbox story (same layout and props), capture **after**.
+4. Delete the sandbox, restore the original branch, and verify a clean tree.
+
+Detail shots of stories that already exist on `main` can still use hosted main for before.
 
 ## Capture sources
 
 Do **not** wait for PR Storybook CI.
 
-| Pass                | Source                                                                                                                                              |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Before**          | Hosted main iframe: `https://metamask.github.io/metamask-design-system/iframe.html?id={storyId}&viewMode=story` and `/react-native/iframe.html?...` |
-| **After**           | PR CloudFront preview **only if** the PR already has a Storybook Links comment with a live URL                                                      |
-| **After (default)** | Local `yarn storybook` (port 6006) and `yarn workspace @metamask/storybook-react-native storybook:web` (port 6007)                                  |
+| Pass                            | Source                                                                                                                                              | When                                                                   |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Before (existing stories)**   | Hosted main iframe: `https://metamask.github.io/metamask-design-system/iframe.html?id={storyId}&viewMode=story` and `/react-native/iframe.html?...` | Story ID exists in hosted `index.json`                                 |
+| **Before (sandbox / showcase)** | Local Storybook on the **base** branch with the temporary sandbox story written                                                                     | High fan-out showcase, or any story that does not exist on hosted main |
+| **After**                       | PR CloudFront preview **only if** the PR already has a Storybook Links comment **and** the story exists in that build                               | Prefer for existing stories when the preview is already live           |
+| **After (default / sandbox)**   | Local `yarn storybook` (port 6006) and `yarn workspace @metamask/storybook-react-native storybook:web` (port 6007) on the **PR** branch             | Default for after; **required** for sandbox showcase                   |
 
 Resolve story IDs from `index.json` / `stories.json` (hosted or `http://localhost:6006/index.json`). Do not invent IDs.
 
 Capture the **iframe** only (no Storybook chrome). Wait until `#storybook-root > *` exists. Then crop to the component — see [Tight crop](#tight-crop). Optional: outline the component (not the canvas) with `3px solid hotpink`.
 
-New stories (not on hosted main): after-only, labeled “new story”. Never post a broken before image.
+New component stories that exist only on the PR branch (not a temporary sandbox): after-only, labeled “new story”. Never post a broken before image. Sandbox showcases are not “new stories” — always capture both passes locally as above.
 
 If pixel-diff vs before is empty (or below a tiny threshold), skip that story in the PR body.
 
@@ -117,7 +127,7 @@ Write Markdown that references **local paths**. `gh` rewrites those paths when t
 ```markdown
 ## **Screenshots/Recordings**
 
-A showcase of every component this change visually affects (not only files in the diff), captured on hosted `main` (before) and this branch (after).
+A showcase of every component this change visually affects (not only files in the diff). Existing stories: before = hosted `main`, after = this branch. Showcase grids: before = local Storybook on base, after = local Storybook on this branch (same temporary sandbox story).
 
 ### React web — consumers
 
@@ -167,8 +177,8 @@ Cloud agents use the VM browser against GitHub Pages, PR preview, or Storybook i
 
 Diff touched `ButtonBase` and `ButtonIcon` (and RN `SegmentedControl` to stay concentric). Correct capture set:
 
-- Web showcase: `ButtonBase`, `Button` variants/sizes, `ButtonHero`, `ButtonFilter`, `TextButton`, `ButtonIcon`
-- RN showcase: those plus `ButtonSemantic`, `SelectButton`, `SegmentedControl`
-- Detail: `ButtonBase` / `ButtonIcon`; RN `SegmentedControl` sizes
+- Web showcase grid (local base → local PR head, same sandbox file): `ButtonBase`, `Button` variants/sizes, `ButtonHero`, `ButtonFilter`, `TextButton`, `ButtonIcon`
+- RN showcase grid (same local-base / local-head pattern): those plus `ButtonSemantic`, `SelectButton`, `SegmentedControl`
+- Detail: `ButtonBase` / `ButtonIcon` / RN `SegmentedControl` sizes — before may use hosted main for these existing stories
 
-Wrong: only `ButtonBase` Default on web, or a full-viewport PNG of a small control such as Badge.
+Wrong: only `ButtonBase` Default on web; a full-viewport PNG of a small control such as Badge; or a showcase “before” from hosted main (the sandbox story is not published there).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Design tokens and components for MetaMask extension (React) and mobile (React Na
 
 - **Do not edit package `CHANGELOG.md` files in feature/fix PRs.** Changelogs are generated and edited only on `release/*` branches (`yarn create-release-branch`). Do not run `yarn changelog:update` unless you are on a release branch. Put consumer-facing notes in the PR description; put breaking-change guidance in `MIGRATION.md`.
 - **User-facing copy uses sentence case** unless it is an approved exception (proper nouns, abbreviations, Secret Recovery Phrase). See `.cursor/rules/content-guidelines.mdc`.
+- **UI PRs include Storybook before/after screenshots** of every visual dependent (not only files in the diff), attached with `gh --attach`. Never paste Cursor artifact URLs. Follow `.cursor/skills/visual-regression-collect/SKILL.md`.
 
 ## Documentation for AI Agents
 
@@ -21,6 +22,10 @@ Repository-specific conventions and patterns. Open the matching file when the ta
 - `.cursor/rules/figma-integration.md`
 - `.cursor/rules/release-workflow.md`
 - `.cursor/rules/content-guidelines.mdc`
+
+**Project skills** live in `.cursor/skills/` (committed). Cursor Desktop and Cloud Agents discover them from the git checkout. Do not put MMDS workflows in `~/.cursor/skills` — cloud agents never see that folder.
+
+- `.cursor/skills/visual-regression-collect/SKILL.md` — Storybook before/after for UI PRs and visual-asset requests
 
 See `docs/ai-agents.md` for the full strategy.
 
@@ -88,6 +93,7 @@ yarn create-component:react-native --name ComponentName --description "Brief des
 
 # Storybook
 yarn storybook                # React web (port 6006)
+yarn workspace @metamask/storybook-react-native storybook:web  # React Native web (port 6007)
 yarn storybook:ios:build      # React Native iOS dev client (first time / native dep changes)
 yarn storybook:ios            # React Native iOS (Metro + dev client)
 yarn storybook:android:build  # React Native Android dev client (first time / native dep changes)
@@ -114,7 +120,7 @@ Storybook apps in `apps/` consume packages for development and testing:
 - `@metamask/storybook-react` - Web component development (`yarn storybook`)
 - `@metamask/storybook-react-native` - Mobile development (`yarn storybook:ios:build` then `yarn storybook:ios`)
 
-These platforms are for manual testing and component showcase. Visual regression testing is planned but not yet implemented.
+These platforms are for manual testing and component showcase. React visual diffs also run in Chromatic; agent-collected Storybook before/after for PRs is `.cursor/skills/visual-regression-collect/SKILL.md`.
 
 **Import using package names, never file paths:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Design tokens and components for MetaMask extension (React) and mobile (React Na
 
 - **Do not edit package `CHANGELOG.md` files in feature/fix PRs.** Changelogs are generated and edited only on `release/*` branches (`yarn create-release-branch`). Do not run `yarn changelog:update` unless you are on a release branch. Put consumer-facing notes in the PR description; put breaking-change guidance in `MIGRATION.md`.
 - **User-facing copy uses sentence case** unless it is an approved exception (proper nouns, abbreviations, Secret Recovery Phrase). See `.cursor/rules/content-guidelines.mdc`.
-- **UI PRs include Storybook before/after screenshots** of every visual dependent (not only files in the diff), attached with `gh --attach`. Never paste Cursor artifact URLs. Follow `.cursor/skills/visual-regression-collect/SKILL.md`.
+- **UI PRs include Storybook before/after screenshots** of every visual dependent (not only files in the diff), attached with `gh --attach` ([CLI 2.99.0 media upload](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/)). Never paste Cursor artifact URLs. Follow `.cursor/skills/visual-regression-collect/SKILL.md`.
 
 ## Documentation for AI Agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ Claude Code expands these `@` imports at session start. Other agents should open
 @.cursor/rules/release-workflow.md
 @.cursor/rules/content-guidelines.mdc
 
+Do **not** `@`-import `.cursor/skills/` here. Skills are on-demand workflows (see `docs/ai-agents.md`). Claude Code still gets the UI-screenshot invariant from `@AGENTS.md`.
+
 See `docs/ai-agents.md` for the full strategy.
 
 ## Personal Overrides

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -22,6 +22,8 @@ Engineers can reference `.cursor/rules/` directly when needed, but the primary i
 ├── .cursor/rules/              # Layer 2: Focused rules
 │   ├── *.mdc                  # Cursor project rules (alwaysApply / globs / description)
 │   └── *.md                   # Detailed checklists (Claude Code @-imports; other agents Read)
+├── .cursor/skills/             # On-demand workflows (see Project skills below)
+├── .cursor/automations/        # Cursor Automations prompt specs (git source of truth)
 └── docs/                       # Layer 3: High-level guides
     └── ai-agents.md           # This file - strategy explanation
 ```
@@ -47,7 +49,7 @@ Engineers can reference `.cursor/rules/` directly when needed, but the primary i
 
 - Claude Code and Cursor both recommend a concise always-loaded file
 - Agents can miss key rules in verbose files
-- Put detailed workflows in `.cursor/rules/`
+- Put detailed workflows in `.cursor/rules/` (conventions) or `.cursor/skills/` (multi-step procedures invoked on demand)
 
 ## Layer 2: .cursor/rules/ (Focused Rules)
 
@@ -85,8 +87,27 @@ Engineers can reference `.cursor/rules/` directly when needed, but the primary i
 
 - **Context efficient:** Every line prevents a mistake
 - **Actionable:** Tell agents what to do, not theory
-- **Reference-based:** Rules point to canonical code examples in the codebase rather than duplicating them
+- **Reference over duplication:** Rules point to canonical code examples in the codebase rather than duplicating them
 - **Maintainable:** Checklists easier to update than narratives
+
+## Project skills (`.cursor/skills/`)
+
+**Purpose:** Multi-step procedures the agent should follow when a matching task starts (create a UI PR, collect screenshots, refresh visual assets). Not standing conventions — those stay in `.cursor/rules/`.
+
+**Location:** `.cursor/skills/<skill-name>/SKILL.md`, committed in this repo.
+
+| Kind | Path | Who sees it |
+| --- | --- | --- |
+| Project skill | `.cursor/skills/` in git | Cursor Desktop and Cloud Agents on a checkout that includes the files |
+| Personal skill | `~/.cursor/skills/` | Local machine only. Cloud agents do **not** load this folder. |
+
+Put MMDS workflows in **project** skills so cloud agents get them. Do not rely on laptop-only skills for this repo.
+
+**Do not** `@`-import skills from `CLAUDE.md`. They are large and should load when the description matches or the user asks, not on every session. Put must-not-miss invariants (e.g. UI PRs need GitHub-attached screenshots) **inline in `AGENTS.md`**.
+
+**Current skills**
+
+- `visual-regression-collect` — Storybook before/after for UI PRs and visual-asset requests; `gh --attach`; tight crop; expand to visual dependents
 
 ## Layer 3: docs/ (High-Level Guides)
 
@@ -139,6 +160,7 @@ What _is_ auto-loaded as markdown instructions:
 - `CLAUDE.md` (Claude Code always; Cursor may also load it — keep it a thin `@AGENTS.md` import so content is not duplicated)
 - `.cursor/rules/*.mdc` according to `alwaysApply` / `globs` / `description`
 - User rules and Team rules from the Cursor dashboard
+- Project skills in `.cursor/skills/` when the skill description matches the task (not every turn)
 
 `.cursor/rules/*.md` files are not Cursor project rules. Claude Code can `@`-import them from `CLAUDE.md` (imports expand at launch). Cursor Cloud Agents only see those files if they open them. Put must-not-miss invariants **inline in `AGENTS.md`**.
 
@@ -154,7 +176,8 @@ What _is_ auto-loaded as markdown instructions:
 1. Open Cursor in this repo
 2. `AGENTS.md` is injected into Agent and Cloud Agent sessions
 3. `.cursor/rules/*.mdc` files attach via `alwaysApply` / globs / description if you add any
-4. `.cursor/rules/*.md` is not auto-injected by Cursor; agents may still `Read` those files when they choose to
+4. `.cursor/skills/*/SKILL.md` attaches when the task matches the skill description
+5. `.cursor/rules/*.md` is not auto-injected by Cursor; agents may still `Read` those files when they choose to
 
 ### Claude Code
 

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -107,7 +107,7 @@ Put MMDS workflows in **project** skills so cloud agents get them. Do not rely o
 
 **Current skills**
 
-- `visual-regression-collect` — Storybook before/after for UI PRs and visual-asset requests; `gh --attach`; tight crop; expand to visual dependents
+- `visual-regression-collect` — Storybook before/after for UI PRs and visual-asset requests; `gh --attach` ([CLI 2.99.0 media](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/)); tight crop; expand to visual dependents
 
 ## Layer 3: docs/ (High-Level Guides)
 

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -96,10 +96,10 @@ Engineers can reference `.cursor/rules/` directly when needed, but the primary i
 
 **Location:** `.cursor/skills/<skill-name>/SKILL.md`, committed in this repo.
 
-| Kind | Path | Who sees it |
-| --- | --- | --- |
-| Project skill | `.cursor/skills/` in git | Cursor Desktop and Cloud Agents on a checkout that includes the files |
-| Personal skill | `~/.cursor/skills/` | Local machine only. Cloud agents do **not** load this folder. |
+| Kind           | Path                     | Who sees it                                                           |
+| -------------- | ------------------------ | --------------------------------------------------------------------- |
+| Project skill  | `.cursor/skills/` in git | Cursor Desktop and Cloud Agents on a checkout that includes the files |
+| Personal skill | `~/.cursor/skills/`      | Local machine only. Cloud agents do **not** load this folder.         |
 
 Put MMDS workflows in **project** skills so cloud agents get them. Do not rely on laptop-only skills for this repo.
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a committed Cursor project skill so local and cloud agents collect Storybook before/after screenshots for UI work: every visual dependent (not only files in the diff), tightly cropped, and uploaded as GitHub-hosted media.

Images go on the PR with GitHub CLI `--attach`, added in CLI 2.99.0 ([GitHub CLI: Media in issues, pull requests, and comments](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/)). Agents write Markdown with local PNG paths and pass the same files to `--attach`; `gh` rewrites them to `user-attachments` URLs. Do not paste Cursor artifact URLs.

`AGENTS.md` keeps the must-not-miss invariant. `docs/ai-agents.md` documents that project skills live in `.cursor/skills/` (git) and personal skills in `~/.cursor/skills/` (local only). `CLAUDE.md` does not `@`-import the skill so the procedure is not loaded on every Claude session.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Confirm `.cursor/skills/visual-regression-collect/SKILL.md` is present on this branch.
2. In Cursor, start a task that creates a UI PR or asks for visual assets and check the skill is offered / followed.
3. Confirm `gh --version` is 2.99.0 or later, then attach a local PNG with `gh pr create` / `gh pr edit` / `gh pr comment --attach` as in the [changelog](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/).

## **Screenshots/Recordings**

Not applicable. This change is agent documentation and a skill, with no component UI updates.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent workflow only; no runtime, auth, or component code changes.
> 
> **Overview**
> Introduces a **committed Cursor project skill** (`.cursor/skills/visual-regression-collect/SKILL.md`) that tells agents how to capture Storybook **before/after** PNGs for UI work: expand beyond diff files to **visual dependents**, **tight crop**, hosted `main` vs local/PR sources, optional temporary showcase sandboxes, and upload via **`gh --attach`** (CLI ≥ 2.99.0)—explicitly **no** Cursor artifact or raw GitHub URLs.
> 
> **`AGENTS.md`** adds a critical invariant that UI PRs must include those screenshots; **`docs/ai-agents.md`** documents the new **project skills** layer (git vs `~/.cursor/skills`); **`CLAUDE.md`** avoids `@`-importing skills so they load on demand. The **`@pr`** rule (`.cursor/rules/pr.mdc`) now treats visual evidence as required for UI changes and wires `gh pr create`/`edit` to **`--attach`**. **`AGENTS.md`** also documents RN web Storybook (`storybook:web` on port 6007) and clarifies Chromatic vs agent-collected PR evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68499d92c07288e9299175d97da9fbda5d8662b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->