### PR TITLE
Release 68.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-design-system",
-  "version": "67.0.0",
+  "version": "68.0.0",
   "private": true,
   "description": "The MetaMask Design System monorepo",
   "repository": {

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: use fully rounded pill shape for ButtonBase and ButtonIcon ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494))
+- feat(react,react-native): deprecate ButtonFilter in favor of FilterButton ([#1509](https://github.com/MetaMask/metamask-design-system/pull/1509))
+
 ## [0.46.0]
 
 ### Added

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.47.0]
 
-### Uncategorized
+### Changed
 
-- feat: use fully rounded pill shape for ButtonBase and ButtonIcon ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494))
-- feat(react,react-native): deprecate ButtonFilter in favor of FilterButton ([#1509](https://github.com/MetaMask/metamask-design-system/pull/1509))
+- Updated `ButtonBase` and `ButtonIcon` to use fully rounded pill shapes across sizes and variants ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494))
+- Deprecated `ButtonFilter` in favor of `FilterButton` ([#1509](https://github.com/MetaMask/metamask-design-system/pull/1509))
 
 ## [0.46.0]
 

--- a/packages/design-system-react-native/CHANGELOG.md
+++ b/packages/design-system-react-native/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.0]
+
 ### Uncategorized
 
 - feat: use fully rounded pill shape for ButtonBase and ButtonIcon ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494))
@@ -762,7 +764,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - React Native integration with TWRNC preset support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.46.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.47.0...HEAD
+[0.47.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.46.0...@metamask/design-system-react-native@0.47.0
 [0.46.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.45.0...@metamask/design-system-react-native@0.46.0
 [0.45.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.44.0...@metamask/design-system-react-native@0.45.0
 [0.44.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react-native@0.43.0...@metamask/design-system-react-native@0.44.0

--- a/packages/design-system-react-native/package.json
+++ b/packages/design-system-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react-native",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Design System React Native",
   "keywords": [
     "MetaMask",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: use fully rounded pill shape for ButtonBase and ButtonIcon ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494))
+- feat(react,react-native): deprecate ButtonFilter in favor of FilterButton ([#1509](https://github.com/MetaMask/metamask-design-system/pull/1509))
+- fix(react): use muted background for TextField ([#1506](https://github.com/MetaMask/metamask-design-system/pull/1506))
+
 ## [0.42.0]
 
 ### Added

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.43.0]
 
-### Uncategorized
+### Changed
 
-- feat: use fully rounded pill shape for ButtonBase and ButtonIcon ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494))
-- feat(react,react-native): deprecate ButtonFilter in favor of FilterButton ([#1509](https://github.com/MetaMask/metamask-design-system/pull/1509))
-- fix(react): use muted background for TextField ([#1506](https://github.com/MetaMask/metamask-design-system/pull/1506))
+- Updated `ButtonBase` and `ButtonIcon` to use fully rounded pill shapes across sizes and variants ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494))
+- Deprecated `ButtonFilter` in favor of `FilterButton` ([#1509](https://github.com/MetaMask/metamask-design-system/pull/1509))
+- Changed the `TextField` background from the default background to the muted background ([#1506](https://github.com/MetaMask/metamask-design-system/pull/1506))
 
 ## [0.42.0]
 

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.0]
+
 ### Uncategorized
 
 - feat: use fully rounded pill shape for ButtonBase and ButtonIcon ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494))
@@ -567,7 +569,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions and enums
 - Tailwind CSS integration with design token support
 
-[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.42.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.43.0...HEAD
+[0.43.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.42.0...@metamask/design-system-react@0.43.0
 [0.42.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.41.0...@metamask/design-system-react@0.42.0
 [0.41.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.40.0...@metamask/design-system-react@0.41.0
 [0.40.0]: https://github.com/MetaMask/metamask-design-system/compare/@metamask/design-system-react@0.39.0...@metamask/design-system-react@0.40.0

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/design-system-react",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Design system react ui components",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Release 68.0.0

This release updates TextField and button visual behavior as part of the brand migration, and deprecates ButtonFilter in favor of FilterButton.

### 📦 Package Versions

- `@metamask/design-system-react`: **0.43.0**
- `@metamask/design-system-react-native`: **0.47.0**
- `@metamask/design-system-shared`: unchanged at **0.37.0**

### 🌐 React Web Updates (0.43.0)

#### Changed

- Updated `ButtonBase` and `ButtonIcon` to use fully rounded pill shapes across sizes and variants ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494)).
- Changed the `TextField` background from the default background to the muted background ([#1506](https://github.com/MetaMask/metamask-design-system/pull/1506)). Consumers using TextField over custom or non-default backgrounds should review the resulting contrast and visual treatment.
- Deprecated `ButtonFilter` in favor of `FilterButton` ([#1509](https://github.com/MetaMask/metamask-design-system/pull/1509)).

### 📱 React Native Updates (0.47.0)

#### Changed

- Updated `ButtonBase` and `ButtonIcon` to use fully rounded pill shapes across sizes and variants ([#1494](https://github.com/MetaMask/metamask-design-system/pull/1494)).
- Deprecated `ButtonFilter` in favor of `FilterButton` ([#1509](https://github.com/MetaMask/metamask-design-system/pull/1509)).

### ⚠️ Breaking Changes

The changes in this release are visual/behavioral breaking changes rather than API-breaking changes:

- `TextField` now uses the muted background instead of the default background on React web.
- `ButtonBase` and `ButtonIcon` now use fully rounded pill shapes. Composed button components inherit this visual change.

No import, prop, or type migration is required. Consumers should review custom layouts, contrast, screenshots, and visual regression baselines where these components are used.

### ✅ Checklist

- [x] Changelogs updated with human-readable descriptions
- [x] Changelog validation passed (`yarn changelog:validate`)
- [x] Version bumps follow semantic versioning
  - [x] `@metamask/design-system-react`: minor (`0.42.0 → 0.43.0`) - visual behavior changes
  - [x] `@metamask/design-system-react-native`: minor (`0.46.0 → 0.47.0`) - visual behavior changes
  - [x] `@metamask/design-system-shared`: unchanged - no shared package changes
- [x] Breaking changes documented with migration guidance
- [x] PR references included in changelog entries

### ✅ Verification

- [x] `yarn build`
- [x] `yarn test`
- [x] `yarn lint`
- [x] `yarn changelog:validate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The release documents visual/behavioral breaking changes (pill buttons, web TextField background, deprecated ButtonFilter) across widely used UI primitives, though this PR only bumps versions and changelogs.
> 
> **Overview**
> **Release 68.0.0** cuts new package versions and records what shipped in the changelogs: `@metamask/design-system-react` **0.43.0** and `@metamask/design-system-react-native` **0.47.0**, plus the monorepo root **67.0.0 → 68.0.0**. `@metamask/design-system-shared` is unchanged.
> 
> The diff itself is version and changelog metadata only; it documents consumer-facing changes already merged elsewhere. **Web (0.43.0):** `ButtonBase` / `ButtonIcon` move to fully rounded pill shapes; `TextField` uses the **muted** background instead of default; `ButtonFilter` is **deprecated** in favor of `FilterButton`. **React Native (0.47.0):** the same pill button styling and `ButtonFilter` deprecation (no `TextField` background note on native in this release entry).
> 
> No import or prop migrations are required in this PR—teams should expect **visual** updates and review layouts, contrast, and regression baselines after upgrading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a38a811800b3968d75aa1df55a156e5f06f8498b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->