### PR TITLE
feat(react,react-native): deprecate ButtonFilter in favor of FilterButton

### DIFF
--- a/packages/design-system-react-native/src/components/ButtonFilter/ButtonFilter.tsx
+++ b/packages/design-system-react-native/src/components/ButtonFilter/ButtonFilter.tsx
@@ -8,14 +8,22 @@ import type { ButtonFilterProps } from './ButtonFilter.types';
 /**
  * @deprecated Use `FilterButton` instead. This component will be removed
  * in a future major version of the design system.
+ *
+ * @param props - Component props.
+ * @param props.isActive - Whether the filter is in the active state.
+ * @param props.twClassName - Tailwind override classes for the container.
+ * @param props.textProps - Props forwarded to the internal text element.
+ * @param props.style - Style overrides applied to the container.
+ * @returns The rendered filter button element.
  */
-export const ButtonFilter: React.FC<ButtonFilterProps> = ({
-  isActive = false,
-  twClassName,
-  textProps,
-  style,
-  ...props
-}) => {
+export const ButtonFilter: React.FC<ButtonFilterProps> = (props) => {
+  const {
+    isActive = false,
+    twClassName,
+    textProps,
+    style,
+    ...restProps
+  } = props;
   const tw = useTailwind();
 
   const mergedStyle = [
@@ -34,6 +42,10 @@ export const ButtonFilter: React.FC<ButtonFilterProps> = ({
   };
 
   return (
-    <ButtonBase textProps={mergedTextProps} style={mergedStyle} {...props} />
+    <ButtonBase
+      textProps={mergedTextProps}
+      style={mergedStyle}
+      {...restProps}
+    />
   );
 };

--- a/packages/design-system-react-native/src/components/ButtonFilter/ButtonFilter.tsx
+++ b/packages/design-system-react-native/src/components/ButtonFilter/ButtonFilter.tsx
@@ -5,6 +5,10 @@ import { ButtonBase } from '../ButtonBase';
 
 import type { ButtonFilterProps } from './ButtonFilter.types';
 
+/**
+ * @deprecated Use `FilterButton` instead. This component will be removed
+ * in a future major version of the design system.
+ */
 export const ButtonFilter: React.FC<ButtonFilterProps> = ({
   isActive = false,
   twClassName,

--- a/packages/design-system-react/src/components/ButtonFilter/ButtonFilter.tsx
+++ b/packages/design-system-react/src/components/ButtonFilter/ButtonFilter.tsx
@@ -5,6 +5,10 @@ import { ButtonBase } from '../ButtonBase';
 
 import type { ButtonFilterProps } from './ButtonFilter.types';
 
+/**
+ * @deprecated Use `FilterButton` instead. This component will be removed
+ * in a future major version of the design system.
+ */
 export const ButtonFilter = forwardRef<HTMLButtonElement, ButtonFilterProps>(
   ({ className, isActive = false, ...props }, ref) => {
     const mergedClassName = twMerge(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Deprecates `ButtonFilter` via TSDoc `@deprecated` in both React and React Native packages. Guidance points consumers to `FilterButton` going forward.

- React: added `@deprecated` JSDoc above `export const ButtonFilter` in `packages/design-system-react`.
- React Native: added `@deprecated` JSDoc above `export const ButtonFilter` in `packages/design-system-react-native` and expanded JSDoc to include `@param`/`@returns` so eslint-plugin-jsdoc passes. Prettier formatting applied.
- No behavior change; compile/runtime unaffected. This is documentation-only and Storybook/TS tooling should surface the deprecation notice wherever supported.
- Per repo policy, no `CHANGELOG.md` edits on feature branches.

## Related issues

Closes DSYS-1103 — Deprecate `ButtonFilter` in favor of `FilterButton` across MMDS, Extension, and Mobile.

## Manual testing steps

1. Build Storybook for web and mobile packages.
2. Open the `ButtonFilter` docs; verify deprecation notice appears in Props/Docs panels (depending on tooling).
3. Confirm no type or lint regressions.

## Screenshots/Recordings

### Before

<!-- n/a — deprecation notice did not exist -->

### After

<!-- n/a — deprecation notice now shown by tools that render TSDoc -->

## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs
- [x] I've completed the PR template to the best of my ability
- [x] I’ve documented my code using JSDoc format where applicable
- [x] No `CHANGELOG.md` edits (kept to release branches only)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C02VD8QG0LT/p1788200983957779?thread_ts=1788200983.957779&cid=C02VD8QG0LT)

<div><a href="https://cursor.com/agents/bc-2460ec43-c0b8-5770-8d42-5df273e76031?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2460ec43-c0b8-5770-8d42-5df273e76031&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

